### PR TITLE
chore(driver): prefer disable-gpu

### DIFF
--- a/packages/browserless/src/driver.js
+++ b/packages/browserless/src/driver.js
@@ -30,6 +30,7 @@ const defaultArgs = [
   '--no-startup-window',
   `--enable-features=${['SharedArrayBuffer'].join(',')}`,
   '--no-zygote', // https://source.chromium.org/search?q=lang:cpp+symbol:kNoZygote&ss=chromium
+  '--disable-gpu',
   '--use-angle=swiftshader', // https://chromium.googlesource.com/chromium/src/+/main/docs/gpu/swiftshader.md
   '--use-gl=angle', // https://chromium.googlesource.com/chromium/src/+/main/docs/gpu/swiftshader.md
   `--disable-features=${[

--- a/packages/screenshot/test/index.js
+++ b/packages/screenshot/test/index.js
@@ -34,7 +34,7 @@ test('graphics features', async t => {
       ? {
           Canvas: 'Hardware accelerated',
           'Direct Rendering Display Compositor': 'Disabled',
-          Compositing: 'Hardware accelerated',
+          Compositing: 'Software only. Hardware acceleration disabled',
           'Multiple Raster Threads': 'Enabled',
           OpenGL: 'Enabled',
           Rasterization: 'Hardware accelerated',
@@ -44,25 +44,25 @@ test('graphics features', async t => {
           'Video Decode': 'Hardware accelerated',
           'Video Encode': 'Software only. Hardware acceleration disabled',
           Vulkan: 'Disabled',
-          WebGL: 'Hardware accelerated',
-          WebGL2: 'Hardware accelerated',
+          WebGL: 'Hardware accelerated but at reduced performance',
+          WebGL2: 'Hardware accelerated but at reduced performance',
           WebGPU: 'Disabled',
           WebNN: 'Disabled'
         }
       : {
           Canvas: 'Hardware accelerated',
-          'Direct Rendering Display Compositor': 'Enabled',
-          Compositing: 'Hardware accelerated',
+          'Direct Rendering Display Compositor': 'Disabled',
+          Compositing: 'Software only. Hardware acceleration disabled',
           'Multiple Raster Threads': 'Enabled',
           OpenGL: 'Enabled',
           Rasterization: 'Hardware accelerated',
           'Raw Draw': 'Disabled',
-          'Skia Graphite': 'Enabled',
+          'Skia Graphite': 'Disabled',
           TreesInViz: 'Disabled',
           'Video Decode': 'Hardware accelerated',
           'Video Encode': 'Hardware accelerated',
-          WebGL: 'Hardware accelerated',
-          WebGL2: 'Hardware accelerated',
+          WebGL: 'Hardware accelerated but at reduced performance',
+          WebGL2: 'Hardware accelerated but at reduced performance',
           WebGPU: 'Software only, hardware acceleration unavailable',
           WebNN: 'Disabled'
         }


### PR DESCRIPTION
There is a chromium limitation and it is not possible to take screenshot larger than 16384px: https://issues.chromium.org/issues/41347676

However, it works fine when gpu is disabled.