### PR TITLE
fix(goto): skip cookies from headers

### DIFF
--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -326,6 +326,8 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
     const headersKeys = Object.keys(headers)
 
     if (headersKeys.length > 0) {
+      const { cookie, ...headersWithoutCookie } = headers
+
       if (headers.cookie) {
         const cookies = parseCookies(url, headers.cookie)
         prePromises.push(
@@ -337,6 +339,9 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
         )
       }
 
+      const extraHTTPHeaders = headers.cookie ? headersWithoutCookie : headers
+      const extraHTTPHeadersKeys = Object.keys(extraHTTPHeaders)
+
       if (headers['user-agent']) {
         prePromises.push(
           run({
@@ -347,13 +352,15 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
         )
       }
 
-      prePromises.push(
-        run({
-          fn: page.setExtraHTTPHeaders(headers),
-          timeout: actionTimeout,
-          debug: { headers: headersKeys }
-        })
-      )
+      if (extraHTTPHeadersKeys.length > 0) {
+        prePromises.push(
+          run({
+            fn: page.setExtraHTTPHeaders(extraHTTPHeaders),
+            timeout: actionTimeout,
+            debug: { headers: extraHTTPHeadersKeys }
+          })
+        )
+      }
     }
 
     if (timezone) {

--- a/packages/goto/test/unit/headers/index.js
+++ b/packages/goto/test/unit/headers/index.js
@@ -76,3 +76,88 @@ test('set `cookie` header', async t => {
   t.is(body.headers.cookie, 'yummy_cookie=choco; tasty_cookie=strawberry')
   t.is(cookies.length, 2)
 })
+
+test('does not forward cookie through extra headers', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+  let extraHTTPHeaders
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const originalSetExtraHTTPHeaders = page.setExtraHTTPHeaders.bind(page)
+    page.setExtraHTTPHeaders = headers => {
+      extraHTTPHeaders = headers
+      return originalSetExtraHTTPHeaders(headers)
+    }
+
+    const result = await goto(page, {
+      url,
+      headers: {
+        'x-foo': 'bar',
+        cookie: 'yummy_cookie=choco'
+      }
+    })
+
+    const cookies = await page.cookies(url)
+    return { result, cookies }
+  })
+
+  const { cookies } = await run()
+
+  t.truthy(extraHTTPHeaders)
+  t.false(Object.prototype.hasOwnProperty.call(extraHTTPHeaders, 'cookie'))
+  t.true(cookies.some(({ name, value }) => name === 'yummy_cookie' && value === 'choco'))
+})
+
+test('cookies are not sent to subrequests via extra headers', async t => {
+  const browserless = await getBrowserContext(t)
+  let subrequestHeaders
+
+  const subrequestUrl = (
+    await runServer(t, ({ req, res }) => {
+      if (req.method === 'OPTIONS') {
+        res.setHeader('access-control-allow-origin', '*')
+        res.setHeader('access-control-allow-methods', 'GET,POST,OPTIONS')
+        res.setHeader('access-control-allow-headers', 'x-foo')
+        res.statusCode = 204
+        return res.end()
+      }
+
+      subrequestHeaders = req.headers
+      res.setHeader('access-control-allow-origin', '*')
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ ok: true }))
+    })
+  ).replace('127.0.0.1', 'localhost')
+
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(`
+      <script>
+        fetch('${subrequestUrl}').finally(() => {
+          window.__subrequest_complete = true
+        })
+      </script>
+    `)
+  })
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, {
+      url,
+      waitForFunction: () => window.__subrequest_complete === true,
+      headers: {
+        'x-foo': 'bar',
+        cookie: 'secret_token=top_secret'
+      }
+    })
+
+    const cookies = await page.cookies(url)
+    return { cookies }
+  })
+
+  const { cookies } = await run()
+
+  t.truthy(subrequestHeaders)
+  t.is(subrequestHeaders['x-foo'], 'bar')
+  t.falsy(subrequestHeaders.cookie)
+  t.true(cookies.some(({ name, value }) => name === 'secret_token' && value === 'top_secret'))
+})


### PR DESCRIPTION
Cookies are parsed and set via `page.setCookie`, so they have to be excluded from being set via `page.setExtraHTTPHeaders`.