### PR TITLE
perf(function): reuse browser websocket endpoint lookup

### DIFF
--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -31,7 +31,7 @@ module.exports =
         const result = await runFunction({
           url,
           code: stringify(fn),
-          browserWSEndpoint: (await browserless.browser()).wsEndpoint(),
+          browserWSEndpoint,
           device,
           ...opts,
           ...fnOpts


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk perf refactor: it only changes how the browser WebSocket endpoint is retrieved/cached within a single invocation, plus adds a regression test to prevent extra `browser()` calls.
> 
> **Overview**
> Avoids calling `browserless.browser().wsEndpoint()` twice during a function invocation by caching the WebSocket endpoint in a local variable and reusing it for `runFunction`.
> 
> Adds a test ensuring the endpoint lookup (and underlying `browser()` call) happens only once per invocation, while preserving the existing error when no WS endpoint is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36a683668a2b1047a75701f20021771fa609fb87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->