### PR TITLE
build: expose internal pool

### DIFF
--- a/packages/pool/src/create.js
+++ b/packages/pool/src/create.js
@@ -52,8 +52,12 @@ module.exports = (opts, launchOpts) => {
 
   const pool = genericPool.createPool(factory, { ...POOL_OPTS, ...opts })
 
-  return fn => {
+  const decorate = fn => {
     debug('acquire browser', poolInfo(pool))
     return pool.use(fn)
   }
+
+  decorate.pool = pool
+
+  return decorate
 }

--- a/packages/pool/src/index.js
+++ b/packages/pool/src/index.js
@@ -4,8 +4,8 @@ const createPool = require('./create')
 
 module.exports = (opts, launchOpts) => {
   const pool = createPool(opts, launchOpts)
-  ;['html', 'text', 'pdf', 'screenshot'].forEach(key => {
-    pool[key] = (...args) => pool(browserless => browserless[key](...args))
+  ;['html', 'text', 'pdf', 'screenshot'].forEach(method => {
+    pool[method] = (...args) => pool(browserless => browserless[method](...args))
   })
   return pool
 }


### PR DESCRIPTION
It is available as `browserlessPool.pool`

Closes #104