### PR TITLE
fix: postinstall script for adblocker

### DIFF
--- a/packages/goto/scripts/postinstall.js
+++ b/packages/goto/scripts/postinstall.js
@@ -12,7 +12,7 @@ const OUTPUT_FILENAME = 'src/engine.bin'
 // Lightweight `fetch` polyfill on top of `got` to allow consumption by adblocker
 const fetch = url =>
   Promise.resolve({
-    text: () => got(url),
+    text: () => got(url).text(),
     arrayBuffer: () => got(url).buffer(),
     json: () => got(url).json()
   })


### PR DESCRIPTION
See: https://github.com/microlinkhq/browserless/pull/140#issuecomment-581837038

The `.text()` is needed otherwise the response is an object with an attribute `body` instead of a string with the response itself.