### PR TITLE
perf(screencast): clean cdp frame listeners on stop

### DIFF
--- a/packages/screencast/test/index.js
+++ b/packages/screencast/test/index.js
@@ -31,3 +31,35 @@ test('capture frames', async t => {
     t.truthy(metadata.timestamp)
   })
 })
+
+test('clean up cdp frame listeners across screencast sessions', async t => {
+  const browserless = await getBrowserContext(t)
+  const page = await browserless.page()
+  const cdp = page._client()
+
+  const countListeners = () => cdp.listenerCount('Page.screencastFrame')
+
+  const screencastA = createScreencast(page, {
+    quality: 0,
+    format: 'png',
+    everyNthFrame: 1
+  })
+
+  t.is(countListeners(), 0)
+
+  await screencastA.start()
+  t.is(countListeners(), 1)
+  await screencastA.stop()
+  t.is(countListeners(), 0)
+
+  const screencastB = createScreencast(page, {
+    quality: 0,
+    format: 'png',
+    everyNthFrame: 1
+  })
+
+  await screencastB.start()
+  t.is(countListeners(), 1)
+  await screencastB.stop()
+  t.is(countListeners(), 0)
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only changes screencast event listener lifecycle to prevent leaking `Page.screencastFrame` handlers across sessions, plus adds a test to assert listener counts.
> 
> **Overview**
> Ensures `Page.screencastFrame` listeners are **attached on `start()` and removed on `stop()`** (with guards to avoid double attach/detach), preventing lingering CDP listeners when multiple screencast sessions run on the same page.
> 
> Adds an AVA test that starts/stops two screencasts and asserts `cdp.listenerCount('Page.screencastFrame')` returns to zero after each stop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0313c81ff647cbd9618136b343294bd8a724ff2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->