### PR TITLE
chore(goto): teardown adbock gracefully

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -97,6 +97,7 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
     const closePage = async (page, name) => {
       if (page && !page.isClosed()) {
         const duration = debug.duration('closePage')
+        if (page.disableAdblock) await page.disableAdblock()
         const [browserProcess, browserContext] = await Promise.all([
           getBrowser(),
           getBrowserContext(),

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -264,6 +264,10 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
     }
 
     if (adblock) {
+      page.disableAdblock = async () => {
+        await engine.disableBlockingInPage(page)
+        debug.adblock('disabled')
+      }
       prePromises.push(
         run({
           fn: engine.enableBlockingInPage(page),


### PR DESCRIPTION
Puppeteer can report errors if the page has been closed but still some requests abortion are pending to be completed:

```
  browserless:goto:adblock block https://www.youtube.com/youtubei/v1/log_event?alt=json
/Users/kikobeats/Projects/microlink/browserless/node_modules/.pnpm/puppeteer-core@24.16.2/node_modules/puppeteer-core/lib/cjs/puppeteer/util/assert.js:18
        throw new Error(message);
              ^

Error: Request Interception is not enabled!
    at assert (/Users/kikobeats/Projects/microlink/browserless/node_modules/.pnpm/puppeteer-core@24.16.2/node_modules/puppeteer-core/lib/cjs/puppeteer/util/assert.js:18:15)
    at CdpHTTPRequest.abort (/Users/kikobeats/Projects/microlink/browserless/node_modules/.pnpm/puppeteer-core@24.16.2/node_modules/puppeteer-core/lib/cjs/puppeteer/api/HTTPRequest.js:305:32)
    at PuppeteerBlocker.onRequest (/Users/kikobeats/Projects/microlink/browserless/node_modules/.pnpm/@ghostery+adblocker-puppeteer@2.11.6_puppeteer@24.16.2_typescript@5.9.2_/node_modules/@ghostery/adblocker-puppeteer/dist/commonjs/index.js:267:25)
    at BlockingContext.onRequest (/Users/kikobeats/Projects/microlink/browserless/node_modules/.pnpm/@ghostery+adblocker-puppeteer@2.11.6_puppeteer@24.16.2_typescript@5.9.2_/node_modules/@ghostery/adblocker-puppeteer/dist/commonjs/index.js:69:47)
    at /Users/kikobeats/Projects/microlink/browserless/node_modules/.pnpm/puppeteer-core@24.16.2/node_modules/puppeteer-core/lib/cjs/puppeteer/api/Page.js:224:32
    at async CdpHTTPRequest.finalizeInterceptions (/Users/kikobeats/Projects/microlink/browserless/node_modules/.pnpm/puppeteer-core@24.16.2/node_modules/puppeteer-core/lib/cjs/puppeteer/api/HTTPRequest.js:151:9)

Node.js v22.18.0
```