### PR TITLE
fix(lighthouse): avoid mutating cached preset config

### DIFF
--- a/packages/lighthouse/src/get-config.js
+++ b/packages/lighthouse/src/get-config.js
@@ -8,7 +8,8 @@ const preset = name =>
     : undefined
 
 module.exports = async ({ preset: presetName, ...settings } = {}) => {
-  const config = (await preset(presetName)) || { extends: 'lighthouse:default' }
-  if (Object.keys(settings).length > 0) config.settings = { ...config.settings, ...settings }
+  const presetConfig = (await preset(presetName)) || { extends: 'lighthouse:default' }
+  const config = { ...presetConfig }
+  if (Object.keys(settings).length > 0) config.settings = { ...presetConfig.settings, ...settings }
   return config
 }


### PR DESCRIPTION
## Summary

- Shallow-copy the preset config object before merging user settings, so the cached `import()` module export is never mutated across calls
- Prevents settings from one `getConfig()` call leaking into subsequent calls using the same preset

## Context

`import()` caches module exports. The previous code assigned `config.settings = { ... }` directly on the cached object, so user-provided settings (e.g. `skipAudits`, `output`) from one request would persist into the next request using the same preset within the same process.

Closes #697

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to config construction that avoids mutating imported preset objects; behavior should be identical aside from preventing cross-call settings leakage.
> 
> **Overview**
> Fixes `get-config` to **avoid mutating the imported Lighthouse preset config** (which can be cached by `import()`). The function now shallow-copies the preset object and merges user-provided `settings` into a new `config.settings`, preventing options from one call leaking into later calls using the same preset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1659f40f876fc4be21d19c3d1171f5af95a12a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->