### PR TITLE
fix: ensure request is aborted

### DIFF
--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -165,7 +165,7 @@ module.exports = ({
         const resourceType = req.resourceType()
         if (!abortTypes.includes(resourceType)) {
           debug('continue', { url: req.url(), resourceType })
-          return req.continue(req.continueRequestOverrides(), 2)
+          return req.continue(req.continueRequestOverrides(), 0)
         }
         debug('abort', { url: req.url(), resourceType })
         return req.abort('blockedbyclient', 2)


### PR DESCRIPTION
Related to:
https://github.com/microlinkhq/browserless/pull/321#discussion_r757642220

not sure if that could be a conflict with the default priority declaration
https://github.com/microlinkhq/browserless/blob/56feb3db78c44661fd611ff431b7c00b464bb8d9/packages/goto/src/index.js#L27

.cc @benallfree @remusao