### PR TITLE
fix: ensure to handle page hang out

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -22,6 +22,7 @@ module.exports = ({
   ...launchOpts
 } = {}) => {
   const goto = createGoto({ puppeteer, timeout, ...launchOpts })
+  const pageTimeout = timeout / 2 / 8
   const proxy = parseProxy(proxyUrl)
 
   const spawn = () =>
@@ -43,7 +44,7 @@ module.exports = ({
   const createPage = async () => {
     const _browser = await browser
     const context = incognito ? await _browser.createIncognitoBrowserContext() : _browser
-    const page = await context.newPage()
+    const page = await pTimeout(context.newPage(), pageTimeout, 'page hang out')
 
     if (proxy) await page.authenticate(proxy)
 


### PR DESCRIPTION
A browser can hang out throwing an error like this:

```js
ErrorEvent {
  target: WebSocket {
    _events: [Object: null prototype] { open: [Function], error: [Function] },
    _eventsCount: 2,
    _maxListeners: undefined,
    _binaryType: 'nodebuffer',
    _closeCode: 1006,
    _closeFrameReceived: false,
    _closeFrameSent: false,
    _closeMessage: '',
    _closeTimer: null,
    _extensions: {},
    _protocol: '',
    _readyState: 3,
    _receiver: null,
    _sender: null,
    _socket: null,
    _bufferedAmount: 0,
    _isServer: false,
    _redirects: 0,
    _url: 'ws://127.0.0.1:36653/devtools/browser/c5fcc2d4-0657-4ae1-a52d-68644e7bb940',
    _req: null,
    [Symbol(kCapture)]: false
  },
  type: 'error',
  message: 'socket hang up',
  error: Error: socket hang up
      at connResetException (internal/errors.js:613:14)
      at Socket.socketOnEnd (_http_client.js:463:23)
      at Socket.emit (events.js:327:22)
      at Socket.EventEmitter.emit (domain.js:485:12)
      at endReadableNT (_stream_readable.js:1201:12)
      at processTicksAndRejections (internal/process/task_queues.js:84:21) {
    code: 'ECONNRESET',
    attemptNumber: 1,
    retriesLeft: 5
  }
}
```


This error is handled and retried, but still, an individual page can hangout probably because the browser was spawned too early

Related: https://sentry.io/share/issue/3716af61571e48d2a3337dc0321d8f11/