### PR TITLE
perf(function): cache browserless factory result per function

### DIFF
--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -18,10 +18,20 @@ module.exports = (
 ) => {
   const code = stringify(fn)
   const needsNetwork = runFunction.isUsingPage(code)
+  let browserPromise
+
+  const getBrowser = async () => {
+    if (!browserPromise) {
+      browserPromise = Promise.resolve(getBrowserless()).catch(error => {
+        browserPromise = undefined
+        throw error
+      })
+    }
+    return browserPromise
+  }
 
   return async (url, fnOpts = {}) => {
-    const browserlessPromise = getBrowserless()
-    const browser = await browserlessPromise
+    const browser = await getBrowser()
     const browserless = await browser.createContext()
 
     return browserless.withPage((page, goto) => async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `getBrowserless()` is invoked by caching and reusing the created browser instance across invocations, which can impact resource lifecycle and concurrency behavior. Adds retry-on-next-call behavior after creation failures, altering error/recovery semantics.
> 
> **Overview**
> **Caches the Browserless factory result per exported function** by memoizing the `getBrowserless()` promise and reusing it across subsequent invocations, while still creating a new context (`createContext()`) each call.
> 
> If initial browser creation fails, the cached promise is cleared so the next invocation retries `getBrowserless()` instead of permanently reusing a failed promise. Tests are updated to assert browser reuse and retry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 350cd5a47e654b13edb08a738c93dbb9538cc620. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->