### PR TITLE
perf(goto): reuse cookie jar while parsing headers

### DIFF
--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -30,15 +30,13 @@ const run = async ({ fn, timeout, debug: props }) => {
   return result
 }
 
-const parseCookies = (url, str) =>
-  str.split(';').reduce((acc, cookieStr) => {
-    const jar = new toughCookie.CookieJar(undefined, { rejectPublicSuffixes: false })
-    jar.setCookieSync(cookieStr.trim(), url)
-    const parsedCookie = jar.serializeSync().cookies[0]
+const parseCookies = (url, str) => {
+  const jar = new toughCookie.CookieJar(undefined, { rejectPublicSuffixes: false })
 
-    // Use this instead of the above when the following issue is fixed:
-    // https://github.com/salesforce/tough-cookie/issues/149
-    // const ret = toughCookie.parse(cookie).serializeSync();
+  return str.split(';').reduce((acc, cookieStr) => {
+    const cookie = jar.setCookieSync(cookieStr.trim(), url)
+    if (!cookie) return acc
+    const parsedCookie = cookie.toJSON()
 
     parsedCookie.name = parsedCookie.key
     delete parsedCookie.key
@@ -50,6 +48,7 @@ const parseCookies = (url, str) =>
     acc.push(parsedCookie)
     return acc
   }, [])
+}
 
 const getMediaFeatures = ({ animations, colorScheme }) => {
   const prefers = []

--- a/packages/goto/test/unit/headers/parse-cookies.js
+++ b/packages/goto/test/unit/headers/parse-cookies.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { spawnSync } = require('child_process')
 const test = require('ava')
 
 const { parseCookies } = require('../../../src')
@@ -35,4 +36,38 @@ test('works fine with subdomains', t => {
   const cookies = parseCookies(url, cookiesStr)
 
   t.true(cookies.every(cookie => cookie.domain === 'this.is.an.example.com'))
+})
+
+test('creates one cookie jar per cookie header', t => {
+  const parseCookiesPath = require.resolve('../../../src')
+  const script = `
+    const Module = require('module')
+    const originalLoad = Module._load
+    let cookieJarCount = 0
+
+    Module._load = function (request, parent, isMain) {
+      if (request === 'tough-cookie') {
+        const mod = originalLoad(request, parent, isMain)
+        class CookieJar extends mod.CookieJar {
+          constructor (...args) {
+            super(...args)
+            cookieJarCount += 1
+          }
+        }
+        return { ...mod, CookieJar }
+      }
+      return originalLoad(request, parent, isMain)
+    }
+
+    const { parseCookies } = require(${JSON.stringify(parseCookiesPath)})
+    parseCookies('https://example.com', 'foo=bar;hello=world;one=more')
+    process.stdout.write(String(cookieJarCount))
+  `
+
+  const { status, stdout, stderr } = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8'
+  })
+
+  t.is(status, 0, stderr)
+  t.is(stdout.trim(), '1')
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to cookie parsing that mainly affects performance and cookie-header edge cases; behavior changes are covered by a new unit test.
> 
> **Overview**
> `parseCookies` now reuses a single `tough-cookie` `CookieJar` per cookie header and parses cookies via the returned cookie object (`toJSON()`), skipping entries that fail to set.
> 
> Adds a unit test that monkeypatches `tough-cookie` to assert only one `CookieJar` is constructed during parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e7bedf8aa5b33d835d0b2a898ded916d633d2ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->