### PR TITLE
fix(screencast): throw if start() is called without onFrame handler

### DIFF
--- a/packages/screencast/src/index.js
+++ b/packages/screencast/src/index.js
@@ -25,6 +25,7 @@ module.exports = (page, opts) => {
   return {
     // https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreencast
     start: () => {
+      if (!onFrame) throw new Error('onFrame callback must be registered before calling start()')
       attachFrameListener()
       return cdp.send('Page.startScreencast', opts)
     },

--- a/packages/screencast/test/index.js
+++ b/packages/screencast/test/index.js
@@ -47,6 +47,7 @@ test('clean up cdp frame listeners across screencast sessions', async t => {
 
   t.is(countListeners(), 0)
 
+  screencastA.onFrame(() => {})
   await screencastA.start()
   t.is(countListeners(), 1)
   await screencastA.stop()
@@ -58,6 +59,7 @@ test('clean up cdp frame listeners across screencast sessions', async t => {
     everyNthFrame: 1
   })
 
+  screencastB.onFrame(() => {})
   await screencastB.start()
   t.is(countListeners(), 1)
   await screencastB.stop()


### PR DESCRIPTION
## Summary

- Throw a clear error when `start()` is called before registering an `onFrame` callback, instead of silently dropping frames
- Update tests to register `onFrame` before `start()` where missing

## Context

If `start()` was called before `onFrame()`, CDP frames were acknowledged but never delivered to the caller, with no error or warning. This makes the API fail fast with an actionable message.

Closes #698

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a fail-fast runtime check and adjusts tests; behavior only changes for incorrect caller usage (calling `start()` without registering `onFrame`).
> 
> **Overview**
> `packages/screencast` now **throws a clear error** if `start()` is called before an `onFrame` callback is registered, instead of starting the CDP screencast and silently dropping frames.
> 
> Tests are updated to always register a no-op `onFrame` handler before starting screencast sessions, keeping the listener cleanup assertions intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed06bb5f77e7f976949a57bb8ee2d4051caea718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->