### PR TITLE
chore(function): avoid eval

### DIFF
--- a/packages/function/src/function.js
+++ b/packages/function/src/function.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-eval */
-
 'use strict'
 
 const path = require('path')
@@ -15,7 +13,7 @@ async ({ url, query, gotoOpts, browserWSEndpoint }) => {
   const getBrowserless = require('browserless')
   const browserless = await getBrowserless({ mode: 'connect', browserWSEndpoint }).createContext()
   const fnWrapper = fn => (page, response) => fn({ page, response, query })
-  const browserFn = browserless.evaluate(fnWrapper(${eval(code)}), gotoOpts)
+  const browserFn = browserless.evaluate(fnWrapper(${code}), gotoOpts)
 
   try {
     const value = await browserFn(url)
@@ -29,7 +27,7 @@ async ({ url, query, gotoOpts, browserWSEndpoint }) => {
 
 process.on('message', async ({ url, code, query, vmOpts, gotoOpts, browserWSEndpoint }) => {
   const vm = createVm(vmOpts)
-  const fn = createFn(code)
+  const fn = createFn(code.endsWith(';') ? code.slice(0, -1) : code)
   const run = vm(fn, scriptPath)
   process.send(await run({ url, query, gotoOpts, browserWSEndpoint }))
 })

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -66,6 +66,41 @@ test('access to page', async t => {
   })
 })
 
+test('access to page (with inline code)', async t => {
+  const myFn = browserlessFunction('({ page }) => page.title()', { vmOpts })
+
+  t.deepEqual(await myFn('https://example.com'), {
+    isFulfilled: true,
+    isRejected: false,
+    value: 'Example Domain'
+  })
+})
+
+test('access to page (with semicolon)', async t => {
+  const myFn = browserlessFunction('({ page }) => page.title();', { vmOpts })
+
+  t.deepEqual(await myFn('https://example.com'), {
+    isFulfilled: true,
+    isRejected: false,
+    value: 'Example Domain'
+  })
+})
+
+test('access to page (with semicolon and break lines)', async t => {
+  const myFn = browserlessFunction(
+    `({ page }) => {
+    return page.title()
+    ; }`,
+    { vmOpts }
+  )
+
+  t.deepEqual(await myFn('https://example.com'), {
+    isFulfilled: true,
+    isRejected: false,
+    value: 'Example Domain'
+  })
+})
+
 test('interact with a page', async t => {
   const code = async ({ page }) => {
     const navigationPromise = page.waitForNavigation()


### PR DESCRIPTION
Since `eval` is considered harmful (although this is a controlled environment since each function is spawned an isolated VM) I was exploring if I can avoid it.


The function that will be executed on the browser context is wrapper using an anonymous function:

```js
(() => {
  // your code goes here
})()
```

The only edge case using this pattern is when the user provides an arrow function that ends with a semicolon, being considered as an interpreter error

```js
(() => 'test';)() // oh no
```

so looks like handle this edge case is enough to avoid using `eval` .

Maybe it could be a fragile solution and more edge cases can appear, but the adoption of this module is low so I think it's worth it to go forward.