### PR TITLE
fix(errors): guard ensureError against non-object throws

### DIFF
--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -94,3 +94,17 @@ test('evaluationFailed', t => {
     t.is(error.message, 'EFAILEDEVAL, version is not defined')
   }
 })
+
+test('ensureError handles non-object input', t => {
+  const errorFromString = errors.ensureError('boom')
+  t.true(errorFromString instanceof Error)
+  t.true(errorFromString.message.includes('boom'))
+
+  const errorFromNull = errors.ensureError(null)
+  t.true(errorFromNull instanceof Error)
+  t.is(errorFromNull.message, 'null')
+
+  const errorFromNestedString = errors.ensureError({ error: 'nested boom' })
+  t.true(errorFromNestedString instanceof Error)
+  t.true(errorFromNestedString.message.includes('nested boom'))
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small defensive checks in error-normalization logic plus tests; main risk is subtle changes to how some malformed inputs are classified/converted into `BrowserlessError`s.
> 
> **Overview**
> `errors.ensureError` is hardened to avoid assuming thrown values are objects: it now guards `__parsed` checks, nested `rawError.error` unwrapping, and message parsing behind an `isObject` helper, and uses a single imported `ensure-error` dependency.
> 
> Adds tests ensuring `ensureError` returns an `Error` when given a string, `null`, or `{ error: '...' }` input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 621026871b0f1fe0de5860d5ac0cbf7a1785516c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->