### PR TITLE
perf(function): cache code analysis across calls

### DIFF
--- a/packages/function/src/function.js
+++ b/packages/function/src/function.js
@@ -5,8 +5,14 @@ const template = require('./template')
 
 const [nodeMajor] = process.version.slice(1).split('.').map(Number)
 
-module.exports = async ({ url, code, vmOpts, browserWSEndpoint, ...opts }) => {
-  const needsNetwork = template.isUsingPage(code)
+module.exports = async ({
+  url,
+  code,
+  vmOpts,
+  browserWSEndpoint,
+  needsNetwork = template.isUsingPage(code),
+  ...opts
+}) => {
   const permissions = needsNetwork && nodeMajor >= 25 ? ['net'] : []
   const [fn, teardown] = isolatedFunction(template(code, needsNetwork), {
     ...vmOpts,
@@ -17,3 +23,5 @@ module.exports = async ({ url, code, vmOpts, browserWSEndpoint, ...opts }) => {
   await teardown()
   return result
 }
+
+module.exports.isUsingPage = template.isUsingPage


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: behavior is largely unchanged, but `needsNetwork` detection is now cached per created wrapper function and could be wrong if callers override `code` dynamically, affecting Node 25+ net permissions.
> 
> **Overview**
> Caches the per-function `isUsingPage`/network-needs analysis so it’s computed once when creating a `browserlessFunction` wrapper, then reused across invocations to avoid repeated parsing.
> 
> `runFunction` now accepts an explicit `needsNetwork` override (defaulting to analysis when omitted) and re-exports `isUsingPage` for callers; a new test asserts the analysis runs only once across two calls by instrumenting `acorn.parse`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe9abf817b69d6c868f5e4614e047af0a4bf385b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->