### PR TITLE
perf(function): reuse prebuilt sandbox template source

### DIFF
--- a/packages/function/src/function.js
+++ b/packages/function/src/function.js
@@ -11,10 +11,11 @@ module.exports = async ({
   vmOpts,
   browserWSEndpoint,
   needsNetwork = template.isUsingPage(code),
+  source = template(code, needsNetwork),
   ...opts
 }) => {
   const permissions = needsNetwork && nodeMajor >= 25 ? ['net'] : []
-  const [fn, teardown] = isolatedFunction(template(code, needsNetwork), {
+  const [fn, teardown] = isolatedFunction(source, {
     ...vmOpts,
     allow: { permissions },
     throwError: false
@@ -25,3 +26,4 @@ module.exports = async ({
 }
 
 module.exports.isUsingPage = template.isUsingPage
+module.exports.buildTemplate = template

--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -18,6 +18,7 @@ module.exports = (
 ) => {
   const code = stringify(fn)
   const needsNetwork = runFunction.isUsingPage(code)
+  const source = runFunction.buildTemplate(code, needsNetwork)
   let browserPromise
 
   const getBrowser = async () => {
@@ -51,6 +52,7 @@ module.exports = (
 
       if (runFunctionOpts.code === code) {
         runFunctionOpts.needsNetwork = needsNetwork
+        runFunctionOpts.source = source
       }
 
       const result = await runFunction(runFunctionOpts)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: primarily a performance optimization that reuses precomputed sandbox source; behavior should be unchanged aside from allowing callers to supply a `source` string, which could affect execution if misused.
> 
> **Overview**
> Prebuilds the sandbox `template` source once per `browserlessFunction` instance and passes it into `runFunction`, instead of regenerating the template string on every invocation.
> 
> `runFunction` now accepts an optional `source` (defaulting to `template(code, needsNetwork)`) and exports `buildTemplate` for callers/tests; a new test asserts the template builder and its `isUsingPage` parsing run only once across repeated calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88502e7b1f2c02bd49626a1f1734690cb13b58d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->