### PR TITLE
perf(function): skip ws endpoint lookup for non-page code

### DIFF
--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -38,13 +38,9 @@ module.exports = (
     return browserless.withPage((page, goto) => async () => {
       const { device } = await goto(page, { url, timeout, ...gotoOpts })
 
-      const browserWSEndpoint = (await browserless.browser()).wsEndpoint()
-      if (!browserWSEndpoint) throw new Error('Browser WebSocket endpoint not found')
-
       const runFunctionOpts = {
         url,
         code,
-        browserWSEndpoint,
         device,
         ...opts,
         ...fnOpts
@@ -53,6 +49,12 @@ module.exports = (
       if (runFunctionOpts.code === code) {
         runFunctionOpts.needsNetwork = needsNetwork
         runFunctionOpts.source = source
+      }
+
+      if (runFunctionOpts.needsNetwork !== false) {
+        const browserWSEndpoint = (await browserless.browser()).wsEndpoint()
+        if (!browserWSEndpoint) throw new Error('Browser WebSocket endpoint not found')
+        runFunctionOpts.browserWSEndpoint = browserWSEndpoint
       }
 
       const result = await runFunction(runFunctionOpts)

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -283,7 +283,7 @@ test('throws error when browser is launched with pipe mode', async t => {
   t.is(error.message, 'Browser WebSocket endpoint not found')
 })
 
-test('retrieve browser websocket endpoint once per invocation', async t => {
+test('skip browser websocket endpoint lookup for non-page functions', async t => {
   let browserCalls = 0
 
   const fakeBrowserless = {
@@ -305,7 +305,7 @@ test('retrieve browser websocket endpoint once per invocation', async t => {
 
   t.true(result.isFulfilled)
   t.is(result.value, 'ok')
-  t.is(browserCalls, 1)
+  t.is(browserCalls, 0)
 })
 test('reuse function code analysis across invocations', t => {
   const browserlessFunctionPath = require.resolve('..')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk perf/behavior tweak that only changes when `browserWSEndpoint` is fetched/passed; main risk is any downstream code that implicitly depended on this lookup side effect for non-`page` functions.
> 
> **Overview**
> Avoids fetching/validating the browser WebSocket endpoint on each invocation when the function does not require page/network access (`needsNetwork === false`), and only adds `browserWSEndpoint` to `runFunction` options when needed.
> 
> Updates tests to assert the WS endpoint is **not** looked up for non-page functions while preserving the existing error behavior when an endpoint is required but unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1cab8843d1da892ec6b5bdb23cd0d1af9f1c616. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->