### PR TITLE
perf(function): avoid parsing code AST twice

### DIFF
--- a/packages/function/src/function.js
+++ b/packages/function/src/function.js
@@ -8,7 +8,7 @@ const [nodeMajor] = process.version.slice(1).split('.').map(Number)
 module.exports = async ({ url, code, vmOpts, browserWSEndpoint, ...opts }) => {
   const needsNetwork = template.isUsingPage(code)
   const permissions = needsNetwork && nodeMajor >= 25 ? ['net'] : []
-  const [fn, teardown] = isolatedFunction(template(code), {
+  const [fn, teardown] = isolatedFunction(template(code, needsNetwork), {
     ...vmOpts,
     allow: { permissions },
     throwError: false

--- a/packages/function/src/template.js
+++ b/packages/function/src/template.js
@@ -29,8 +29,8 @@ const isUsingPage = code => {
   return result
 }
 
-const template = code => {
-  if (!isUsingPage(code)) return `async (url, _, opts) => (${code})(opts)`
+const template = (code, usesPage = isUsingPage(code)) => {
+  if (!usesPage) return `async (url, _, opts) => (${code})(opts)`
   return `
     async (url, browserWSEndpoint, opts) => {
       const puppeteer = require('@cloudflare/puppeteer')

--- a/packages/function/test/template.js
+++ b/packages/function/test/template.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { spawnSync } = require('child_process')
 const test = require('ava')
 
 const template = require('../src/template')
@@ -50,4 +51,40 @@ test('require puppeteer if page is used', t => {
     const code = obj => obj.page.title()
     t.is(template(code.toString()).includes('puppeteer'), true)
   }
+})
+
+test('reuse page usage analysis to avoid parsing code twice', t => {
+  const templatePath = require.resolve('../src/template')
+  const script = `
+    const Module = require('module')
+    const originalLoad = Module._load
+    let parseCalls = 0
+
+    Module._load = function (request, parent, isMain) {
+      if (request === 'acorn') {
+        const acorn = originalLoad(request, parent, isMain)
+        return {
+          ...acorn,
+          parse (...args) {
+            parseCalls += 1
+            return acorn.parse(...args)
+          }
+        }
+      }
+      return originalLoad(request, parent, isMain)
+    }
+
+    const template = require(${JSON.stringify(templatePath)})
+    const code = '({ page }) => page.title()'
+    const usesPage = template.isUsingPage(code)
+    template(code, usesPage)
+    process.stdout.write(String(parseCalls))
+  `
+
+  const { status, stdout, stderr } = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8'
+  })
+
+  t.is(status, 0, stderr)
+  t.is(stdout.trim(), '1')
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk perf-only change that reuses the existing `isUsingPage` result to skip a redundant `acorn.parse`; behavior should be unchanged aside from how `template()` is invoked.
> 
> **Overview**
> Avoids parsing the user `code` AST twice when building an isolated function.
> 
> `template()` now accepts an optional precomputed `usesPage` flag (defaulting to its own analysis), and `function.js` passes the `needsNetwork` result into `template()` so page/network detection is reused. Adds a regression test that monkeypatches `acorn.parse` to assert it is called only once.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10548e4ea7b94c3a72b50db2c1a83147b7a19fbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->