### PR TITLE
feat!: Puppeteer 25 Browser.connected API

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@kikobeats/time-span": "latest",
     "asciichart": "latest",
-    "browserless": "latest",
+    "browserless": "workspace:*",
     "debug-logfmt": "latest",
     "measured": "latest",
     "meow": "9",

--- a/packages/browserless/package.json
+++ b/packages/browserless/package.json
@@ -51,7 +51,7 @@
     "@browserless/test": "workspace:*",
     "ava": "5",
     "ps-list": "7",
-    "puppeteer": "25.0.3",
+    "puppeteer": "25",
     "tinyspawn": "latest"
   },
   "engines": {

--- a/packages/browserless/package.json
+++ b/packages/browserless/package.json
@@ -48,7 +48,7 @@
     "superlock": "~1.2.7"
   },
   "devDependencies": {
-    "@browserless/test": "workspace:^10.12.6",
+    "@browserless/test": "workspace:*",
     "ava": "5",
     "ps-list": "7",
     "puppeteer": "25.0.3",

--- a/packages/browserless/package.json
+++ b/packages/browserless/package.json
@@ -48,10 +48,10 @@
     "superlock": "~1.2.7"
   },
   "devDependencies": {
-    "@browserless/test": "^10.12.6",
+    "@browserless/test": "workspace:^10.12.6",
     "ava": "5",
     "ps-list": "7",
-    "puppeteer": "24",
+    "puppeteer": "25.0.3",
     "tinyspawn": "latest"
   },
   "engines": {

--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -14,6 +14,9 @@ const { AbortError } = pRetry
 
 const driver = require('./driver')
 
+const isConnected = browser =>
+  typeof browser?.isConnected === 'function' ? browser.isConnected() : !!browser?.connected
+
 module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
   const lock = withLock()
   const goto = createGoto({ timeout: globalTimeout, ...launchOpts })
@@ -71,7 +74,7 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
     if (isClosed) return browserProcessPromise
     const browserProcess = await lock(async () => {
       const browserProcess = await browserProcessPromise
-      if (browserProcess.isConnected()) return browserProcess
+      if (isConnected(browserProcess)) return browserProcess
       await respawn()
     })
 

--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -14,9 +14,6 @@ const { AbortError } = pRetry
 
 const driver = require('./driver')
 
-const isConnected = browser =>
-  typeof browser?.isConnected === 'function' ? browser.isConnected() : !!browser?.connected
-
 module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
   const lock = withLock()
   const goto = createGoto({ timeout: globalTimeout, ...launchOpts })
@@ -74,7 +71,7 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
     if (isClosed) return browserProcessPromise
     const browserProcess = await lock(async () => {
       const browserProcess = await browserProcessPromise
-      if (isConnected(browserProcess)) return browserProcess
+      if (browserProcess.connected) return browserProcess
       await respawn()
     })
 

--- a/packages/browserless/test/driver.js
+++ b/packages/browserless/test/driver.js
@@ -6,8 +6,6 @@ const test = require('ava')
 const browserless = require('..')
 
 const isCI = !!process.env.CI
-const isConnected = browser =>
-  typeof browser?.isConnected === 'function' ? browser.isConnected() : !!browser?.connected
 
 const getChromiumPs = async () => {
   const ps = await psList()
@@ -63,9 +61,9 @@ test('.close() disconnect in connect mode', async t => {
 
   const browser = await browserlessFactory.browser()
 
-  t.true(isConnected(browser))
+  t.true(browser.connected)
 
   await browserlessFactory.close()
 
-  t.false(isConnected(browser))
+  t.false(browser.connected)
 })

--- a/packages/browserless/test/driver.js
+++ b/packages/browserless/test/driver.js
@@ -6,6 +6,8 @@ const test = require('ava')
 const browserless = require('..')
 
 const isCI = !!process.env.CI
+const isConnected = browser =>
+  typeof browser?.isConnected === 'function' ? browser.isConnected() : !!browser?.connected
 
 const getChromiumPs = async () => {
   const ps = await psList()
@@ -61,9 +63,9 @@ test('.close() disconnect in connect mode', async t => {
 
   const browser = await browserlessFactory.browser()
 
-  t.true(browser.isConnected())
+  t.true(isConnected(browser))
 
   await browserlessFactory.close()
 
-  t.false(browser.isConnected())
+  t.false(isConnected(browser))
 })

--- a/packages/browserless/test/driver.unit.js
+++ b/packages/browserless/test/driver.unit.js
@@ -8,7 +8,7 @@ const createFakePuppeteer = onLaunch => ({
   launch: async options => {
     onLaunch(options)
     return {
-      isConnected: () => true,
+      connected: true,
       close: async () => {},
       process: () => ({ pid: 1 })
     }

--- a/packages/browserless/test/index.js
+++ b/packages/browserless/test/index.js
@@ -219,7 +219,7 @@ test('withPage timeout cleanup should not emit unhandled rejections', async t =>
 
     return Promise.resolve({
       process: () => ({ pid: ++pid }),
-      isConnected: () => true,
+      connected: true,
       once: () => {},
       version: () => Promise.resolve('mock'),
       createBrowserContext: () => Promise.resolve(browserContext),
@@ -299,7 +299,7 @@ test('withPage clears timeout cleanup timer after success', async t => {
 
     return Promise.resolve({
       process: () => ({ pid: ++pid }),
-      isConnected: () => true,
+      connected: true,
       once: () => {},
       version: () => Promise.resolve('mock'),
       createBrowserContext: () => Promise.resolve(browserContext),
@@ -357,7 +357,7 @@ test('withPage does not retry non-transient errors', async t => {
 
     return Promise.resolve({
       process: () => ({ pid: ++pid }),
-      isConnected: () => true,
+      connected: true,
       once: () => {},
       version: () => Promise.resolve('mock'),
       createBrowserContext: () => Promise.resolve(browserContext),
@@ -418,7 +418,7 @@ test('withPage retries transient context disconnections', async t => {
 
     return Promise.resolve({
       process: () => ({ pid: ++pid }),
-      isConnected: () => true,
+      connected: true,
       once: () => {},
       version: () => Promise.resolve('mock'),
       createBrowserContext: () => Promise.resolve(browserContext),
@@ -479,7 +479,7 @@ test('withPage retries on "Session closed" error', async t => {
 
     return Promise.resolve({
       process: () => ({ pid: ++pid }),
-      isConnected: () => true,
+      connected: true,
       once: () => {},
       version: () => Promise.resolve('mock'),
       createBrowserContext: () => Promise.resolve(browserContext),
@@ -540,7 +540,7 @@ test('withPage retries on "Attempted to use detached Frame" error', async t => {
 
     return Promise.resolve({
       process: () => ({ pid: ++pid }),
-      isConnected: () => true,
+      connected: true,
       once: () => {},
       version: () => Promise.resolve('mock'),
       createBrowserContext: () => Promise.resolve(browserContext),
@@ -609,7 +609,9 @@ test('withPage close does not respawn browser for metadata logging', async t => 
 
     return Promise.resolve({
       process: () => ({ pid: ++pid }),
-      isConnected: () => isConnected,
+      get connected () {
+        return isConnected
+      },
       once: () => {},
       version: () => Promise.resolve('mock'),
       createBrowserContext: () => Promise.resolve(browserContext),
@@ -664,7 +666,9 @@ test('withPage create does not respawn browser for metadata logging', async t =>
 
     return Promise.resolve({
       process: () => ({ pid: ++pid }),
-      isConnected: () => isConnected,
+      get connected () {
+        return isConnected
+      },
       once: () => {},
       version: () => Promise.resolve('mock'),
       createBrowserContext: () => Promise.resolve(browserContext),
@@ -707,7 +711,7 @@ test('lock is scoped per browserless instance', async t => {
     setTimeout(instance === 'slow' ? 500 : 0).then(() => ({
       pid: ++pid,
       close: () => Promise.resolve(),
-      isConnected: () => true,
+      connected: true,
       once: () => {},
       version: () => Promise.resolve('mock')
     }))

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -38,7 +38,7 @@
     "require-one-of": "~1.0.24"
   },
   "devDependencies": {
-    "@browserless/test": "^10.12.6",
+    "@browserless/test": "workspace:^10.12.6",
     "ava": "5",
     "lodash": "latest"
   },

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -38,7 +38,7 @@
     "require-one-of": "~1.0.24"
   },
   "devDependencies": {
-    "@browserless/test": "workspace:^10.12.6",
+    "@browserless/test": "workspace:*",
     "ava": "5",
     "lodash": "latest"
   },

--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -42,7 +42,7 @@
     "tough-cookie": "~6.0.1"
   },
   "devDependencies": {
-    "@browserless/test": "^10.12.6",
+    "@browserless/test": "workspace:^10.12.6",
     "ava": "5",
     "p-wait-for": "3"
   },

--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -42,7 +42,7 @@
     "tough-cookie": "~6.0.1"
   },
   "devDependencies": {
-    "@browserless/test": "workspace:^10.12.6",
+    "@browserless/test": "workspace:*",
     "ava": "5",
     "p-wait-for": "3"
   },

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -35,7 +35,7 @@
     "lighthouse": "~13.3.0"
   },
   "devDependencies": {
-    "@browserless/test": "^10.12.6",
+    "@browserless/test": "workspace:^10.12.6",
     "ava": "5"
   },
   "engines": {

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -35,7 +35,7 @@
     "lighthouse": "~13.3.0"
   },
   "devDependencies": {
-    "@browserless/test": "workspace:^10.12.6",
+    "@browserless/test": "workspace:*",
     "ava": "5"
   },
   "engines": {

--- a/packages/screencast/package.json
+++ b/packages/screencast/package.json
@@ -35,7 +35,7 @@
     "null-prototype-object": "~1.2.6"
   },
   "devDependencies": {
-    "@browserless/test": "workspace:^10.12.6",
+    "@browserless/test": "workspace:*",
     "@kikobeats/time-span": "latest",
     "@skyra/gifenc": "latest",
     "ava": "5",

--- a/packages/screencast/package.json
+++ b/packages/screencast/package.json
@@ -35,7 +35,7 @@
     "null-prototype-object": "~1.2.6"
   },
   "devDependencies": {
-    "@browserless/test": "^10.12.6",
+    "@browserless/test": "workspace:^10.12.6",
     "@kikobeats/time-span": "latest",
     "@skyra/gifenc": "latest",
     "ava": "5",

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -51,7 +51,7 @@
     "svg-gradient": "~1.0.4"
   },
   "devDependencies": {
-    "@browserless/test": "workspace:^10.12.6",
+    "@browserless/test": "workspace:*",
     "ava": "5",
     "cheerio": "latest"
   },

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -51,7 +51,7 @@
     "svg-gradient": "~1.0.4"
   },
   "devDependencies": {
-    "@browserless/test": "^10.12.6",
+    "@browserless/test": "workspace:^10.12.6",
     "ava": "5",
     "cheerio": "latest"
   },

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -36,11 +36,11 @@
   "devDependencies": {
     "async-listen": "latest",
     "ava": "5",
-    "browserless": "latest",
+    "browserless": "workspace:*",
     "fs-extra": "latest",
     "img-diff-js": "latest",
     "pdf-parse": "latest",
-    "puppeteer": "24",
+    "puppeteer": "25.0.3",
     "signal-exit": "latest",
     "temperment": "latest"
   },

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -40,7 +40,7 @@
     "fs-extra": "latest",
     "img-diff-js": "latest",
     "pdf-parse": "latest",
-    "puppeteer": "25.0.3",
+    "puppeteer": "25",
     "signal-exit": "latest",
     "temperment": "latest"
   },


### PR DESCRIPTION
## Summary
- fix Puppeteer 25 compatibility in `packages/browserless`
- replace direct `browser.isConnected()` usage with a cross-version guard (`isConnected()` when present, otherwise `connected`)
- update the connect-mode driver test to use the same compatibility check

## Why
PR #765 upgrades `puppeteer` from `24` to `25`, but Puppeteer 25 removes `Browser.isConnected()`.
This caused CI failures across multiple packages with:

`TypeError: browserProcess.isConnected is not a function`

This PR restores compatibility while keeping support for older Puppeteer behavior.

## Validation
- `CI=true pnpm --filter "./packages/browserless" exec c8 pnpm test`
- `CI=true pnpm --filter "./packages/function" exec c8 pnpm test`
- `CI=true pnpm --filter "./packages/lighthouse" exec c8 pnpm test`

All passed locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `browserless` browser lifecycle/respawn logic by changing the connection check to `browser.connected`, which could affect process reuse/respawn behavior across Puppeteer versions. Also bumps Puppeteer to `25` in test/dev setups, so failures would show up mostly at runtime or in CI if compatibility assumptions are wrong.
> 
> **Overview**
> Restores Puppeteer 25 compatibility by replacing `Browser.isConnected()` usage with the `browser.connected` state in `packages/browserless` and updating related tests/mocks to assert the new API.
> 
> Updates monorepo package devDependencies to use `workspace:*` for internal packages (e.g. `browserless`, `@browserless/test`) and bumps Puppeteer devDependency from `24` to `25` where used for testing/benchmarking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f0305515a916edb375141b37e67d7477364dc09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->