### PR TITLE
fix(browserless): associate a context id

### DIFF
--- a/packages/browserless/src/driver.js
+++ b/packages/browserless/src/driver.js
@@ -49,7 +49,7 @@ const spawn = ({
   ...launchOpts
 } = {}) => puppeteer[mode]({ ignoreHTTPSErrors: true, args, ...launchOpts })
 
-const pid = subprocess => {
+const getPid = subprocess => {
   if ('pid' in subprocess) return subprocess.pid
   const browserProcess = 'process' in subprocess ? subprocess.process() : undefined
   if (browserProcess === undefined || browserProcess === null) return
@@ -57,7 +57,8 @@ const pid = subprocess => {
 }
 
 const close = async (subprocess, { signal = 'SIGKILL', ...debugOpts } = {}) => {
-  if (pid(subprocess) === undefined) return
+  const pid = getPid(subprocess)
+  if (pid === undefined) return
 
   // It's necessary to call `browser.close` for removing temporal files associated
   // and remove listeners attached to the main process; check
@@ -65,8 +66,8 @@ const close = async (subprocess, { signal = 'SIGKILL', ...debugOpts } = {}) => {
   // - https://github.com/puppeteer/puppeteer/blob/69d85e874416d62de6e821bef30e5cebcfd42f15/src/node/BrowserRunner.ts#L189
   await pReflect('close' in subprocess ? subprocess.close() : killProcessGroup(subprocess, signal))
 
-  debug('close', { pid: subprocess.pid, signal, ...debugOpts })
-  return { pid: subprocess.pid }
+  debug('close', { pid, signal, ...debugOpts })
+  return { pid }
 }
 
-module.exports = { spawn, pid, close, defaultArgs }
+module.exports = { spawn, pid: getPid, close, defaultArgs }

--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -6,6 +6,7 @@ const debug = require('debug-logfmt')('browserless')
 const createGoto = require('@browserless/goto')
 const createPdf = require('@browserless/pdf')
 const { withLock } = require('superlock')
+const { randomUUID } = require('crypto')
 const pReflect = require('p-reflect')
 const pTimeout = require('p-timeout')
 const pRetry = require('p-retry')
@@ -59,7 +60,9 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
   let browserProcessPromise = spawn()
 
   const createBrowserContext = contextOpts =>
-    getBrowser().then(browser => browser.createIncognitoBrowserContext(contextOpts))
+    getBrowser()
+      .then(browser => browser.createIncognitoBrowserContext(contextOpts))
+      .then(context => (context._id = randomUUID()) && context)
 
   const getBrowser = async () => {
     if (isClosed) return browserProcessPromise


### PR DESCRIPTION
This change is necessary since puppeteer decided to make `._id` a private value

Related: https://github.com/puppeteer/puppeteer/pull/8506