### PR TITLE
Add evasion techniques

### DIFF
--- a/packages/browserless/src/driver.js
+++ b/packages/browserless/src/driver.js
@@ -44,7 +44,7 @@ const args = [
   '--font-render-hinting=none', // could be 'none', 'medium'
   '--enable-font-antialiasing',
   // perf
-  '--single-process',
+  // '--single-process'
   '--memory-pressure-off'
 ]
 

--- a/packages/cli/src/spinner.js
+++ b/packages/cli/src/spinner.js
@@ -36,7 +36,7 @@ const start = () => {
   }, TICK_INTERVAL)
 }
 
-const stop = str => {
+const stop = (str = '') => {
   spinner.stop()
   clearInterval(timer)
   const sizeValue = `=${prettyBytes(Buffer.from(JSON.stringify(str)).byteLength)}`

--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -45,7 +45,8 @@
   "devDependencies": {
     "ava": "latest",
     "browserless": "latest",
-    "puppeteer": "latest"
+    "puppeteer": "latest",
+    "ua-string": "latest"
   },
   "engines": {
     "node": ">= 10"

--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -38,12 +38,14 @@
     "pretty-ms": "~7.0.0",
     "shallow-equal": "~1.2.1",
     "time-span": "~4.0.0",
-    "tldts": "~5.6.33"
+    "tldts": "~5.6.35",
+    "top-user-agents": "~1.0.9",
+    "unique-random-array": "~2.0.0"
   },
   "devDependencies": {
     "ava": "latest",
-    "coveralls": "latest",
-    "nyc": "latest"
+    "browserless": "latest",
+    "puppeteer": "latest"
   },
   "engines": {
     "node": ">= 10"
@@ -53,9 +55,8 @@
     "src"
   ],
   "scripts": {
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "postinstall": "node scripts/postinstall",
-    "test": "nyc ava"
+    "test": "ava test/**/*.js"
   },
   "license": "MIT"
 }

--- a/packages/goto/src/evasions/chrome-runtime.js
+++ b/packages/goto/src/evasions/chrome-runtime.js
@@ -1,0 +1,80 @@
+'use strict'
+
+/**
+ * Pass the Chrome Test.
+ *
+ * This will work for iframes as well, except for `srcdoc` iframes:
+ * https://github.com/puppeteer/puppeteer/issues/1106
+ *
+ * Could be mocked further.
+ */
+module.exports = page =>
+  page.evaluateOnNewDocument(() => {
+    const installer = { install () {} }
+    window.chrome = {
+      app: {
+        isInstalled: false,
+        InstallState: {
+          DISABLED: 'disabled',
+          INSTALLED: 'installed',
+          NOT_INSTALLED: 'not_installed'
+        },
+        RunningState: {
+          CANNOT_RUN: 'cannot_run',
+          READY_TO_RUN: 'ready_to_run',
+          RUNNING: 'running'
+        }
+      },
+      csi () {},
+      loadTimes () {},
+      webstore: {
+        onInstallStageChanged: {},
+        onDownloadProgress: {},
+        install (url, onSuccess, onFailure) {
+          installer.install(url, onSuccess, onFailure)
+        }
+      },
+      runtime: {
+        OnInstalledReason: {
+          CHROME_UPDATE: 'chrome_update',
+          INSTALL: 'install',
+          SHARED_MODULE_UPDATE: 'shared_module_update',
+          UPDATE: 'update'
+        },
+        OnRestartRequiredReason: {
+          APP_UPDATE: 'app_update',
+          OS_UPDATE: 'os_update',
+          PERIODIC: 'periodic'
+        },
+        PlatformArch: {
+          ARM: 'arm',
+          MIPS: 'mips',
+          MIPS64: 'mips64',
+          X86_32: 'x86-32',
+          X86_64: 'x86-64'
+        },
+        PlatformNaclArch: {
+          ARM: 'arm',
+          MIPS: 'mips',
+          MIPS64: 'mips64',
+          X86_32: 'x86-32',
+          X86_64: 'x86-64'
+        },
+        PlatformOs: {
+          ANDROID: 'android',
+          CROS: 'cros',
+          LINUX: 'linux',
+          MAC: 'mac',
+          OPENBSD: 'openbsd',
+          WIN: 'win'
+        },
+        RequestUpdateCheckStatus: {
+          NO_UPDATE: 'no_update',
+          THROTTLED: 'throttled',
+          UPDATE_AVAILABLE: 'update_available'
+        },
+        connect: function () {}.bind(function () {}), // eslint-disable-line
+        sendMessage: function () {}.bind(function () {}) // eslint-disable-line
+      }
+    }
+  })

--- a/packages/goto/src/evasions/chrome-runtime.js
+++ b/packages/goto/src/evasions/chrome-runtime.js
@@ -10,7 +10,6 @@
  */
 module.exports = page =>
   page.evaluateOnNewDocument(() => {
-    const installer = { install () {} }
     window.chrome = {
       app: {
         isInstalled: false,
@@ -23,15 +22,6 @@ module.exports = page =>
           CANNOT_RUN: 'cannot_run',
           READY_TO_RUN: 'ready_to_run',
           RUNNING: 'running'
-        }
-      },
-      csi () {},
-      loadTimes () {},
-      webstore: {
-        onInstallStageChanged: {},
-        onDownloadProgress: {},
-        install (url, onSuccess, onFailure) {
-          installer.install(url, onSuccess, onFailure)
         }
       },
       runtime: {
@@ -48,6 +38,7 @@ module.exports = page =>
         },
         PlatformArch: {
           ARM: 'arm',
+          ARM64: 'arm64',
           MIPS: 'mips',
           MIPS64: 'mips64',
           X86_32: 'x86-32',
@@ -72,9 +63,7 @@ module.exports = page =>
           NO_UPDATE: 'no_update',
           THROTTLED: 'throttled',
           UPDATE_AVAILABLE: 'update_available'
-        },
-        connect: function () {}.bind(function () {}), // eslint-disable-line
-        sendMessage: function () {}.bind(function () {}) // eslint-disable-line
+        }
       }
     }
   })

--- a/packages/goto/src/evasions/console-debug.js
+++ b/packages/goto/src/evasions/console-debug.js
@@ -1,0 +1,9 @@
+'use strict'
+
+/**
+ * Pass toString test, though it breaks console.debug() from working
+ */
+module.exports = page =>
+  page.evaluateOnNewDocument(() => {
+    window.console.debug = () => null
+  })

--- a/packages/goto/src/evasions/error-stack-trace.js
+++ b/packages/goto/src/evasions/error-stack-trace.js
@@ -1,0 +1,47 @@
+'use strict'
+
+/**
+ *
+ * Prevent detect Puppeteer via variable name
+ *
+ * References:
+ * - https://github.com/digitalhurricane-io/puppeteer-detection-100-percent
+ * - https://github.com/berstend/puppeteer-extra/issues/209
+ */
+module.exports = page =>
+  page.evaluateOnNewDocument(() => {
+    const errors = {
+      Error,
+      EvalError,
+      RangeError,
+      ReferenceError,
+      SyntaxError,
+      TypeError,
+      URIError
+    }
+    for (const name in errors) {
+      globalThis[name] = (function (NativeError) {
+        return function (message) {
+          const err = new NativeError(message)
+          const stub = {
+            message: err.message,
+            name: err.name,
+            toString: () => err.toString(),
+            get stack () {
+              const lines = err.stack.split('\n')
+              lines.splice(1, 1) // remove anonymous function above
+              lines.pop() // remove puppeteer line
+              return lines.join('\n')
+            }
+          }
+          if (this === globalThis) {
+            // called as function, not constructor
+            stub.__proto__ = NativeError
+            return stub
+          }
+          Object.assign(this, stub)
+          this.__proto__ = NativeError
+        }
+      })(errors[name])
+    }
+  })

--- a/packages/goto/src/evasions/error-stack-trace.js
+++ b/packages/goto/src/evasions/error-stack-trace.js
@@ -20,6 +20,7 @@ module.exports = page =>
       URIError
     }
     for (const name in errors) {
+      // eslint-disable-next-line
       globalThis[name] = (function (NativeError) {
         return function (message) {
           const err = new NativeError(message)
@@ -34,12 +35,15 @@ module.exports = page =>
               return lines.join('\n')
             }
           }
+          // eslint-disable-next-line
           if (this === globalThis) {
             // called as function, not constructor
+            // eslint-disable-next-line
             stub.__proto__ = NativeError
             return stub
           }
           Object.assign(this, stub)
+          // eslint-disable-next-line
           this.__proto__ = NativeError
         }
       })(errors[name])

--- a/packages/goto/src/evasions/iframe-content-window.js
+++ b/packages/goto/src/evasions/iframe-content-window.js
@@ -1,0 +1,8 @@
+module.exports = page =>
+  page.evaluateOnNewDocument(() =>
+    Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+      get: function () {
+        return window
+      }
+    })
+  )

--- a/packages/goto/src/evasions/iframe-content-window.js
+++ b/packages/goto/src/evasions/iframe-content-window.js
@@ -1,5 +1,6 @@
 module.exports = page =>
   page.evaluateOnNewDocument(() =>
+    // eslint-disable-next-line
     Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
       get: function () {
         return window

--- a/packages/goto/src/evasions/index.js
+++ b/packages/goto/src/evasions/index.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  chromeRuntime: require('./chrome-runtime'),
+  consoleDebug: require('./console-debug'),
+  errorStackTrace: require('./error-stack-trace'),
+  iframeContentWindow: require('./iframe-content-window'),
+  mediaCodecs: require('./media-codecs'),
+  navigatorPermissions: require('./navigator-permissions'),
+  navigatorPlugins: require('./navigator-plugins'),
+  navigatorWebdriver: require('./navigator-webdriver'),
+  randomizeUserAgent: require('./randomize-user-agent'),
+  webglVendor: require('./webgl-vendor'),
+  windowOuter: require('./window-outer')
+}

--- a/packages/goto/src/evasions/media-codecs.js
+++ b/packages/goto/src/evasions/media-codecs.js
@@ -1,0 +1,76 @@
+'use strict'
+
+/**
+ * Fix Chromium not reporting "probably" to codecs like `videoEl.canPlayType('video/mp4; codecs="avc1.42E01E"')`.
+ * (Chromium doesn't support proprietary codecs, only Chrome does)
+ */
+module.exports = page =>
+  page.evaluateOnNewDocument(() => {
+    try {
+      /**
+       * Input might look funky, we need to normalize it so e.g. whitespace isn't an issue for our spoofing.
+       *
+       * @example
+       * video/webm; codecs="vp8, vorbis"
+       * video/mp4; codecs="avc1.42E01E"
+       * audio/x-m4a;
+       * audio/ogg; codecs="vorbis"
+       * @param {String} arg
+       */
+      const parseInput = arg => {
+        const [mime, codecStr] = arg.trim().split(';')
+        let codecs = []
+        if (codecStr && codecStr.includes('codecs="')) {
+          codecs = codecStr
+            .trim()
+            .replace('codecs="', '')
+            .replace('"', '')
+            .trim()
+            .split(',')
+            .filter(x => !!x)
+            .map(x => x.trim())
+        }
+        return { mime, codecStr, codecs }
+      }
+
+      /* global HTMLMediaElement */
+      const canPlayType = {
+        // Make toString() native
+        get (target, key) {
+          // Mitigate Chromium bug (#130)
+          if (typeof target[key] === 'function') {
+            return target[key].bind(target)
+          }
+          return Reflect.get(target, key)
+        },
+        // Intercept certain requests
+        apply: function (target, ctx, args) {
+          if (!args || !args.length) {
+            return target.apply(ctx, args)
+          }
+          const { mime, codecs } = parseInput(args[0])
+          // This specific mp4 codec is missing in Chromium
+          if (mime === 'video/mp4') {
+            if (codecs.includes('avc1.42E01E')) {
+              return 'probably'
+            }
+          }
+          // This mimetype is only supported if no codecs are specified
+          if (mime === 'audio/x-m4a' && !codecs.length) {
+            return 'maybe'
+          }
+
+          // This mimetype is only supported if no codecs are specified
+          if (mime === 'audio/aac' && !codecs.length) {
+            return 'probably'
+          }
+          // Everything else as usual
+          return target.apply(ctx, args)
+        }
+      }
+      HTMLMediaElement.prototype.canPlayType = new Proxy(
+        HTMLMediaElement.prototype.canPlayType,
+        canPlayType
+      )
+    } catch (err) {}
+  })

--- a/packages/goto/src/evasions/navigator-permissions.js
+++ b/packages/goto/src/evasions/navigator-permissions.js
@@ -1,0 +1,43 @@
+'use strict'
+
+/**
+ * Pass the Permissions Test.
+ */
+module.exports = page =>
+  page.evaluateOnNewDocument(() => {
+    if (!window.Notification) {
+      window.Notification = {
+        permission: 'denied'
+      }
+    }
+
+    const originalQuery = window.navigator.permissions.query
+    // eslint-disable-next-line
+    window.navigator.permissions.__proto__.query = parameters =>
+      parameters.name === 'notifications'
+        ? Promise.resolve({ state: window.Notification.permission })
+        : originalQuery(parameters)
+
+    // Inspired by: https://github.com/ikarienator/phantomjs_hide_and_seek/blob/master/5.spoofFunctionBind.js
+    const oldCall = Function.prototype.call
+    function call () {
+      return oldCall.apply(this, arguments)
+    }
+    // eslint-disable-next-line
+    Function.prototype.call = call
+
+    const nativeToStringFunctionString = Error.toString().replace(/Error/g, 'toString')
+    const oldToString = Function.prototype.toString
+
+    function functionToString () {
+      if (this === window.navigator.permissions.query) {
+        return 'function query() { [native code] }'
+      }
+      if (this === functionToString) {
+        return nativeToStringFunctionString
+      }
+      return oldCall.call(oldToString, this)
+    }
+    // eslint-disable-next-line
+    Function.prototype.toString = functionToString
+  })

--- a/packages/goto/src/evasions/navigator-plugins.js
+++ b/packages/goto/src/evasions/navigator-plugins.js
@@ -1,0 +1,197 @@
+'use strict'
+
+/**
+ * In headless mode `navigator.mimeTypes` and `navigator.plugins` are empty.
+ * This plugin quite emulates both of these to match regular headful Chrome.
+ * We even go so far as to mock functional methods, instance types and `.toString` properties. :D
+ */
+module.exports = page =>
+  page.evaluateOnNewDocument(() => {
+    function mockPluginsAndMimeTypes () {
+      /* global MimeType MimeTypeArray PluginArray */
+
+      // Disguise custom functions as being native
+      const makeFnsNative = (fns = []) => {
+        const oldCall = Function.prototype.call
+        function call () {
+          return oldCall.apply(this, arguments)
+        }
+        // eslint-disable-next-line
+        Function.prototype.call = call
+
+        const nativeToStringFunctionString = Error.toString().replace(/Error/g, 'toString')
+        const oldToString = Function.prototype.toString
+
+        function functionToString () {
+          for (const fn of fns) {
+            if (this === fn.ref) {
+              return `function ${fn.name}() { [native code] }`
+            }
+          }
+
+          if (this === functionToString) {
+            return nativeToStringFunctionString
+          }
+          return oldCall.call(oldToString, this)
+        }
+        // eslint-disable-next-line
+        Function.prototype.toString = functionToString
+      }
+
+      const mockedFns = []
+
+      const fakeData = {
+        mimeTypes: [
+          {
+            type: 'application/pdf',
+            suffixes: 'pdf',
+            description: '',
+            __pluginName: 'Chrome PDF Viewer'
+          },
+          {
+            type: 'application/x-google-chrome-pdf',
+            suffixes: 'pdf',
+            description: 'Portable Document Format',
+            __pluginName: 'Chrome PDF Plugin'
+          },
+          {
+            type: 'application/x-nacl',
+            suffixes: '',
+            description: 'Native Client Executable',
+            enabledPlugin: Plugin,
+            __pluginName: 'Native Client'
+          },
+          {
+            type: 'application/x-pnacl',
+            suffixes: '',
+            description: 'Portable Native Client Executable',
+            __pluginName: 'Native Client'
+          }
+        ],
+        plugins: [
+          {
+            name: 'Chrome PDF Plugin',
+            filename: 'internal-pdf-viewer',
+            description: 'Portable Document Format'
+          },
+          {
+            name: 'Chrome PDF Viewer',
+            filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai',
+            description: ''
+          },
+          {
+            name: 'Native Client',
+            filename: 'internal-nacl-plugin',
+            description: ''
+          }
+        ],
+        fns: {
+          namedItem: instanceName => {
+            // Returns the Plugin/MimeType with the specified name.
+            const fn = function (name) {
+              if (!arguments.length) {
+                throw new TypeError(
+                  `Failed to execute 'namedItem' on '${instanceName}': 1 argument required, but only 0 present.`
+                )
+              }
+              return this[name] || null
+            }
+            mockedFns.push({ ref: fn, name: 'namedItem' })
+            return fn
+          },
+          item: instanceName => {
+            // Returns the Plugin/MimeType at the specified index into the array.
+            const fn = function (index) {
+              if (!arguments.length) {
+                throw new TypeError(
+                  `Failed to execute 'namedItem' on '${instanceName}': 1 argument required, but only 0 present.`
+                )
+              }
+              return this[index] || null
+            }
+            mockedFns.push({ ref: fn, name: 'item' })
+            return fn
+          },
+          refresh: instanceName => {
+            // Refreshes all plugins on the current page, optionally reloading documents.
+            const fn = function () {
+              return undefined
+            }
+            mockedFns.push({ ref: fn, name: 'refresh' })
+            return fn
+          }
+        }
+      }
+      // Poor mans _.pluck
+      const getSubset = (keys, obj) => keys.reduce((a, c) => ({ ...a, [c]: obj[c] }), {})
+
+      function generateMimeTypeArray () {
+        const arr = fakeData.mimeTypes
+          .map(obj => getSubset(['type', 'suffixes', 'description'], obj))
+          .map(obj => Object.setPrototypeOf(obj, MimeType.prototype))
+        arr.forEach(obj => {
+          arr[obj.type] = obj
+        })
+
+        // Mock functions
+        arr.namedItem = fakeData.fns.namedItem('MimeTypeArray')
+        arr.item = fakeData.fns.item('MimeTypeArray')
+
+        return Object.setPrototypeOf(arr, MimeTypeArray.prototype)
+      }
+
+      const mimeTypeArray = generateMimeTypeArray()
+      Object.defineProperty(navigator, 'mimeTypes', {
+        get: () => mimeTypeArray
+      })
+
+      function generatePluginArray () {
+        const arr = fakeData.plugins
+          .map(obj => getSubset(['name', 'filename', 'description'], obj))
+          .map(obj => {
+            const mimes = fakeData.mimeTypes.filter(m => m.__pluginName === obj.name)
+            // Add mimetypes
+            mimes.forEach((mime, index) => {
+              navigator.mimeTypes[mime.type].enabledPlugin = obj
+              obj[mime.type] = navigator.mimeTypes[mime.type]
+              obj[index] = navigator.mimeTypes[mime.type]
+            })
+            obj.length = mimes.length
+            return obj
+          })
+          .map(obj => {
+            // Mock functions
+            obj.namedItem = fakeData.fns.namedItem('Plugin')
+            obj.item = fakeData.fns.item('Plugin')
+            return obj
+          })
+          .map(obj => Object.setPrototypeOf(obj, Plugin.prototype))
+        arr.forEach(obj => {
+          arr[obj.name] = obj
+        })
+
+        // Mock functions
+        arr.namedItem = fakeData.fns.namedItem('PluginArray')
+        arr.item = fakeData.fns.item('PluginArray')
+        arr.refresh = fakeData.fns.refresh('PluginArray')
+
+        return Object.setPrototypeOf(arr, PluginArray.prototype)
+      }
+
+      const pluginArray = generatePluginArray()
+      Object.defineProperty(navigator, 'plugins', {
+        get: () => pluginArray
+      })
+
+      // Make mockedFns toString() representation resemble a native function
+      makeFnsNative(mockedFns)
+    }
+    try {
+      const isPluginArray = navigator.plugins instanceof PluginArray
+      const hasPlugins = isPluginArray && navigator.plugins.length > 0
+      if (isPluginArray && hasPlugins) {
+        return // nothing to do here
+      }
+      mockPluginsAndMimeTypes()
+    } catch (err) {}
+  })

--- a/packages/goto/src/evasions/navigator-plugins.js
+++ b/packages/goto/src/evasions/navigator-plugins.js
@@ -58,6 +58,7 @@ module.exports = page =>
             type: 'application/x-nacl',
             suffixes: '',
             description: 'Native Client Executable',
+            // eslint-disable-next-line
             enabledPlugin: Plugin,
             __pluginName: 'Native Client'
           },
@@ -165,6 +166,7 @@ module.exports = page =>
             obj.item = fakeData.fns.item('Plugin')
             return obj
           })
+          // eslint-disable-next-line
           .map(obj => Object.setPrototypeOf(obj, Plugin.prototype))
         arr.forEach(obj => {
           arr[obj.name] = obj

--- a/packages/goto/src/evasions/navigator-webdriver.js
+++ b/packages/goto/src/evasions/navigator-webdriver.js
@@ -1,0 +1,8 @@
+'use strict'
+
+/**
+ * Pass the Webdriver Test.
+ * Will delete `navigator.webdriver` property.
+ */
+module.exports = page =>
+  page.evaluateOnNewDocument(() => delete Object.getPrototypeOf(navigator).webdriver)

--- a/packages/goto/src/evasions/randomize-user-agent.js
+++ b/packages/goto/src/evasions/randomize-user-agent.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const uniqueRandomArray = require('unique-random-array')
+const userAgents = require('top-user-agents')
+
+const randomUserAgent = uniqueRandomArray(userAgents)
+
+module.exports = page => page.setUserAgent(randomUserAgent())

--- a/packages/goto/src/evasions/webgl-vendor.js
+++ b/packages/goto/src/evasions/webgl-vendor.js
@@ -1,0 +1,61 @@
+/**
+ * Fix WebGL Vendor/Renderer being set to Google in headless mode
+ */
+module.exports = page =>
+  page.evaluateOnNewDocument(() => {
+    try {
+      // Remove traces of our Proxy ;-)
+      var stripErrorStack = stack =>
+        stack
+          .split('\n')
+          .filter(line => !line.includes('at Object.apply'))
+          .filter(line => !line.includes('at Object.get'))
+          .join('\n')
+
+      const getParameterProxyHandler = {
+        get (target, key) {
+          try {
+            // Mitigate Chromium bug (#130)
+            if (typeof target[key] === 'function') {
+              return target[key].bind(target)
+            }
+            return Reflect.get(target, key)
+          } catch (err) {
+            err.stack = stripErrorStack(err.stack)
+            throw err
+          }
+        },
+        apply: function (target, thisArg, args) {
+          const param = (args || [])[0]
+          // UNMASKED_VENDOR_WEBGL
+          if (param === 37445) {
+            return 'Intel Inc.'
+          }
+          // UNMASKED_RENDERER_WEBGL
+          if (param === 37446) {
+            return 'Intel(R) Iris(TM) Plus Graphics 640'
+          }
+          try {
+            return Reflect.apply(target, thisArg, args)
+          } catch (err) {
+            err.stack = stripErrorStack(err.stack)
+            throw err
+          }
+        }
+      }
+
+      const proxy = new Proxy(
+        window.WebGLRenderingContext.prototype.getParameter,
+        getParameterProxyHandler
+      )
+      // To find out the original values here: Object.getOwnPropertyDescriptors(WebGLRenderingContext.prototype.getParameter)
+      Object.defineProperty(window.WebGLRenderingContext.prototype, 'getParameter', {
+        configurable: true,
+        enumerable: false,
+        writable: false,
+        value: proxy
+      })
+    } catch (err) {
+      console.warn(err)
+    }
+  })

--- a/packages/goto/src/evasions/window-outer.js
+++ b/packages/goto/src/evasions/window-outer.js
@@ -1,0 +1,11 @@
+'use strict'
+
+/**
+ * Fix missing window.outerWidth/window.outerHeight in headless mode Will also set
+ * the viewport to match window size, unless specified by user
+ */
+module.exports = page =>
+  page.evaluateOnNewDocument(() => {
+    window.outerWidth = window.innerWidth
+    window.outerHeight = window.innerHeight
+  })

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -171,7 +171,9 @@ module.exports = ({ evasions = [], defaultDevice = 'Macbook Pro 13', timeout, ..
   const getDevice = createDevices(deviceOpts)
   const { viewport: defaultViewport } = getDevice.findDevice(defaultDevice)
 
-  const applyEvasions = evasions.filter(Boolean).reduce((acc, key) => [...acc, EVASIONS[key]], [])
+  const applyEvasions = castArray(evasions)
+    .filter(Boolean)
+    .reduce((acc, key) => [...acc, EVASIONS[key]], [])
 
   const goto = async (
     page,

--- a/packages/goto/test/evasions/antibots.js
+++ b/packages/goto/test/evasions/antibots.js
@@ -3,16 +3,19 @@
 const test = require('ava')
 
 const createBrowserless = require('browserless')
+const userAgent = require('ua-string')
 
-const browserless = createBrowserless()
+const { evasions } = require('../..')
 
-test('https://arh.antoinevastel.com/bots/areyouheadless', async t => {
+test('arh.antoinevastel.com/bots/areyouheadless', async t => {
+  const browserless = createBrowserless({ evasions })
   const content = await browserless.text('https://arh.antoinevastel.com/bots/areyouheadless')
   t.true(content.includes('You are not Chrome headless'))
 })
 
 // See https://antoinevastel.com/bot%20detection/2018/11/13/fp-scanner-library-demo.html
-test.only('https://antoinevastel.com/bots/fpstructured', async t => {
+test('antoinevastel.com/bots/fpstructured', async t => {
+  const browserless = createBrowserless({ evasions })
   const fpCollect = browserless.evaluate((page, response) =>
     page.evaluate(() => {
       const fp = JSON.parse(document.getElementById('fp').innerText)
@@ -21,12 +24,27 @@ test.only('https://antoinevastel.com/bots/fpstructured', async t => {
     })
   )
 
-  const { fp, scanner } = await fpCollect('https://antoinevastel.com/bots/fpstructured')
-  console.log(fp)
+  const { scanner } = await fpCollect('https://antoinevastel.com/bots/fpstructured')
   Object.keys(scanner)
-    .filter(key => key !== 'CHR_MEMORY') // https://github.com/antoinevastel/fpscanner/issues/9
+    // looks it isn't accurate,
+    // see https://github.com/antoinevastel/fpscanner/issues/9
+    .filter(key => key !== 'CHR_MEMORY')
     .forEach(scannerKey => {
       const scannerValue = scanner[scannerKey]
       t.true(scannerValue.consistent === 3, `${scannerKey} is inconsistent`)
     })
+})
+
+test('device-info.fr/are_you_a_bot', async t => {
+  const browserless = createBrowserless({
+    evasions: evasions.filter(evasion => evasion !== 'randomizeUserAgent')
+  })
+  const content = await browserless.text('https://device-info.fr/are_you_a_bot', {
+    headers: {
+      // the test false/positive under some popular user agents
+      // so we setup a fixed value
+      'user-agent': userAgent
+    }
+  })
+  t.true(content.includes('You are human!'))
 })

--- a/packages/goto/test/evasions/antibots.js
+++ b/packages/goto/test/evasions/antibots.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const test = require('ava')
+
+const createBrowserless = require('browserless')
+
+const browserless = createBrowserless()
+
+test('https://arh.antoinevastel.com/bots/areyouheadless', async t => {
+  const content = await browserless.text('https://arh.antoinevastel.com/bots/areyouheadless')
+  t.true(content.includes('You are not Chrome headless'))
+})
+
+// See https://antoinevastel.com/bot%20detection/2018/11/13/fp-scanner-library-demo.html
+test.only('https://antoinevastel.com/bots/fpstructured', async t => {
+  const fpCollect = browserless.evaluate((page, response) =>
+    page.evaluate(() => {
+      const fp = JSON.parse(document.getElementById('fp').innerText)
+      const scanner = JSON.parse(document.getElementById('scanner').innerText)
+      return { fp, scanner }
+    })
+  )
+
+  const { fp, scanner } = await fpCollect('https://antoinevastel.com/bots/fpstructured')
+  console.log(fp)
+  Object.keys(scanner)
+    .filter(key => key !== 'CHR_MEMORY') // https://github.com/antoinevastel/fpscanner/issues/9
+    .forEach(scannerKey => {
+      const scannerValue = scanner[scannerKey]
+      t.true(scannerValue.consistent === 3, `${scannerKey} is inconsistent`)
+    })
+})

--- a/packages/goto/test/evasions/index.js
+++ b/packages/goto/test/evasions/index.js
@@ -1,0 +1,303 @@
+'use strict'
+
+const test = require('ava')
+
+const createBrowserless = require('browserless')
+const path = require('path')
+
+const evasions = require('../../src/evasions')
+
+const browserless = createBrowserless()
+
+const fileUrl = `file://${path.join(__dirname, '../fixtures/dummy.html')}`
+
+test('randomize user agent', async t => {
+  const page = await browserless.page()
+  const userAgent = () => page.evaluate(() => window.navigator.userAgent)
+
+  t.true(/HeadlessChrome/.test(await userAgent()))
+
+  await evasions.randomizeUserAgent(page)
+
+  t.false(/HeadlessChrome/.test(await userAgent()))
+
+  await page.close()
+})
+
+test('hide navigator.webdriver', async t => {
+  const page = await browserless.page()
+  const webdriver = () => page.evaluate(() => window.navigator.webdriver)
+  const javaEnabled = () => page.evaluate(() => navigator.javaEnabled())
+
+  await page.goto(fileUrl)
+  t.false((await webdriver()) === undefined)
+  t.false((await javaEnabled()) === undefined)
+
+  await evasions.navigatorWebdriver(page)
+  await page.goto(fileUrl)
+
+  t.true((await webdriver()) === undefined)
+  t.false((await javaEnabled()) === undefined)
+
+  await page.close()
+})
+
+test('inject chrome runtime', async t => {
+  const page = await browserless.page()
+  const chrome = () => page.evaluate(() => window.chrome)
+  t.is(await chrome(), undefined)
+
+  await evasions.chromeRuntime(page)
+  await page.goto(fileUrl)
+
+  t.true((await chrome()) instanceof Object)
+
+  await page.close()
+})
+
+test('override navigator.permissions', async t => {
+  const page = await browserless.page()
+
+  const permissionStatusState = () =>
+    page.evaluate(async () => {
+      const permissionStatus = await navigator.permissions.query({
+        name: 'notifications'
+      })
+      return permissionStatus.state
+    })
+
+  t.is(await permissionStatusState(), 'prompt')
+
+  await evasions.navigatorPermissions(page)
+  await page.goto(fileUrl)
+
+  t.is(await permissionStatusState(), 'denied')
+
+  await page.close()
+})
+
+test('mock navigator.plugins', async t => {
+  const page = await browserless.page()
+  const plugins = () => page.evaluate(() => window.navigator.plugins.length)
+  const mimeTypes = () => page.evaluate(() => window.navigator.mimeTypes.length)
+
+  t.is(await plugins(), 0)
+  t.is(await mimeTypes(), 0)
+
+  await evasions.navigatorPlugins(page)
+  await page.goto(fileUrl)
+
+  t.is(await plugins(), 3)
+  t.is(await mimeTypes(), 4)
+
+  await page.close()
+})
+
+test('ensure navigator.languages is present', async t => {
+  const page = await browserless.page()
+  const languages = () => page.evaluate(() => window.navigator.languages)
+  t.deepEqual(await languages(), ['en-US'])
+  await page.close()
+})
+
+test('ensure media codecs are present', async t => {
+  const page = await browserless.page()
+
+  await page.goto(fileUrl, { waitUntil: 'networkidle0' })
+
+  const videoCodecs = () =>
+    page.evaluate(() => {
+      const el = document.createElement('video')
+      if (!el.canPlayType) return { ogg: 'unknown', h264: 'unknown', webm: 'unknown' }
+      return {
+        ogg: el.canPlayType('video/ogg; codecs="theora"'),
+        h264: el.canPlayType('video/mp4; codecs="avc1.42E01E"'),
+        webm: el.canPlayType('video/webm; codecs="vp8, vorbis"')
+      }
+    })
+
+  const audioCodecs = () =>
+    page.evaluate(() => {
+      const el = document.createElement('audio')
+      if (!el.canPlayType) {
+        return { ogg: 'unknown', mp3: 'unknown', wav: 'unknown', m4a: 'unknown', aac: 'unknown' }
+      }
+      return {
+        ogg: el.canPlayType('audio/ogg; codecs="vorbis"'),
+        mp3: el.canPlayType('audio/mpeg;'),
+        wav: el.canPlayType('audio/wav; codecs="1"'),
+        m4a: el.canPlayType('audio/x-m4a;'),
+        aac: el.canPlayType('audio/aac;')
+      }
+    })
+
+  t.deepEqual(await videoCodecs(), { ogg: 'probably', h264: '', webm: 'probably' })
+
+  t.deepEqual(await audioCodecs(), {
+    ogg: 'probably',
+    mp3: 'probably',
+    wav: 'probably',
+    m4a: '',
+    aac: ''
+  })
+
+  await evasions.mediaCodecs(page)
+  await page.goto(fileUrl)
+
+  t.deepEqual(await videoCodecs(), { ogg: 'probably', h264: 'probably', webm: 'probably' })
+
+  t.deepEqual(await audioCodecs(), {
+    ogg: 'probably',
+    mp3: 'probably',
+    wav: 'probably',
+    m4a: 'maybe',
+    aac: 'probably'
+  })
+
+  await page.close()
+})
+
+test('console.debug is defined', async t => {
+  const page = await browserless.page()
+
+  const consoleDebug = () =>
+    page.evaluate(() => {
+      let gotYou = 0
+      const spooky = /./
+      spooky.toString = function () {
+        gotYou++
+        return 'spooky'
+      }
+      console.debug(spooky)
+      return gotYou
+    })
+
+  t.is(await consoleDebug(), 1)
+
+  await evasions.consoleDebug(page)
+  await page.goto(fileUrl)
+
+  t.is(await consoleDebug(), 0)
+
+  await page.close()
+})
+
+test('navigator.vendor is defined', async t => {
+  const page = await browserless.page()
+  const vendor = () => page.evaluate(() => window.navigator.vendor)
+  t.is(await vendor(), 'Google Inc.')
+  await page.close()
+})
+
+test('setup a better webgl video card', async t => {
+  const page = await browserless.page()
+
+  const videoCard = () =>
+    page.evaluate(() => {
+      try {
+        const canvas = document.createElement('canvas')
+        const ctx = canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
+        let webGLVendor, webGLRenderer
+        if (ctx.getSupportedExtensions().indexOf('WEBGL_debug_renderer_info') >= 0) {
+          webGLVendor = ctx.getParameter(
+            ctx.getExtension('WEBGL_debug_renderer_info').UNMASKED_VENDOR_WEBGL
+          )
+          webGLRenderer = ctx.getParameter(
+            ctx.getExtension('WEBGL_debug_renderer_info').UNMASKED_RENDERER_WEBGL
+          )
+        } else {
+          webGLVendor = 'Not supported'
+          webGLRenderer = 'Not supported'
+        }
+        return [webGLVendor, webGLRenderer]
+      } catch (e) {
+        return 'Not supported;;;Not supported'
+      }
+    })
+
+  t.deepEqual(await videoCard(), ['Google Inc.', 'Google SwiftShader'])
+
+  await evasions.webglVendor(page)
+  await page.goto(fileUrl)
+
+  t.deepEqual(await videoCard(), ['Intel Inc.', 'Intel(R) Iris(TM) Plus Graphics 640'])
+
+  await page.close()
+})
+
+test('window.outerWidth & window.outerHeight are defined', async t => {
+  const page = await browserless.page()
+
+  const windowOuterWidth = () => page.evaluate(() => window.outerWidth)
+  const windowOuterHeight = () => page.evaluate(() => window.outerHeight)
+
+  t.is(await windowOuterWidth(), 0)
+  t.is(await windowOuterHeight(), 0)
+
+  await evasions.windowOuter(page)
+  await page.goto(fileUrl)
+
+  t.true((await windowOuterWidth()) > 0)
+  t.true((await windowOuterHeight()) > 0)
+
+  await page.close()
+})
+
+test('broken images have dimensions', async t => {
+  const page = await browserless.page()
+
+  const brokenImage = () =>
+    page.evaluate(() => {
+      const body = document.body
+      const image = document.createElement('img')
+      image.src = 'http://iloveponeydotcom32188.jg'
+      image.setAttribute('id', 'fakeimage')
+      image.onerror = () => Promise.resolve(`${image.width}x${image.height}`)
+      body.appendChild(image)
+    })
+
+  t.true((await brokenImage()) !== '0x0')
+
+  await page.close()
+})
+
+test('remove puppeteer from stack traces', async t => {
+  const page = await browserless.page()
+
+  const errorStackTrace = () =>
+    page.evaluate(() => {
+      const error = new Error('oh no!')
+      return error.stack.toString()
+    })
+
+  t.true((await errorStackTrace()).includes('puppeteer_evaluation_script'))
+
+  await evasions.errorStackTrace(page)
+  await page.goto(fileUrl)
+
+  t.false((await errorStackTrace()).includes('puppeteer_evaluation_script'))
+
+  await page.close()
+})
+
+test('iframe', async t => {
+  const page = await browserless.page()
+
+  const iframeChrome = () =>
+    page.evaluate(() => {
+      const iframe = document.createElement('iframe')
+      iframe.srcdoc = 'blank page'
+      document.body.appendChild(iframe)
+      return typeof iframe.contentWindow.chrome
+    })
+
+  t.true((await iframeChrome()) === 'undefined')
+
+  await evasions.chromeRuntime(page)
+  await evasions.iframeContentWindow(page)
+  await page.goto(fileUrl)
+
+  t.true((await iframeChrome()) !== 'undefined')
+
+  await page.close()
+})

--- a/packages/goto/test/fixtures/dummy.html
+++ b/packages/goto/test/fixtures/dummy.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>title foo</title>
+    <!-- Testing evasions with a real html page makes things easier -->
+  </head>
+  <body>
+    <h1>Test page</h1>
+  </body>
+</html>

--- a/packages/goto/test/headers/index.js
+++ b/packages/goto/test/headers/index.js
@@ -61,7 +61,7 @@ test('set `cookie` header', async t => {
   const headers = request.headers()
   const content = JSON.parse(body)
 
-  t.is(content.headers['Cookie'], 'yummy_cookie=choco; tasty_cookie=strawberry')
-  t.is(headers['cookie'], 'yummy_cookie=choco; tasty_cookie=strawberry')
+  t.is(content.headers.Cookie, 'yummy_cookie=choco; tasty_cookie=strawberry')
+  t.is(headers.cookie, 'yummy_cookie=choco; tasty_cookie=strawberry')
   t.is(cookies.length, 2)
 })

--- a/packages/goto/test/headers/index.js
+++ b/packages/goto/test/headers/index.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const test = require('ava')
+
+const createBrowserless = require('browserless')
+
+const createPing = browserless =>
+  browserless.evaluate(async (page, response) => {
+    const userAgent = await page.evaluate(() => window.navigator.userAgent)
+    const cookies = await page.cookies()
+    const request = response.request()
+    const body = await response.buffer()
+    return { cookies, userAgent, body, request, response }
+  })
+
+test('set extra HTTP headers', async t => {
+  const browserless = createBrowserless()
+  const ping = createPing(browserless)
+
+  const { body, request } = await ping('https://httpbin.org/headers', {
+    headers: {
+      'X-Foo': 'bar'
+    }
+  })
+
+  const headers = request.headers()
+  const content = JSON.parse(body)
+
+  t.is(headers['x-foo'], 'bar')
+  t.is(content.headers['X-Foo'], 'bar')
+})
+
+test('set `uset agent` header', async t => {
+  const browserless = createBrowserless()
+  const ping = createPing(browserless)
+
+  const { userAgent, body, request } = await ping('https://httpbin.org/headers', {
+    headers: {
+      'user-agent': 'googlebot'
+    }
+  })
+
+  const headers = request.headers()
+  const content = JSON.parse(body)
+
+  t.is(content.headers['User-Agent'], 'googlebot')
+  t.is(headers['user-agent'], 'googlebot')
+  t.is(userAgent, 'googlebot')
+})
+
+test('set `cookie` header', async t => {
+  const browserless = createBrowserless()
+  const ping = createPing(browserless)
+
+  const { cookies, body, request } = await ping('https://httpbin.org/headers', {
+    headers: {
+      cookie: 'yummy_cookie=choco; tasty_cookie=strawberry'
+    }
+  })
+
+  const headers = request.headers()
+  const content = JSON.parse(body)
+
+  t.is(content.headers['Cookie'], 'yummy_cookie=choco; tasty_cookie=strawberry')
+  t.is(headers['cookie'], 'yummy_cookie=choco; tasty_cookie=strawberry')
+  t.is(cookies.length, 2)
+})

--- a/packages/goto/test/headers/parse-cookies.js
+++ b/packages/goto/test/headers/parse-cookies.js
@@ -2,7 +2,7 @@
 
 const test = require('ava')
 
-const { parseCookies } = require('../src')
+const { parseCookies } = require('../../src')
 
 test('parse cookies from string with `; ` delimiter', t => {
   const url = 'https://example.com'


### PR DESCRIPTION
**features**

- Add `evasions` field for enabling specific anti-bot protections. It's empty by default until documentation is ready.

**enhancements**

- Remove `--single-process` since it can be considered specific to AWS Lambda and similar environments. You can still pass it as usual.

**bugfix**

- Fix a bug related with setup `user-agent` at HTTP headers level but also at the page level.

**test**

- add suite test for HTTP headers.
- add e2e antibot cases.




**TODO**

- [ ] Add `evasions` documentation 

Closes #11