### PR TITLE
fix(function): merge vmOpts.allow instead of overwriting

### DIFF
--- a/packages/function/src/function.js
+++ b/packages/function/src/function.js
@@ -15,9 +15,13 @@ module.exports = async ({
   ...opts
 }) => {
   const permissions = needsNetwork && nodeMajor >= 25 ? ['net'] : []
+  const vmOptsAllow = vmOpts?.allow || {}
   const [fn, teardown] = isolatedFunction(source, {
     ...vmOpts,
-    allow: { permissions },
+    allow: {
+      ...vmOptsAllow,
+      permissions: [...(vmOptsAllow.permissions || []), ...permissions]
+    },
     throwError: false
   })
   const result = await fn(url, browserWSEndpoint, opts)


### PR DESCRIPTION
## Summary

- Merge `vmOpts.allow` with the internally computed permissions instead of replacing it entirely
- Preserves caller-provided `allow.dependencies` and other `allow` fields passed through `vmOpts`

## Context

The `allow: { permissions }` literal after `...vmOpts` was overwriting any `vmOpts.allow` object, silently discarding dependency whitelists that callers relied on to restrict which packages the sandbox can import.

Closes #690

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how sandbox `allow` options are composed, preserving caller-provided settings while appending internal network permissions.
> 
> **Overview**
> Preserves caller-provided sandbox `vmOpts.allow` settings (e.g., dependency whitelists) by **merging** them into the options passed to `isolated-function` instead of overwriting with `allow: { permissions }`.
> 
> Internally computed `permissions` (e.g., `net` on Node >=25 when network is needed) are now **appended** to any existing `vmOpts.allow.permissions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88fc9406c3478bf84d1c0db317d2a70c2015b170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->