### PR TITLE
fix(goto): abort page.goto after timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [10.5.0-alpha.0](https://github.com/microlinkhq/browserless/compare/v10.4.1...v10.5.0-alpha.0) (2024-04-22)
+
+### Bug Fixes
+
+* **goto:** abort page.goto after timeout ([638fa4e](https://github.com/microlinkhq/browserless/commit/638fa4efadf59ddde2cd772fbc2d012ae9535f68))
+
 ## [10.4.1](https://github.com/microlinkhq/browserless/compare/v10.4.0...v10.4.1) (2024-03-23)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "10.4.1",
+  "version": "10.5.0-alpha.0",
   "command": {
     "bootstrap": {
       "npmClientArgs": [

--- a/packages/browserless/CHANGELOG.md
+++ b/packages/browserless/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [10.5.0-alpha.0](https://github.com/microlinkhq/browserless/compare/v10.4.1...v10.5.0-alpha.0) (2024-04-22)
+
+**Note:** Version bump only for package browserless
+
 # [10.4.0](https://github.com/microlinkhq/browserless/compare/v10.3.0...v10.4.0) (2024-03-19)
 
 **Note:** Version bump only for package browserless

--- a/packages/browserless/package.json
+++ b/packages/browserless/package.json
@@ -2,7 +2,7 @@
   "name": "browserless",
   "description": "The headless Chrome/Chromium performance driver for Node.js",
   "homepage": "https://browserless.js.org",
-  "version": "10.4.0",
+  "version": "10.5.0-alpha.0",
   "main": "src/index.js",
   "author": {
     "email": "hello@microlink.io",
@@ -32,9 +32,9 @@
   ],
   "dependencies": {
     "@browserless/errors": "^10.3.0",
-    "@browserless/goto": "^10.4.0",
-    "@browserless/pdf": "^10.4.0",
-    "@browserless/screenshot": "^10.4.0",
+    "@browserless/goto": "^10.5.0-alpha.0",
+    "@browserless/pdf": "^10.5.0-alpha.0",
+    "@browserless/screenshot": "^10.5.0-alpha.0",
     "debug-logfmt": "~1.2.1",
     "kill-process-group": "~1.0.7",
     "p-reflect": "~2.1.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [10.5.0-alpha.0](https://github.com/microlinkhq/browserless/compare/v10.4.1...v10.5.0-alpha.0) (2024-04-22)
+
+**Note:** Version bump only for package @browserless/cli
+
 # [10.4.0](https://github.com/microlinkhq/browserless/compare/v10.3.0...v10.4.0) (2024-03-19)
 
 **Note:** Version bump only for package @browserless/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@browserless/cli",
   "description": "CLI to interact with Browserless capabilities",
   "homepage": "https://browserless.js.org",
-  "version": "10.4.0",
+  "version": "10.5.0-alpha.0",
   "bin": {
     "browserless": "src/index.js"
   },
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "beauty-error": "~1.2.18",
-    "browserless": "^10.4.0",
+    "browserless": "^10.5.0-alpha.0",
     "dark-mode": "~3.0.0",
     "dset": "~3.1.3",
     "mri": "~1.2.0",

--- a/packages/function/CHANGELOG.md
+++ b/packages/function/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [10.5.0-alpha.0](https://github.com/microlinkhq/browserless/compare/v10.4.1...v10.5.0-alpha.0) (2024-04-22)
+
+**Note:** Version bump only for package @browserless/function
+
 # [10.4.0](https://github.com/microlinkhq/browserless/compare/v10.3.0...v10.4.0) (2024-03-19)
 
 **Note:** Version bump only for package @browserless/function

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -2,7 +2,7 @@
   "name": "@browserless/function",
   "description": "Run abritrary JavaScript inside a browser sandbox",
   "homepage": "https://browserless.js.org",
-  "version": "10.4.0",
+  "version": "10.5.0-alpha.0",
   "main": "src/index.js",
   "author": {
     "email": "hello@microlink.io",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@browserless/test": "^10.3.0",
     "ava": "5",
-    "browserless": "^10.4.0",
+    "browserless": "^10.5.0-alpha.0",
     "lodash": "latest"
   },
   "engines": {

--- a/packages/goto/CHANGELOG.md
+++ b/packages/goto/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [10.5.0-alpha.0](https://github.com/microlinkhq/browserless/compare/v10.4.1...v10.5.0-alpha.0) (2024-04-22)
+
+### Bug Fixes
+
+* **goto:** abort page.goto after timeout ([638fa4e](https://github.com/microlinkhq/browserless/commit/638fa4efadf59ddde2cd772fbc2d012ae9535f68))
+
 # [10.4.0](https://github.com/microlinkhq/browserless/compare/v10.3.0...v10.4.0) (2024-03-19)
 
 ### Performance Improvements

--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -2,7 +2,7 @@
   "name": "@browserless/goto",
   "description": "Go to a page aborting unnecessary requests",
   "homepage": "https://browserless.js.org/#/?id=gotopage-options",
-  "version": "10.4.0",
+  "version": "10.5.0-alpha.0",
   "main": "src/index.js",
   "author": {
     "email": "hello@microlink.io",

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -197,7 +197,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       scripts,
       scroll,
       styles,
-      timeout = globalTimeout,
+      timeout,
       timezone,
       url,
       username,
@@ -210,7 +210,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       ...args
     }
   ) => {
-    const baseTimeout = timeouts.base(globalTimeout)
+    const baseTimeout = timeouts.base(timeout || globalTimeout)
     const actionTimeout = timeouts.action(baseTimeout)
     const gotoTimeout = timeouts.goto(baseTimeout)
 
@@ -363,7 +363,10 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
     const { value: response, reason: error } = await run({
       fn: html
         ? page.setContent(html, { waitUntil, ...args })
-        : page.goto(url, { waitUntil, ...args }),
+        : Promise.race([
+          page.goto(url, { waitUntil, ...args }),
+          setTimeout(gotoTimeout).then(() => page._client().send('Page.stopLoading'))
+        ]),
       timeout: gotoTimeout,
       debug: { fn: html ? 'html' : 'url', waitUntil }
     })

--- a/packages/goto/test/index.js
+++ b/packages/goto/test/index.js
@@ -61,3 +61,14 @@ test('handle page disconnections', async t => {
 
   await intercept('chrome://version')
 })
+
+test('handle page.goto hanging', async t => {
+  const browserless = await getBrowserContext(t)
+
+  const html = await browserless.html('https://test-timeout.vercel.app/', {
+    timeout: 5000,
+    animations: true
+  })
+
+  t.is(html, '<html><head></head><body></body></html>')
+})

--- a/packages/pdf/CHANGELOG.md
+++ b/packages/pdf/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [10.5.0-alpha.0](https://github.com/microlinkhq/browserless/compare/v10.4.1...v10.5.0-alpha.0) (2024-04-22)
+
+**Note:** Version bump only for package @browserless/pdf
+
 # [10.4.0](https://github.com/microlinkhq/browserless/compare/v10.3.0...v10.4.0) (2024-03-19)
 
 **Note:** Version bump only for package @browserless/pdf

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -2,7 +2,7 @@
   "name": "@browserless/pdf",
   "description": "Sensible good defaults for exporting a website as PDF",
   "homepage": "https://browserless.js.org/#/?id=pdfurl-options",
-  "version": "10.4.0",
+  "version": "10.5.0-alpha.0",
   "main": "src",
   "repository": {
     "directory": "packages/pdf",
@@ -24,7 +24,7 @@
     "screen"
   ],
   "dependencies": {
-    "@browserless/goto": "^10.4.0"
+    "@browserless/goto": "^10.5.0-alpha.0"
   },
   "engines": {
     "node": ">= 12"

--- a/packages/screenshot/CHANGELOG.md
+++ b/packages/screenshot/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [10.5.0-alpha.0](https://github.com/microlinkhq/browserless/compare/v10.4.1...v10.5.0-alpha.0) (2024-04-22)
+
+**Note:** Version bump only for package @browserless/screenshot
+
 # [10.4.0](https://github.com/microlinkhq/browserless/compare/v10.3.0...v10.4.0) (2024-03-19)
 
 ### Performance Improvements

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -2,7 +2,7 @@
   "name": "@browserless/screenshot",
   "description": "Take a clean screenshot of any website",
   "homepage": "https://browserless.js.org/#/?id=screenshoturl-options",
-  "version": "10.4.0",
+  "version": "10.5.0-alpha.0",
   "main": "src/index.js",
   "author": {
     "email": "hello@microlink.io",
@@ -28,7 +28,7 @@
     "screenshot"
   ],
   "dependencies": {
-    "@browserless/goto": "^10.4.0",
+    "@browserless/goto": "^10.5.0-alpha.0",
     "@kikobeats/time-span": "~1.0.3",
     "debug-logfmt": "~1.2.1",
     "got": "~11.8.6",


### PR DESCRIPTION
I discovered there is no way to cancel `page.goto` unless you take care about it.

Long issue with several workarounds: https://github.com/puppeteer/puppeteer/issues/3238