### PR TITLE
perf(goto): avoid args spread in device lookup

### DIFF
--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -361,7 +361,11 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       )
     }
 
-    const device = getDevice({ headers, ...args, device: args.device ?? defaultDevice })
+    const device = getDevice({
+      headers,
+      device: args.device ?? defaultDevice,
+      viewport: args.viewport
+    })
 
     if (device.userAgent && !headers['user-agent']) {
       headers['user-agent'] = device.userAgent


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk performance refactor that narrows the `getDevice` call to explicit inputs; behavior should be unchanged unless `getDevice` previously relied on other properties inside `...args`.
> 
> **Overview**
> Avoids spreading the full `...args` object into the device resolution call in `packages/goto/src/index.js`.
> 
> `getDevice` is now invoked with only `headers`, the resolved `device` name, and an explicit `viewport`, reducing unnecessary object work during navigation setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdbb968f3b20e61cae2d77ac62ef19849656e22e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->