### PR TITLE
perf(goto): avoid Object.entries in wait checks

### DIFF
--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -466,13 +466,20 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
         })
       }
 
-      for (const [key, value] of Object.entries({
-        waitForSelector,
-        waitForFunction
-      })) {
-        if (value) {
-          await run({ fn: page[key](value), timeout: gotoTimeout, debug: { [key]: value } })
-        }
+      if (waitForSelector) {
+        await run({
+          fn: page.waitForSelector(waitForSelector),
+          timeout: gotoTimeout,
+          debug: { waitForSelector }
+        })
+      }
+
+      if (waitForFunction) {
+        await run({
+          fn: page.waitForFunction(waitForFunction),
+          timeout: gotoTimeout,
+          debug: { waitForFunction }
+        })
       }
 
       if (waitForTimeout) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small refactor of navigation wait logic plus a new test; behavior should be equivalent aside from ensuring both waits execute when provided.
> 
> **Overview**
> Simplifies `goto`'s post-navigation wait logic by replacing the `Object.entries` loop with explicit `if (waitForSelector)` / `if (waitForFunction)` blocks, ensuring both waits can run in the same navigation.
> 
> Adds an integration test verifying `waitForSelector` and `waitForFunction` work together on a page that becomes ready asynchronously.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f94184523269ab9736981fa2aa2eef6840c9c54a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->