### PR TITLE
fix(goto): clear cached promise on adblock asset load failure

### DIFF
--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -10,7 +10,11 @@ const debug = require('debug-logfmt')('browserless:goto:adblock')
 
 const lazy = fn => {
   let p
-  return () => (p ??= fn())
+  return () =>
+    (p ??= fn().catch(err => {
+      p = undefined
+      throw err
+    }))
 }
 
 const autoconsentDir = path.dirname(require.resolve('@duckduckgo/autoconsent'))
@@ -135,7 +139,9 @@ const setupAutoConsent = async (page, timeout) => {
      message carries the nonce, then run the autoconsent script. Child frames
      keep the raw CDP binding which lacks the nonce, so their messages are
      silently rejected. */
-  const nonceGuard = `(function(n){if(window.self!==window.top)return;var raw=window.autoconsentSendMessage;if(raw)window.autoconsentSendMessage=function(msg){return raw(Object.assign({},msg,{__nonce:n}))}})(${JSON.stringify(nonce)});`
+  const nonceGuard = `(function(n){if(window.self!==window.top)return;var raw=window.autoconsentSendMessage;if(raw)window.autoconsentSendMessage=function(msg){return raw(Object.assign({},msg,{__nonce:n}))}})(${JSON.stringify(
+    nonce
+  )});`
   await page.evaluateOnNewDocument(nonceGuard + autoconsentPlaywrightScript)
   page._autoconsentSetup = true
 }


### PR DESCRIPTION
## Summary

- Reset the `lazy` helper's cached promise when it rejects, so subsequent calls retry the file read instead of permanently returning the cached rejection

## Context

The `lazy` helper uses `??=` which only assigns when the value is `null`/`undefined`. A rejected Promise is truthy, so once a load fails the rejection is cached forever. While transient filesystem errors on bundled assets are rare, this makes the helper resilient by design.

Closes #699

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior only changes on failed lazy loads, ensuring subsequent calls retry instead of reusing a cached rejection; normal successful paths are unchanged.
> 
> **Overview**
> Makes the `lazy` helper in `packages/goto/src/adblock.js` resilient to transient asset-load failures by **clearing its cached promise when the underlying async initializer rejects**, so later calls retry instead of permanently returning the same rejection.
> 
> Also reformats the `nonceGuard` injection string construction without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44aba06cda3f7d63c10cd8f9559ebbbc8dc52d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->