### PR TITLE
fix(browserless): disconnect connect-mode browser on close

### DIFF
--- a/packages/browserless/test/driver.js
+++ b/packages/browserless/test/driver.js
@@ -3,6 +3,7 @@
 const { createBrowser } = require('@browserless/test')
 const psList = require('ps-list')
 const test = require('ava')
+const browserless = require('..')
 
 const isCI = !!process.env.CI
 
@@ -46,4 +47,23 @@ const getChromiumPs = async () => {
 
   await browserlessFactory.close()
   t.is(await getChromiumPs(), initialPs)
+})
+
+test('.close() disconnect in connect mode', async t => {
+  const remoteBrowser = await browserless.driver.spawn()
+  t.teardown(() => browserless.driver.close(remoteBrowser))
+
+  const browserlessFactory = browserless({
+    mode: 'connect',
+    browserWSEndpoint: remoteBrowser.wsEndpoint()
+  })
+  t.teardown(browserlessFactory.close)
+
+  const browser = await browserlessFactory.browser()
+
+  t.true(browser.isConnected())
+
+  await browserlessFactory.close()
+
+  t.false(browser.isConnected())
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes shutdown behavior for Puppeteer `connect` sessions, which can affect resource cleanup and connection lifecycle but is localized to `driver.close` and covered by a new test.
> 
> **Overview**
> Fixes `driver.close` to properly clean up *connect-mode* Puppeteer instances by calling `subprocess.disconnect()` (or `subprocess.close()` when available) even when no local PID exists, instead of no-op’ing.
> 
> Updates the return value to omit `pid` when unknown, and adds an AVA test asserting `.close()` disconnects a connected remote browser (`browser.isConnected()` flips to `false`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6d5a720499f30d328ae2c2f8fa625f1f54e9718. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->