### PR TITLE
perf(goto): use set lookup for abort resource types

### DIFF
--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -225,6 +225,8 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       )
     }
 
+    const abortTypesSet = abortTypes.length > 0 ? new Set(abortTypes) : null
+
     const enableInterception =
       (onPageRequest || abortTypes.length > 0) &&
       run({
@@ -245,7 +247,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
           const resourceType = req.resourceType()
           const url = truncate(req.url())
 
-          if (!abortTypes.includes(resourceType)) {
+          if (!abortTypesSet.has(resourceType)) {
             debug.continue({ url, resourceType })
             return req.continue(
               req.continueRequestOverrides(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small performance-oriented change in request interception logic plus a focused regression test; behavior should be equivalent but could affect resource-type abort matching if misapplied.
> 
> **Overview**
> Switches `abortTypes` matching in `packages/goto` request interception from `Array.includes` to a precomputed `Set` (`abortTypesSet`) for faster lookups.
> 
> Adds an AVA regression test that passes duplicated `abortTypes` values and asserts request interception still behaves as expected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48b6cb76b657b49fd4be25b1dffe157240a0fe83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->