### PR TITLE
perf(pdf): render final pdf once in auto wait mode

### DIFF
--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const createPdf = require('@browserless/pdf')
+const path = require('path')
+const fs = require('fs')
+const test = require('ava')
+
+const whiteScreenshot = fs.readFileSync(
+  path.resolve(__dirname, '../../screenshot/test/fixtures/white-5k.png')
+)
+
+const noWhiteScreenshot = fs.readFileSync(
+  path.resolve(__dirname, '../../screenshot/test/fixtures/no-white-5k.png')
+)
+
+test('waitUntil auto should generate final pdf once', async t => {
+  let screenshotCalls = 0
+  let pdfCalls = 0
+  let waitUntilAutoCalls = 0
+
+  const page = {
+    screenshot: async () => (screenshotCalls++ === 0 ? whiteScreenshot : noWhiteScreenshot),
+    pdf: async () => {
+      pdfCalls += 1
+      return Buffer.from(`pdf-${pdfCalls}`)
+    }
+  }
+
+  const goto = async (page, opts = {}) => {
+    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
+    return { response: {} }
+  }
+
+  goto.timeouts = {
+    action: () => 100000
+  }
+
+  goto.waitUntilAuto = async () => {
+    waitUntilAutoCalls += 1
+  }
+
+  const pdf = createPdf({ goto })(page)
+  const buffer = await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
+
+  t.true(Buffer.isBuffer(buffer))
+  t.is(pdfCalls, 1)
+  t.true(screenshotCalls >= 2)
+  t.is(waitUntilAutoCalls, 1)
+})

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -49,23 +49,20 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
           do {
             ++retry
             const screenshotTime = timeSpan()
-            ;[isWhite, pdfBuffer] = await Promise.all([
-              isWhiteScreenshot(
-                await page.screenshot({
-                  ...opts,
-                  optimizeForSpeed: true,
-                  type: 'jpeg',
-                  quality: 30
-                })
-              ),
-              generatePdf(page),
-              retry === 1 ? goto.waitUntilAuto(page, { timeout: opts.timeout }) : Promise.resolve()
-            ])
+            const screenshot = await page.screenshot({
+              ...opts,
+              optimizeForSpeed: true,
+              type: 'jpeg',
+              quality: 30
+            })
+            isWhite = await isWhiteScreenshot(screenshot)
+            if (retry === 1) await goto.waitUntilAuto(page, { timeout: opts.timeout })
             debug('retry', { waitUntil, isWhite, retry, duration: screenshotTime() })
           } while (isWhite && timePdf() < timeout)
 
           debug({ waitUntil, isWhite, timeout, duration: require('pretty-ms')(timePdf()) })
         }
+        pdfBuffer = await generatePdf(page)
       }
 
       return pdfBuffer


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `waitUntil: 'auto'` behavior to defer PDF generation until after the white-page polling loop, which can alter timing and output for some pages. Risk is moderate because it affects PDF rendering flow and depends on screenshot/timeout interactions.
> 
> **Overview**
> In `@browserless/pdf` when `waitUntil: 'auto'` is used, the retry loop now **only takes screenshots to detect blank/white renders** and defers `page.pdf()` until after the loop finishes, so the *final PDF is generated once* instead of on each retry.
> 
> Adds an AVA test (`packages/browserless/test/pdf.js`) that stubs `page.screenshot`/`page.pdf` and asserts a single PDF generation call while still performing multiple screenshot retries and invoking `goto.waitUntilAuto` once.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f06b2699d9c2ee203d6190fbe473b68e46fec3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->