### PR TITLE
fix(function): getTargetId

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
   },
   "nano-staged": {
     "*.js": [
-      "npx -y @kikobeats/prettier-standard",
+      "npx @kikobeats/prettier-standard",
       "standard --fix"
     ],
     "package.json": [

--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -6,6 +6,17 @@ const runFunction = require('./function')
 
 const stringify = fn => fn.toString().trim().replace(/;$/, '')
 
+const getTargetId = async page => {
+  try {
+    const session = await page.createCDPSession()
+    const { targetInfo } = await session.send('Target.getTargetInfo')
+    await session.detach()
+    return targetInfo.targetId
+  } catch {
+    return undefined
+  }
+}
+
 const serializeResponse = response => ({
   status: response.status(),
   statusText: response.statusText(),
@@ -50,6 +61,8 @@ module.exports = (
     return browserless.withPage((page, goto) => async () => {
       const { device, response } = await goto(page, { url, timeout, ...gotoOpts })
 
+      const targetId = await getTargetId(page)
+
       const runFunctionOpts = {
         url,
         code,
@@ -73,6 +86,7 @@ module.exports = (
 
         if (!browserWSEndpoint) throw new Error('Browser WebSocket endpoint not found')
         runFunctionOpts.browserWSEndpoint = browserWSEndpoint
+        runFunctionOpts.targetId = targetId
       }
 
       const result = await runFunction(runFunctionOpts)

--- a/packages/function/src/template.js
+++ b/packages/function/src/template.js
@@ -50,7 +50,19 @@ const template = (code, usesPage = isUsingPage(code)) => {
       const puppeteer = require('@cloudflare/puppeteer')
       const browser = await puppeteer.connect({ browserWSEndpoint })
       const pages = await browser.pages()
-      const page = pages[pages.length - 1]
+      const { targetId } = opts
+      let page
+      if (targetId && pages.length > 1) {
+        for (const p of pages) {
+          try {
+            const session = await p.createCDPSession()
+            const { targetInfo } = await session.send('Target.getTargetInfo')
+            await session.detach()
+            if (targetInfo.targetId === targetId) { page = p; break }
+          } catch {}
+        }
+      }
+      if (!page) page = pages[pages.length - 1]
       try {
         return await (${code})({ page, response, ...rest })
       } finally {

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -711,3 +711,27 @@ test('retry getBrowserless on next call when initial creation fails', async t =>
   t.true(second.isFulfilled)
   t.is(getBrowserlessCalls, 2)
 })
+
+test('concurrent page functions return the correct page for each request', async t => {
+  const { runServer } = require('@browserless/test/create')({ timeout: 120000 })
+
+  const CONCURRENCY = 5
+
+  const urls = await Promise.all(
+    Array.from({ length: CONCURRENCY }, (_, i) =>
+      runServer(t, ({ res }) => {
+        res.setHeader('content-type', 'text/html')
+        res.end(`<html><head><title>page-${i}</title></head><body>page-${i}</body></html>`)
+      })
+    )
+  )
+
+  const fns = urls.map(url => browserlessFunction(({ page }) => page.url(), opts))
+
+  const results = await Promise.all(fns.map((fn, i) => fn(urls[i])))
+
+  for (let i = 0; i < CONCURRENCY; i++) {
+    t.true(results[i].isFulfilled, `request ${i} should succeed`)
+    t.is(results[i].value, urls[i], `request ${i} should return its own URL`)
+  }
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how page-based functions pick the Puppeteer `page` by adding CDP `targetId` plumbing, which can affect runtime behavior under load and across different Puppeteer/Chrome versions. Includes a new concurrency test that should catch regressions but still warrants review in real deployments.
> 
> **Overview**
> Fixes a concurrency bug where page-based functions could run against the wrong Puppeteer `page` when multiple pages exist.
> 
> The wrapper now captures the current page’s CDP `targetId` and passes it into the isolated function; the generated template uses that `targetId` to find the matching page after `puppeteer.connect`, falling back to the last page if unavailable. Adds a test asserting concurrent requests each receive their own page, and tweaks `nano-staged` to run `prettier-standard` without `npx -y`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56abbf2bd0d11accee33ed43212178fedb2d4f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->