### PR TITLE
perf(browserless): avoid browser lookup on createPage

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -80,15 +80,13 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
 
     const createPage = async name => {
       const duration = debug.duration('createPage')
-      const [browserProcess, browserContext] = await Promise.all([
-        getBrowser(),
-        getBrowserContext()
-      ])
+      const browserContext = await getBrowserContext()
       const page = await browserContext.newPage()
+      const browser = typeof page.browser === 'function' ? page.browser() : undefined
       const metadata = {
         id: page._client().id(),
         contextId: browserContext.id,
-        browserPid: driver.pid(browserProcess)
+        browserPid: browser ? driver.pid(browser) : undefined
       }
       pageMetadata.set(page, metadata)
       duration({ name, ...metadata })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Touches the core `createPage` path, but behavior change is limited to how PID metadata is gathered/logged and is guarded for missing `page.browser()`; adds coverage to prevent unintended respawns.
> 
> **Overview**
> Avoids calling `getBrowser()` during `createPage` just to log metadata, preventing a disconnected browser from being respawned as a side effect of page creation.
> 
> `browserPid` is now derived from `page.browser()` when available (otherwise left `undefined`), and a new test asserts that `withPage` page creation does not trigger a respawn when the underlying browser connection has dropped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4b6589c81681a816db4c23c7e443d6fe8830b60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->