### PR TITLE
expose goto error to context.evaluate callback

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -156,8 +156,8 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
     const evaluate = (fn, gotoOpts) =>
       wrapError(
         page => async (url, opts) => {
-          const { response } = await goto(page, { url, ...gotoOpts, ...opts })
-          return fn(page, response)
+          const { response, error } = await goto(page, { url, ...gotoOpts, ...opts })
+          return fn(page, response, error)
         },
         gotoOpts
       )


### PR DESCRIPTION
this allows my team to use browserContext.evaluate with custom collection of page data alongside html gathering with retry support (vs one-off goto calls) and still pickup the final errors (ie net::ERR_NAME_NOT_RESOLVED)