### PR TITLE
perf(goto): fast-path cookie header parsing

### DIFF
--- a/packages/goto/test/unit/headers/parse-cookies.js
+++ b/packages/goto/test/unit/headers/parse-cookies.js
@@ -38,7 +38,7 @@ test('works fine with subdomains', t => {
   t.true(cookies.every(cookie => cookie.domain === 'this.is.an.example.com'))
 })
 
-test('creates one cookie jar per cookie header', t => {
+test('skips cookie jar allocations in the fast-path', t => {
   const parseCookiesPath = require.resolve('../../../src')
   const script = `
     const Module = require('module')
@@ -69,5 +69,49 @@ test('creates one cookie jar per cookie header', t => {
   })
 
   t.is(status, 0, stderr)
+  t.is(stdout.trim(), '0')
+})
+
+test('falls back to tough-cookie for invalid tokens', t => {
+  const parseCookiesPath = require.resolve('../../../src')
+  const script = `
+    const Module = require('module')
+    const originalLoad = Module._load
+    let cookieJarCount = 0
+
+    Module._load = function (request, parent, isMain) {
+      if (request === 'tough-cookie') {
+        const mod = originalLoad(request, parent, isMain)
+        class CookieJar extends mod.CookieJar {
+          constructor (...args) {
+            super(...args)
+            cookieJarCount += 1
+          }
+        }
+        return { ...mod, CookieJar }
+      }
+      return originalLoad(request, parent, isMain)
+    }
+
+    const { parseCookies } = require(${JSON.stringify(parseCookiesPath)})
+
+    try {
+      parseCookies('https://example.com', 'foo=bar;')
+    } catch {}
+
+    process.stdout.write(String(cookieJarCount))
+  `
+
+  const { status, stdout, stderr } = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8'
+  })
+
+  t.is(status, 0, stderr)
   t.is(stdout.trim(), '1')
+})
+
+test('preserves default cookie path resolution', t => {
+  const cookies = parseCookies('https://example.com/foo/bar', 'foo=bar;hello=world')
+
+  t.true(cookies.every(cookie => cookie.path === '/foo'))
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cookie parsing logic used to set page cookies; subtle edge cases (invalid headers, URL/path handling) could affect request authentication/state despite a conservative fallback to `tough-cookie`.
> 
> **Overview**
> Optimizes `parseCookies` by adding a fast-path that parses simple `Cookie` headers without allocating a `tough-cookie` `CookieJar`, while preserving domain/path derivation via a new `getDefaultPath` helper.
> 
> Adds a `parseCookiesWithJar` fallback for invalid URLs or malformed cookie tokens, and expands unit tests to assert both the allocation-free fast-path behavior and the fallback/default-path semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60435bee4a9257cd8dd2ad23b0829b8c0d9e8c5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->