### PR TITLE
fix(lighthouse): ensure teardown runs when withPage throws

### DIFF
--- a/packages/lighthouse/src/index.js
+++ b/packages/lighthouse/src/index.js
@@ -17,7 +17,9 @@ module.exports =
           url
         })
 
-      const result = await browserless.withPage(fn, { timeout })()
-      if (teardown) await teardown()
-      return result
+      try {
+        return await browserless.withPage(fn, { timeout })()
+      } finally {
+        if (teardown) await teardown()
+      }
     }


### PR DESCRIPTION
## Summary

- Wrap the `withPage` call in `try/finally` so the teardown callback always executes, preventing browser context leaks when lighthouse audits fail (timeouts, navigation errors, etc.)
- No changes needed in `microlink/api` — the existing `teardown(() => browserless.close(id))` registration works correctly once the teardown is guaranteed to run

## Context

When `withPage()` throws, the teardown callback registered by consumers (e.g. `browserless.close(id)` in microlink/api) was never called because control flow skipped the teardown line. This caused browser contexts to leak on every failed lighthouse audit.

Closes #693

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk control-flow change that ensures `teardown` runs even when `browserless.withPage` throws, reducing the chance of leaked browser contexts.
> 
> **Overview**
> Ensures browser resources are always cleaned up by wrapping the `browserless.withPage(...)()` call in `try/finally` and moving the `teardown` invocation into the `finally` block.
> 
> This guarantees teardown executes on Lighthouse failures/timeouts instead of being skipped on exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e653fb9ad00b623776610d0425d1acb66cac1900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->