### PR TITLE
perf(browserless): retry only transient context reset errors

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -148,9 +148,9 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
               debug('onFailedAttempt', { name: error.name, code: error.code, isRejected })
               if (error.name === 'AbortError') throw error
               if (isRejected || isDestroyedForced) throw new AbortError()
-              if (error.code === 'EBRWSRCONTEXTCONNRESET') {
-                _contextPromise = createBrowserContext(contextOpts)
-              }
+              const isRetryable = error.code === 'EBRWSRCONTEXTCONNRESET'
+              if (!isRetryable) throw error
+              _contextPromise = createBrowserContext(contextOpts)
               const { message, attemptNumber, retriesLeft } = error
               debug('retry', { attemptNumber, retriesLeft, message })
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: narrows retry behavior to a single known transient error code and adds targeted tests; main risk is reduced resiliency if other errors were previously (incorrectly) being masked by retries.
> 
> **Overview**
> `withPage` now **retries only when the failure is a transient browser-context connection reset** (`EBRWSRCONTEXTCONNRESET`), and immediately rethrows any other error instead of recreating the context and retrying.
> 
> Adds test coverage to ensure **non-transient errors are not retried** and that **transient context disconnections do retry and recover**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8418da362603a4945d6b966c21823df8b0c88ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->