### PR TITLE
feat: improve respawn browser under certain errors

### DIFF
--- a/packages/benchmark/src/screenshot/fixtures/example.html
+++ b/packages/benchmark/src/screenshot/fixtures/example.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html data-lt-installed="true"><head>
+  <title>Example Domain</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+  body {
+      background-color: #f0f0f2;
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+  }
+  div {
+      width: 600px;
+      margin: 5em auto;
+      padding: 2em;
+      background-color: #fdfdff;
+      border-radius: 0.5em;
+      box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
+  }
+  a:link, a:visited {
+      color: #38488f;
+      text-decoration: none;
+  }
+  @media (max-width: 700px) {
+      div {
+          margin: 0 auto;
+          width: auto;
+      }
+  }
+  </style>
+<style>
+          .flipX video::-webkit-media-text-track-display {
+              transform: matrix(-1, 0, 0, 1, 0, 0) !important;
+          }
+          .flipXY video::-webkit-media-text-track-display {
+              transform: matrix(-1, 0, 0, -1, 0, 0) !important;
+          }
+          .flipXYX video::-webkit-media-text-track-display {
+              transform: matrix(1, 0, 0, -1, 0, 0) !important;
+          }</style><style>
+          @keyframes blinkWarning {
+              0% { color: red; }
+              100% { color: white; }
+          }
+          @-webkit-keyframes blinkWarning {
+              0% { color: red; }
+              100% { color: white; }
+          }
+          .blinkWarning {
+              -webkit-animation: blinkWarning 1s linear infinite;
+              -moz-animation: blinkWarning 1s linear infinite;
+              animation: blinkWarning 1s linear infinite;
+          }</style></head>
+
+<body class="vsc-initialized" cz-shortcut-listen="true">
+<div>
+  <h1>Example Domain</h1>
+  <p>This domain is meant for use in documentation as well as automated tests to illustrate an example domain.</p>
+  <p>If you're looking for example usage of Vercel, see <a href="https://examples.vercel.live">examples.vercel.live</a></p>
+</div>
+
+
+</body></html>

--- a/packages/benchmark/src/screenshot/speed.js
+++ b/packages/benchmark/src/screenshot/speed.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const createBrowser = require('browserless')
+const path = require('path')
+
+const remoteBrowser = createBrowser()
+
+const optimizeForSpeed = process.argv[2] === 'true'
+
+const fileUrl = `file://${path.join(__dirname, './fixtures/example.html')}`
+
+/**
+ * Run:
+ * $ hyperfine -L optimizeForSpeed false,true 'node src/screenshot/speed.js {optimizeForSpeed}'
+ */
+const main = async () => {
+  const browserless = await remoteBrowser.createContext()
+  await browserless.screenshot(fileUrl, { optimizeForSpeed })
+  await browserless.destroyContext()
+  await remoteBrowser.close()
+}
+
+main()
+  .then(remoteBrowser.close)
+  .catch(error => {
+    console.log(error)
+    process.exit(1)
+  })

--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -185,7 +185,7 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
     }
   }
 
-  return { createContext, respawn, browser: getBrowser, close }
+  return { createContext, respawn, browser: getBrowser, close, isClosed: () => isClosed }
 }
 
 module.exports.driver = driver

--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -100,46 +100,46 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
 
     const withPage =
       (fn, { timeout: evaluateTimeout } = {}) =>
-      async (...args) => {
-        let isRejected = false
+        async (...args) => {
+          let isRejected = false
 
-        async function run () {
-          let page
+          async function run () {
+            let page
 
-          try {
-            page = await createPage(args)
-            setTimeout(() => closePage(page), timeout).unref()
-            const value = await fn(page, goto)(...args)
-            await closePage(page)
-            return value
-          } catch (error) {
-            await closePage(page)
-            if (!isRejected) throw ensureError(error)
-          }
-        }
-
-        const task = () =>
-          pRetry(run, {
-            retries: retry,
-            onFailedAttempt: async error => {
-              debug('onFailedAttempt', { name: error.name, code: error.code, isRejected })
-              if (error.name === 'AbortError') throw error
-              if (isRejected) throw new AbortError()
-              if (error.code === 'EBRWSRCONTEXTCONNRESET') {
-                _contextPromise = createBrowserContext(contextOpts)
-              }
-              const { message, attemptNumber, retriesLeft } = error
-              debug('retry', { attemptNumber, retriesLeft, message })
+            try {
+              page = await createPage(args)
+              setTimeout(() => closePage(page), timeout).unref()
+              const value = await fn(page, goto)(...args)
+              await closePage(page)
+              return value
+            } catch (error) {
+              await closePage(page)
+              if (!isRejected) throw ensureError(error)
             }
+          }
+
+          const task = () =>
+            pRetry(run, {
+              retries: retry,
+              onFailedAttempt: async error => {
+                debug('onFailedAttempt', { name: error.name, code: error.code, isRejected })
+                if (error.name === 'AbortError') throw error
+                if (isRejected) throw new AbortError()
+                if (error.code === 'EBRWSRCONTEXTCONNRESET') {
+                  _contextPromise = createBrowserContext(contextOpts)
+                }
+                const { message, attemptNumber, retriesLeft } = error
+                debug('retry', { attemptNumber, retriesLeft, message })
+              }
+            })
+
+          const timeout = evaluateTimeout || contextTimeout || globalTimeout
+
+          return pTimeout(task(), timeout, () => {
+            isRejected = true
+            throw browserTimeout({ timeout })
           })
-
-        const timeout = evaluateTimeout || contextTimeout || globalTimeout
-
-        return pTimeout(task(), timeout, () => {
-          isRejected = true
-          throw browserTimeout({ timeout })
-        })
-      }
+        }
 
     const evaluate = (fn, gotoOpts) =>
       withPage(

--- a/packages/browserless/test/driver.js
+++ b/packages/browserless/test/driver.js
@@ -7,7 +7,7 @@ const test = require('ava')
 
 const getChromiumPs = async () => {
   const ps = await psList()
-  return ps.filter(ps => ps.name.includes('Chromium'))
+  return ps.filter(ps => ps.name === 'Google Chrome for Testing')
 }
 
 ;(isCI ? test.skip : test.serial)('.close() will kill process and subprocess', async t => {
@@ -20,15 +20,14 @@ const getChromiumPs = async () => {
   t.is((await getChromiumPs())[0].pid, (await browserlessFactory.browser()).process().pid)
 
   const browserless = await browserlessFactory.createContext()
-  t.is((await getChromiumPs()).length, 3)
+  t.is((await getChromiumPs()).length, 1)
 
   await browserless.destroyContext()
-  t.is((await getChromiumPs()).length, 3)
+  t.is((await getChromiumPs()).length, 1)
 
   await browserlessFactory.close()
-  t.is((await getChromiumPs()).length, initialPs)
+  t.is((await getChromiumPs()).length, initialPs.length)
 })
-
 ;(isCI ? test.skip : test.serial)('.close() is idempotency', async t => {
   const initialPs = await getChromiumPs()
 
@@ -36,8 +35,8 @@ const getChromiumPs = async () => {
   t.is((await getChromiumPs()).length, 1)
 
   await browserlessFactory.close()
-  t.is((await getChromiumPs()).length, initialPs)
+  t.is((await getChromiumPs()).length, initialPs.length)
 
   await browserlessFactory.close()
-  t.is((await getChromiumPs()).length, initialPs)
+  t.is((await getChromiumPs()).length, initialPs.length)
 })

--- a/packages/browserless/test/index.js
+++ b/packages/browserless/test/index.js
@@ -2,6 +2,9 @@
 
 const { createBrowser, getBrowserContext, getBrowser } = require('@browserless/test/util')
 const { request, createServer } = require('http')
+const { setTimeout } = require('timers/promises')
+const execa = require('execa')
+const path = require('path')
 
 const test = require('ava')
 
@@ -63,4 +66,94 @@ test('ensure to close browser', async t => {
   const browser = require('..')()
   await browser.close()
   t.true(browser.isClosed())
+})
+
+test("don't respawn after close", async t => {
+  const script = path.join(__dirname, '../../../packages/benchmark/src/screenshot/speed.js')
+  const { exitCode } = await execa.node(script, { stdio: 'inherit' })
+  t.is(exitCode, 0)
+})
+
+test('respawn under `Protocol error (Target.createBrowserContext): Target closed`', async t => {
+  /**
+   * It simulates the browser is dead before created a context
+   */
+  {
+    const browserlessFactory = createBrowser()
+    t.teardown(browserlessFactory.close)
+
+    const pid = (await browserlessFactory.browser()).process().pid
+
+    process.kill(pid, 'SIGKILL')
+    const browserless = await browserlessFactory.createContext()
+
+    await browserless.text('https://example.com')
+    await browserless.destroyContext()
+
+    const anotherPid = (await browserlessFactory.browser()).process().pid
+
+    t.true(pid !== anotherPid)
+  }
+
+  /**
+   * It simulates the browser is dead after created a context
+   */
+  {
+    const browserlessFactory = createBrowser()
+    t.teardown(browserlessFactory.close)
+
+    const pid = (await browserlessFactory.browser()).process().pid
+
+    const browserless = await browserlessFactory.createContext()
+    process.kill(pid, 'SIGKILL')
+
+    await browserless.text('https://example.com')
+    await browserless.destroyContext()
+
+    const anotherPid = (await browserlessFactory.browser()).process().pid
+
+    t.true(pid !== anotherPid)
+  }
+})
+
+test('respawn under `Protocol error (Target.createTarget): Target closed`', async t => {
+  /**
+   * It simulates te context is created but the URL is not set yet
+   */
+  const browserlessFactory = createBrowser()
+  t.teardown(browserlessFactory.close)
+
+  const pid = (await browserlessFactory.browser()).process().pid
+
+  const browserless = await browserlessFactory.createContext()
+  await setTimeout(0)
+  process.kill(pid, 'SIGKILL')
+
+  await browserless.text('https://example.com')
+  await browserless.destroyContext()
+
+  const anotherPid = (await browserlessFactory.browser()).process().pid
+
+  t.true(pid !== anotherPid)
+})
+
+test('respawn under `Protocol error (Target.createTarget): browserContextId`', async t => {
+  const browserlessFactory = createBrowser()
+  t.teardown(browserlessFactory.close)
+
+  const pid = (await browserlessFactory.browser()).process().pid
+
+  const browserless = await browserlessFactory.createContext()
+  const contextId = await browserless.context().then(({ id }) => id)
+
+  await browserless.text('https://example.com')
+  await browserless.destroyContext()
+
+  await browserless.text('https://example.com')
+  const anotherContextId = await browserless.context().then(({ id }) => id)
+
+  const anotherPid = (await browserlessFactory.browser()).process().pid
+
+  t.true(pid === anotherPid)
+  t.false(contextId === anotherContextId)
 })

--- a/packages/browserless/test/index.js
+++ b/packages/browserless/test/index.js
@@ -58,3 +58,9 @@ test('ensure to destroy browser contexts', async t => {
 
   t.is(browser.browserContexts().length, 1)
 })
+
+test('ensure to close browser', async t => {
+  const browser = require('..')()
+  await browser.close()
+  t.true(browser.isClosed())
+})

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -22,11 +22,6 @@ browserlessError.evaluationFailed = createBrowserlessError({
   message: 'Evaluation failed'
 })
 
-browserlessError.browserDisconnected = createBrowserlessError({
-  code: 'EBRWSRCONNRESET',
-  message: 'The browser is not connected.'
-})
-
 browserlessError.contextDisconnected = createBrowserlessError({
   code: 'EBRWSRCONTEXTCONNRESET',
   message: 'The browser context is not connected.'
@@ -36,14 +31,17 @@ browserlessError.ensureError = rawError => {
   debug('ensureError', serializeError(rawError))
 
   const error = 'error' in rawError ? rawError.error : rawError
-
-  if (error.code === 'ECONNREFUSED') {
-    return browserlessError.browserDisconnected()
-  }
-
   const { message: errorMessage = '' } = error
 
-  if (errorMessage === 'Protocol error (Target.createTarget): browserContextId') {
+  console.log({ errorMessage })
+
+  if (
+    [
+      'Protocol error (Target.createTarget): browserContextId',
+      'Protocol error (Target.createTarget): Target closed',
+      'Protocol error (Target.createBrowserContext): Target closed'
+    ].includes(errorMessage)
+  ) {
     return browserlessError.contextDisconnected()
   }
 

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -33,8 +33,6 @@ browserlessError.ensureError = rawError => {
   const error = 'error' in rawError ? rawError.error : rawError
   const { message: errorMessage = '' } = error
 
-  console.log({ errorMessage })
-
   if (
     [
       'Protocol error (Target.createTarget): browserContextId',

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -20,21 +20,6 @@ test('protocolError', t => {
   t.is(error.message, 'EPROTOCOL, Target closed.')
 })
 
-test('browserDisconnected', t => {
-  const parsedError = errors.ensureError({ code: 'ECONNREFUSED' })
-
-  t.true(parsedError instanceof Error)
-  t.is(parsedError.name, 'BrowserlessError')
-  t.is(parsedError.code, 'EBRWSRCONNRESET')
-  t.is(parsedError.message, 'EBRWSRCONNRESET, The browser is not connected.')
-
-  const error = errors.browserDisconnected()
-  t.true(error instanceof Error)
-  t.is(error.name, 'BrowserlessError')
-  t.is(parsedError.code, 'EBRWSRCONNRESET')
-  t.is(parsedError.message, 'EBRWSRCONNRESET, The browser is not connected.')
-})
-
 test('browserTimeout', t => {
   const error = errors.browserTimeout({ timeout: 50 })
 


### PR DESCRIPTION
- The error that can respawn a browser have the `EBRWSRCONTEXTCONNRESET` code associated.
- Added a unit test for every case.
- Add a benchmark for `optimizeForSpeed` option for screenshot
- Dropped `EBRWSRCONNRESET` error since is not used.