### PR TITLE
chore: add evaluation failed error variations

### DIFF
--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -52,7 +52,8 @@ browserlessError.ensureError = rawError => {
   if (
     ['Evaluation failed', 'Cannot read properties of undefined'].some(message =>
       errorMessage.startsWith(message)
-    )
+    ) ||
+    errorMessage.endsWith('is not defined')
   ) {
     const messages = errorMessage.split(': ')
     return browserlessError.evaluationFailed({

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -49,7 +49,11 @@ browserlessError.ensureError = rawError => {
     })
   }
 
-  if (errorMessage.startsWith('Evaluation failed')) {
+  if (
+    ['Evaluation failed', 'Cannot read properties of undefined'].some(message =>
+      errorMessage.startsWith(message)
+    )
+  ) {
     const messages = errorMessage.split(': ')
     return browserlessError.evaluationFailed({
       message: messages[messages.length - 1]

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -68,4 +68,22 @@ test('evaluationFailed', t => {
     t.is(error.code, 'EFAILEDEVAL')
     t.is(error.message, "EFAILEDEVAL, Cannot read properties of undefined (reading 'versoin')")
   }
+  {
+    const parsedError = errors.ensureError({
+      message: 'version is not defined'
+    })
+
+    t.true(parsedError instanceof Error)
+    t.is(parsedError.name, 'BrowserlessError')
+    t.is(parsedError.code, 'EFAILEDEVAL')
+
+    t.is(parsedError.message, 'EFAILEDEVAL, version is not defined')
+
+    const error = errors.evaluationFailed('version is not defined')
+
+    t.true(error instanceof Error)
+    t.is(error.name, 'BrowserlessError')
+    t.is(error.code, 'EFAILEDEVAL')
+    t.is(error.message, 'EFAILEDEVAL, version is not defined')
+  }
 })

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -30,19 +30,42 @@ test('browserTimeout', t => {
 })
 
 test('evaluationFailed', t => {
-  const parsedError = errors.ensureError({
-    message: "Evaluation failed: TypeError: Cannot read property 'bar' of undefined"
-  })
+  {
+    const parsedError = errors.ensureError({
+      message: "Evaluation failed: TypeError: Cannot read property 'bar' of undefined"
+    })
 
-  t.true(parsedError instanceof Error)
-  t.is(parsedError.name, 'BrowserlessError')
-  t.is(parsedError.code, 'EFAILEDEVAL')
-  t.is(parsedError.message, "EFAILEDEVAL, Cannot read property 'bar' of undefined")
+    t.true(parsedError instanceof Error)
+    t.is(parsedError.name, 'BrowserlessError')
+    t.is(parsedError.code, 'EFAILEDEVAL')
+    t.is(parsedError.message, "EFAILEDEVAL, Cannot read property 'bar' of undefined")
 
-  const error = errors.evaluationFailed("Cannot read property 'bar' of undefined")
+    const error = errors.evaluationFailed("Cannot read property 'bar' of undefined")
 
-  t.true(error instanceof Error)
-  t.is(error.name, 'BrowserlessError')
-  t.is(error.code, 'EFAILEDEVAL')
-  t.is(error.message, "EFAILEDEVAL, Cannot read property 'bar' of undefined")
+    t.true(error instanceof Error)
+    t.is(error.name, 'BrowserlessError')
+    t.is(error.code, 'EFAILEDEVAL')
+    t.is(error.message, "EFAILEDEVAL, Cannot read property 'bar' of undefined")
+  }
+  {
+    const parsedError = errors.ensureError({
+      message: "Cannot read properties of undefined (reading 'versoin')"
+    })
+
+    t.true(parsedError instanceof Error)
+    t.is(parsedError.name, 'BrowserlessError')
+    t.is(parsedError.code, 'EFAILEDEVAL')
+
+    t.is(
+      parsedError.message,
+      "EFAILEDEVAL, Cannot read properties of undefined (reading 'versoin')"
+    )
+
+    const error = errors.evaluationFailed("Cannot read properties of undefined (reading 'versoin')")
+
+    t.true(error instanceof Error)
+    t.is(error.name, 'BrowserlessError')
+    t.is(error.code, 'EFAILEDEVAL')
+    t.is(error.message, "EFAILEDEVAL, Cannot read properties of undefined (reading 'versoin')")
+  }
 })

--- a/packages/goto/test/e2e/evasions.js
+++ b/packages/goto/test/e2e/evasions.js
@@ -6,7 +6,7 @@ const ava = require('ava')
 
 const test = process.env.CI ? ava.serial : ava
 
-test('arh.antoinevastel.com/bots/areyouheadless', async t => {
+test.serial('arh.antoinevastel.com/bots/areyouheadless', async t => {
   let assertion = false
 
   const fn = async () => {
@@ -20,7 +20,7 @@ test('arh.antoinevastel.com/bots/areyouheadless', async t => {
   t.true(assertion)
 })
 
-test('creepjs', async t => {
+test.serial('creepjs', async t => {
   const browserless = await getBrowserContext(t)
 
   const fingerprint = await browserless.evaluate(page =>
@@ -43,7 +43,7 @@ test('creepjs', async t => {
   t.true(fingerprintOne !== fingerprintTwo)
 })
 
-test('fingerprintjs', async t => {
+test.serial('fingerprintjs', async t => {
   const browserless = await getBrowserContext(t)
 
   const fingerprint = await browserless.evaluate(page =>
@@ -58,7 +58,7 @@ test('fingerprintjs', async t => {
   t.true(fingerprintOne !== fingerprintTwo)
 })
 
-test('amiunique.org/fp', async t => {
+test.serial('amiunique.org/fp', async t => {
   const browserless = await getBrowserContext(t)
   const content = await browserless.text('https://amiunique.org/fingerprint', {
     waitForSelector:


### PR DESCRIPTION
to reproduce it in a browser: `window.next.versoin`