### PR TITLE
fix: handle EINVALCLIP

### DIFF
--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -40,6 +40,11 @@ browserlessError.evaluationFailed = createBrowserlessError({
   message: 'Evaluation failed'
 })
 
+browserlessError.invalidClip = createBrowserlessError({
+  code: 'EINVALCLIP',
+  message: 'The `clip` must be an object with numeric x, y, width and height.'
+})
+
 browserlessError.contextDisconnected = createBrowserlessError({
   code: 'EBRWSRCONTEXTCONNRESET',
   message: 'The browser context is not connected.'

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -92,6 +92,15 @@ test('evaluationFailed', t => {
   }
 })
 
+test('invalidClip', t => {
+  const error = errors.invalidClip()
+
+  t.true(error instanceof Error)
+  t.is(error.name, 'BrowserlessError')
+  t.is(error.code, 'EINVALCLIP')
+  t.is(error.message, 'EINVALCLIP, The `clip` must be an object with numeric x, y, width and height.')
+})
+
 test('ensureError handles non-object input', t => {
   const errorFromString = errors.ensureError('boom')
   t.true(errorFromString instanceof Error)

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -32,6 +32,7 @@
     "web-capture"
   ],
   "dependencies": {
+    "@browserless/errors": "^10.12.6",
     "@browserless/goto": "^10.12.7",
     "@kikobeats/content-type": "~1.0.4",
     "@kikobeats/time-span": "~1.0.12",

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -2,6 +2,7 @@
 
 const debug = require('debug-logfmt')('browserless:screenshot')
 const createGoto = require('@browserless/goto')
+const { invalidClip } = require('@browserless/errors')
 const pReflect = require('p-reflect')
 
 const isWhiteScreenshot = require('./is-white-screenshot')
@@ -13,6 +14,28 @@ const { waitForDomStability, resolveWaitForDom, DEFAULT_WAIT_FOR_DOM } = require
 const createElapsed = () => {
   const start = Date.now()
   return () => Date.now() - start
+}
+
+const toFiniteNumber = value => {
+  const number = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+  return Number.isFinite(number) ? number : undefined
+}
+
+const normalizeClip = clip => {
+  if (clip === undefined) return undefined
+  if (typeof clip !== 'object' || clip === null) throw invalidClip()
+
+  const x = toFiniteNumber(clip.x)
+  const y = toFiniteNumber(clip.y)
+  const width = toFiniteNumber(clip.width)
+  const height = toFiniteNumber(clip.height)
+
+  if (x === undefined || x < 0) throw invalidClip()
+  if (y === undefined || y < 0) throw invalidClip()
+  if (width === undefined || width <= 0) throw invalidClip()
+  if (height === undefined || height <= 0) throw invalidClip()
+
+  return { ...clip, x, y, width, height }
 }
 
 const getPageSnapshot = page =>
@@ -210,7 +233,8 @@ module.exports = ({ goto, ...gotoOpts }) => {
         if (waitUntil !== 'auto') {
           ;({ response } = await goto(page, { ...opts, url, waitUntil }))
           const screenshotOpts = await beforeScreenshot(page, response, opts)
-          screenshot = await page.screenshot({ ...opts, ...screenshotOpts })
+          const screenshotParams = { ...opts, ...screenshotOpts, clip: normalizeClip(screenshotOpts.clip ?? opts.clip) }
+          screenshot = await page.screenshot(screenshotParams)
           debug('screenshot', { waitUntil, duration: timeScreenshot() })
         } else {
           ;({ response } = await goto(page, { ...opts, url, waitUntil, waitUntilAuto }))
@@ -219,6 +243,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
             const { isWhite, isReady, retry } = await takeScreenshot({
               ...opts,
               ...screenshotOpts,
+              clip: normalizeClip(screenshotOpts.clip ?? opts.clip),
               isPageReady,
               response
             })

--- a/packages/screenshot/test/index.js
+++ b/packages/screenshot/test/index.js
@@ -96,3 +96,20 @@ test('dialog listener is cleaned up between screenshot calls on same page', asyn
   t.is(listenersAfterFirst, listenersBefore)
   t.is(listenersAfterSecond, listenersBefore)
 })
+
+test('invalid clip throws EINVALCLIP', async t => {
+  const browserless = await getBrowserContext(t)
+
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end('<html><body><h1>ok</h1></body></html>')
+  })
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const screenshot = createScreenshot({ goto })(page)
+    await screenshot(url, { waitUntil: 'load', adblock: false, timeout: 2000, clip: true })
+  })
+
+  const error = await t.throwsAsync(run())
+  t.is(error.code, 'EINVALCLIP')
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized input-validation change to screenshot parameters that mainly affects callers passing invalid `clip` values; no auth/security or persistence changes.
> 
> **Overview**
> Adds a new `@browserless/errors` `invalidClip` (`EINVALCLIP`) error and associated tests.
> 
> Updates `@browserless/screenshot` to depend on `@browserless/errors` and to validate/normalize the `clip` screenshot option (including coercing numeric strings), throwing `EINVALCLIP` for invalid shapes/values; adds a regression test ensuring invalid `clip` input fails with that code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d053c37c8ad503e6579b798a83d721dc0dc7ab89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->