### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ You can configure the overlay by specifying the following:
 - **background**: Specifies the background to use. A number of value types are supported:
   - Hexadecimal/RGB/RGBA color codes, eg. `#c1c1c1`.
   - [CSS gradients](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient), eg. `linear-gradient(225deg, #FF057C 0%, #8D0B93 50%, #321575 100%)`
-  - Image URLs, eg. `https://source.unsplash.com/random/1920x1080`.
+  - Image URLs, eg. `https://picsum.photos/1920/1080`.
 
 ```js
 const buffer = await browserless.screenshot(url.toString(), {


### PR DESCRIPTION
`README.md` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` (and the related `source.unsplash.com/featured`) was deprecated by Unsplash in mid-2024 and the endpoint now returns HTTP 503 instead of an image. Browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600?office | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Updates the README's background-image examples list so the `Image URLs` option documents a working URL example for the browserless API.

#### Replacement details

Docs-only. The README enumerates accepted inputs for a background-image parameter (hex codes, CSS gradients, Image URLs). The Image URLs example currently references a 503 endpoint, which is confusing when users test the feature with the documented URL.

#### Background

I'm tracking the deprecated `source.unsplash.com/random` endpoint across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. But if you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights this same broken-URL pattern in any landing page — useful for verifying the fix lands and for finding other places `source.unsplash.com/random` slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
