### PR TITLE
bug(cli): lighthouse must be installed

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -50,6 +50,11 @@ The `@browserless/cli` package allows you to:
 | `status <url>` | Get the HTTP status code |
 | `goto <url>` | Navigate to a URL and return page/response info |
 
+> **Note:** The `lighthouse` command requires an extra installation.  
+> 
+> Please make sure to install the standalone package by running:<br>
+> <kbd>npm install -g @browserless/lighthouse</kbd>
+
 ### How it fits in the monorepo
 This package depends on:
 

--- a/packages/cli/src/commands/lighthouse.js
+++ b/packages/cli/src/commands/lighthouse.js
@@ -1,6 +1,19 @@
 'use strict'
 
-const createLighthouse = require('../../../lighthouse/src')
+const { existsSync } = require('fs')
+const { resolve } = require('path')
+
+const lighthousePath = resolve(__dirname, '../../../lighthouse/src')
+
+let createLighthouse
+
+if (existsSync(lighthousePath)) {
+  createLighthouse = require(lighthousePath)
+} else {
+  console.error('The @browserless/lighthouse package is not installed.')
+  console.error('Please install it by running: npm install -g @browserless/lighthouse')
+  process.exit(1)
+}
 
 module.exports = async ({ url, browserless, opts }) => {
   const lighthouse = createLighthouse(async teardown => {


### PR DESCRIPTION
Added a check for the lighthouse dependency before execution.

Now displays a clear message asking the user to install the package if it's missing.

Updated the README/docs to clarify that lighthouse is a peer dependency for this specific command.