### PR TITLE
chore: update adblocker and use pre-built engine from CDN

### DIFF
--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -29,9 +29,9 @@
   ],
   "dependencies": {
     "@browserless/devices": "^5.18.5",
-    "@cliqz/adblocker-puppeteer": "~1.4.1",
+    "@cliqz/adblocker-puppeteer": "~1.5.0",
     "debug-logfmt": "~1.0.4",
-    "got": "~9.6.0",
+    "got": "~10.2.2",
     "p-reflect": "~2.1.0",
     "p-timeout": "~3.2.0",
     "tldts": "~5.6.3"

--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -31,7 +31,7 @@
     "@browserless/devices": "^5.18.5",
     "@cliqz/adblocker-puppeteer": "~1.5.0",
     "debug-logfmt": "~1.0.4",
-    "got": "~10.2.2",
+    "got": "~9.6.0",
     "p-reflect": "~2.1.0",
     "p-timeout": "~3.2.0",
     "tldts": "~5.6.3"

--- a/packages/goto/scripts/postinstall.js
+++ b/packages/goto/scripts/postinstall.js
@@ -9,12 +9,17 @@ const writeFile = promisify(fs.writeFile)
 
 const OUTPUT_FILENAME = 'src/engine.bin'
 
+// Small helpers to allow fetching different types of data with `got`
+const fetchBuffer = async url => (await got(url, { encoding: null })).body
+const fetchText = async url => Buffer.from(await fetchBuffer(url), 'ascii')
+const fetchJson = async url => JSON.parse(await fetchText(url))
+
 // Lightweight `fetch` polyfill on top of `got` to allow consumption by adblocker
 const fetch = url =>
   Promise.resolve({
-    text: got(url).text,
-    arrayBuffer: got(url).buffer,
-    json: got(url).json
+    text: () => fetchText(url),
+    arrayBuffer: () => fetchBuffer(url),
+    json: () => fetchJson(url)
   })
 
 const main = async () => {

--- a/packages/goto/scripts/postinstall.js
+++ b/packages/goto/scripts/postinstall.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { PuppeteerBlocker, fullLists } = require('@cliqz/adblocker-puppeteer')
+const { PuppeteerBlocker } = require('@cliqz/adblocker-puppeteer')
 const { promisify } = require('util')
 const got = require('got')
 const fs = require('fs')
@@ -10,19 +10,16 @@ const writeFile = promisify(fs.writeFile)
 const OUTPUT_FILENAME = 'src/engine.bin'
 
 // Lightweight `fetch` polyfill on top of `got` to allow consumption by adblocker
-const fetch = async url => {
-  const body = (await got(url)).body
-
-  return {
-    text: () => body,
-    arrayBuffer: () => Buffer.from(body, 'ascii').buffer,
-    json: () => JSON.parse(body)
-  }
-}
+const fetch = url =>
+  Promise.resolve({
+    text: got(url).text,
+    arrayBuffer: got(url).buffer,
+    json: got(url).json
+  })
 
 const main = async () => {
   // create a ad-blocker engine
-  const engine = await PuppeteerBlocker.fromLists(fetch, fullLists)
+  const engine = await PuppeteerBlocker.fromPrebuiltFull(fetch)
   await writeFile(OUTPUT_FILENAME, engine.serialize())
 }
 

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@browserless/goto": "^5.19.9",
-    "got": "~9.6.0",
+    "got": "~10.2.2",
     "is-url-http": "~1.2.4",
     "p-reflect": "~2.1.0",
     "sharp": "~0.23.4",

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@browserless/goto": "^5.19.9",
-    "got": "~10.2.2",
+    "got": "~9.6.0",
     "is-url-http": "~1.2.4",
     "p-reflect": "~2.1.0",
     "sharp": "~0.23.4",


### PR DESCRIPTION
Closes https://github.com/microlinkhq/browserless/pull/133

* Fix fetch abstraction on top of 'got'
* Update 'got' to latest to get 'text', 'json', and 'buffer' helpers
* Make use of prebuilt engine from CDN whenever possible