### PR TITLE
fix(function): move acorn/acorn-walk to dependencies

### DIFF
--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -32,13 +32,13 @@
   ],
   "dependencies": {
     "@browserless/errors": "^10.12.14",
+    "acorn": "~8.16.0",
+    "acorn-walk": "~8.3.5",
     "isolated-function": "~0.1.51",
     "require-one-of": "~1.0.24"
   },
   "devDependencies": {
     "@browserless/test": "^10.12.6",
-    "acorn": "~8.16.0",
-    "acorn-walk": "~8.3.5",
     "ava": "5",
     "lodash": "latest"
   },


### PR DESCRIPTION
## Summary

- Move `acorn` and `acorn-walk` from `devDependencies` to `dependencies` in `@browserless/function`
- Both are required at runtime by `template.js` for AST parsing to detect page usage

## Context

`template.js` calls `require('acorn')` and `require('acorn-walk')` at runtime, but they were only listed as `devDependencies`. This works inside the monorepo due to hoisting but breaks standalone `npm install @browserless/function` installs.

Closes #694

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk packaging change: only adjusts `@browserless/function` dependency classification to ensure runtime `require('acorn')`/`require('acorn-walk')` works in standalone installs.
> 
> **Overview**
> Ensures `@browserless/function` installs correctly outside the monorepo by moving `acorn` and `acorn-walk` from `devDependencies` to `dependencies`.
> 
> This makes the runtime AST parsing in `src/template.js` available after a standalone `npm install`, avoiding failures caused by hoisted-only dev deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf96b80cb99fdd396d5195080a58528c36c980b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->