### PR TITLE
fix(goto): check page state before intercept

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -118,7 +118,6 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
             try {
               page = await createPage(args)
               setTimeout(() => closePage(page), timeout).unref()
-
               const value = await fn(page, goto)(...args)
               await closePage(page)
               return value
@@ -153,7 +152,7 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
 
     const evaluate = (fn, gotoOpts) =>
       withPage(
-        page => async (url, opts) => {
+        (page, goto) => async (url, opts) => {
           const { response, error } = await goto(page, { url, ...gotoOpts, ...opts })
           return fn(page, response, error)
         },

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -249,7 +249,7 @@ module.exports = ({
     }
 
     const enableInterception =
-      (onPageRequest || abortTypes.length > 0) && page.setRequestInterception(true)
+      (onPageRequest || abortTypes.length > 0) && run({ fn: page.setRequestInterception(true), debug: 'enableInterception' })
 
     if (onPageRequest) {
       Promise.resolve(enableInterception).then(() => page.on('request', onPageRequest))

--- a/packages/goto/test/index.js
+++ b/packages/goto/test/index.js
@@ -40,3 +40,24 @@ test('setup `styles`', async t => {
 
   t.is(style, '"Helvetica Neue", Helvetica, Arial, sans-serif')
 })
+
+test('handle page disconnections', async t => {
+  t.plan(1)
+  const browserless = await getBrowserContext(t, { retry: 0 })
+  const onPageRequest = req => {
+    console.log('req.url', req.url)
+  }
+  const intercept = browserless.withPage((page, goto) => async url => {
+    await page.close()
+
+    const result = await goto(page, {
+      url,
+      onPageRequest,
+      abortTypes: ['image', 'stylesheet', 'font']
+    })
+
+    t.deepEqual(Object.keys(result), ['response', 'device', 'error'])
+  })
+
+  await intercept('chrome://version')
+})


### PR DESCRIPTION
otherwise, a `Protocol error (Fetch.enable): Session closed. Most likely the page has been closed.` sync error is emitted