### PR TITLE
fix(errors): classify session/frame errors as context disconnected

### DIFF
--- a/packages/browserless/test/index.js
+++ b/packages/browserless/test/index.js
@@ -454,6 +454,130 @@ test('withPage retries transient context disconnections', async t => {
   t.is(attempts, 2)
 })
 
+test('withPage retries on "Session closed" error', async t => {
+  const browserlessFactory = require('..')
+  const { driver } = browserlessFactory
+
+  const originalSpawn = driver.spawn
+  const originalClose = driver.close
+  let pid = 4100
+
+  driver.spawn = () => {
+    let isClosed = false
+
+    const page = {
+      _client: () => ({ id: () => 'page-id' }),
+      close: () => Promise.resolve().then(() => (isClosed = true)),
+      isClosed: () => isClosed
+    }
+
+    const browserContext = {
+      id: `ctx-${pid}`,
+      close: () => Promise.resolve(),
+      newPage: () => Promise.resolve(page)
+    }
+
+    return Promise.resolve({
+      process: () => ({ pid: ++pid }),
+      isConnected: () => true,
+      once: () => {},
+      version: () => Promise.resolve('mock'),
+      createBrowserContext: () => Promise.resolve(browserContext),
+      close: () => Promise.resolve(),
+      disconnect: () => Promise.resolve()
+    })
+  }
+
+  driver.close = subprocess => Promise.resolve(subprocess.close && subprocess.close())
+
+  t.teardown(() => {
+    driver.spawn = originalSpawn
+    driver.close = originalClose
+  })
+
+  const browser = browserlessFactory({ timeout: 3000 })
+  t.teardown(browser.close)
+  const browserless = await browser.createContext({ retry: 1 })
+
+  let attempts = 0
+  const evaluate = browserless.withPage(
+    () => async () => {
+      attempts += 1
+      if (attempts === 1) throw new Error('Session closed. Most likely the page has been closed.')
+      return 'recovered'
+    },
+    { timeout: 3000 }
+  )
+
+  const result = await evaluate()
+
+  t.is(result, 'recovered')
+  t.is(attempts, 2)
+})
+
+test('withPage retries on "Attempted to use detached Frame" error', async t => {
+  const browserlessFactory = require('..')
+  const { driver } = browserlessFactory
+
+  const originalSpawn = driver.spawn
+  const originalClose = driver.close
+  let pid = 4200
+
+  driver.spawn = () => {
+    let isClosed = false
+
+    const page = {
+      _client: () => ({ id: () => 'page-id' }),
+      close: () => Promise.resolve().then(() => (isClosed = true)),
+      isClosed: () => isClosed
+    }
+
+    const browserContext = {
+      id: `ctx-${pid}`,
+      close: () => Promise.resolve(),
+      newPage: () => Promise.resolve(page)
+    }
+
+    return Promise.resolve({
+      process: () => ({ pid: ++pid }),
+      isConnected: () => true,
+      once: () => {},
+      version: () => Promise.resolve('mock'),
+      createBrowserContext: () => Promise.resolve(browserContext),
+      close: () => Promise.resolve(),
+      disconnect: () => Promise.resolve()
+    })
+  }
+
+  driver.close = subprocess => Promise.resolve(subprocess.close && subprocess.close())
+
+  t.teardown(() => {
+    driver.spawn = originalSpawn
+    driver.close = originalClose
+  })
+
+  const browser = browserlessFactory({ timeout: 3000 })
+  t.teardown(browser.close)
+  const browserless = await browser.createContext({ retry: 1 })
+
+  let attempts = 0
+  const evaluate = browserless.withPage(
+    () => async () => {
+      attempts += 1
+      if (attempts === 1) {
+        throw new Error("Attempted to use detached Frame 'BF1FB34FC20107D5D21C354065F61277'.")
+      }
+      return 'recovered'
+    },
+    { timeout: 3000 }
+  )
+
+  const result = await evaluate()
+
+  t.is(result, 'recovered')
+  t.is(attempts, 2)
+})
+
 test('withPage close does not respawn browser for metadata logging', async t => {
   const browserlessFactory = require('..')
   const { driver } = browserlessFactory

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -59,7 +59,9 @@ browserlessError.ensureError = rawError => {
       'Protocol error (Target.createTarget): Failed to find browser context with id',
       'Protocol error (Target.createTarget): Target closed',
       'Protocol error (Target.createBrowserContext): Target closed'
-    ].some(message => errorMessage.startsWith(message))
+    ].some(message => errorMessage.startsWith(message)) ||
+    errorMessage.includes('Session closed') ||
+    errorMessage.includes('Attempted to use detached Frame')
   ) {
     return browserlessError.contextDisconnected()
   }

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -92,6 +92,26 @@ test('evaluationFailed', t => {
   }
 })
 
+test('contextDisconnected from "Session closed"', t => {
+  const error = errors.ensureError({
+    message: 'Session closed. Most likely the page has been closed.'
+  })
+
+  t.true(error instanceof Error)
+  t.is(error.name, 'BrowserlessError')
+  t.is(error.code, 'EBRWSRCONTEXTCONNRESET')
+})
+
+test('contextDisconnected from "Attempted to use detached Frame"', t => {
+  const error = errors.ensureError({
+    message: "Attempted to use detached Frame 'BF1FB34FC20107D5D21C354065F61277'."
+  })
+
+  t.true(error instanceof Error)
+  t.is(error.name, 'BrowserlessError')
+  t.is(error.code, 'EBRWSRCONTEXTCONNRESET')
+})
+
 test('ensureError handles non-object input', t => {
   const errorFromString = errors.ensureError('boom')
   t.true(errorFromString instanceof Error)


### PR DESCRIPTION
"Session closed" and "Attempted to use detached Frame" are browser lifecycle failures, same class as "Target closed". Classifying them as EBRWSRCONTEXTCONNRESET makes them retryable via withPage retry loop instead of propagating as unrecoverable EPROTOCOL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error classification so certain runtime failures now trigger the `withPage` retry/respawn loop; misclassification could cause unexpected retries or mask real failures.
> 
> **Overview**
> Classifies Puppeteer/Chrome lifecycle errors containing **"Session closed"** or **"Attempted to use detached Frame"** as `contextDisconnected` (`EBRWSRCONTEXTCONNRESET`) in `packages/errors/ensureError`, making them retryable instead of falling through to `EPROTOCOL`/generic errors.
> 
> Adds coverage in `packages/errors/test` for the new mappings and in `packages/browserless/test` to verify `withPage` retries and successfully recovers when these errors occur once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fab2e3cb05e5b7ae37a747bb8d9a96076f1290a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->