### PR TITLE
fix(browserless): handle respawn promise rejections

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -44,7 +44,14 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
     })
 
     promise.then(async browser => {
-      if (launchOpts.mode !== 'connect') browser.once('disconnected', getBrowser)
+      if (launchOpts.mode !== 'connect') {
+        browser.once('disconnected', () =>
+          getBrowser().catch(error => {
+            const { message } = ensureError(error)
+            debug('respawn:error', { message })
+          })
+        )
+      }
       debug('spawn', {
         respawn: isRespawn,
         pid: driver.pid(browser) || launchOpts.mode,
@@ -65,7 +72,7 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
     const browserProcess = await lock(async () => {
       const browserProcess = await browserProcessPromise
       if (browserProcess.isConnected()) return browserProcess
-      respawn()
+      await respawn()
     })
 
     return browserProcess || getBrowser()


### PR DESCRIPTION
## Summary

- Await `respawn()` inside `getBrowser()` so spawn failures propagate instead of becoming unhandled promise rejections
- Wrap the `disconnected` event handler so the promise returned by `getBrowser()` is caught and logged

## Context

When `respawn()` was called without `await` inside the lock callback, a failed `spawn()` produced an unhandled rejection. Under `--unhandled-rejections=strict` this crashes the process. The same issue applied to `getBrowser` being passed directly as a `'disconnected'` event handler — its returned promise was never observed.

Closes #696

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches browser lifecycle/respawn logic, so regressions could affect process stability under disconnects; change is small and primarily improves error propagation/logging.
> 
> **Overview**
> Prevents unhandled promise rejections when the browser disconnects or a respawn fails.
> 
> `getBrowser()` now `await`s `respawn()` inside the lock so spawn/close failures propagate correctly, and the `'disconnected'` handler wraps `getBrowser()` to catch and log respawn errors instead of dropping the returned promise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5163a04a7b7b0b2c69e8dbe575dfa951dfe1712b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->