### PR TITLE
feat(cli): add page-weight script

### DIFF
--- a/packages/cli/src/commands/page-weight.js
+++ b/packages/cli/src/commands/page-weight.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const prettyBytes = require('pretty-bytes')
+
+module.exports = async ({ url, browserless, opts }) => {
+  const pageResources = browserless.evaluate(async page =>
+    page.evaluate(() =>
+      window.performance.getEntriesByType('resource').map(resource => ({
+        transferredSize: resource.transferSize,
+        decodedBodySize: resource.decodedBodySize
+      }))
+    )
+  )
+
+  const resources = await pageResources(url, opts)
+
+  const [transferSize, resourcesSize] = resources
+    .reduce(
+      (acc, { transferredSize, decodedBodySize }) => {
+        acc[0] += transferredSize
+        acc[1] += decodedBodySize
+        return acc
+      },
+      [0, 0]
+    )
+    .map(prettyBytes)
+
+  const resume = `
+  ⬩ ${resources.length} network requests
+  ⬩ ${transferSize} transferred bytes
+  ⬩ ${resourcesSize} resources bytes`
+
+  return [resume]
+}


### PR DESCRIPTION
```
$ browserless page-weight https://timer.blog/ --no-verbose

  ⬩ 15 network requests
  ⬩ 85.1 kB transferred bytes
  ⬩ 266 kB resources bytes
```

Microlink version: https://runkit.com/kikobeats/microlink-page-weight