### PR TITLE
feat(function)!: update dependencies

### DIFF
--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -34,7 +34,7 @@
     "@browserless/errors": "^11.0.0",
     "acorn": "~8.16.0",
     "acorn-walk": "~8.3.5",
-    "isolated-function": "~0.1.51",
+    "isolated-function": "~0.1.55",
     "require-one-of": "~1.0.24"
   },
   "devDependencies": {

--- a/packages/function/src/function.js
+++ b/packages/function/src/function.js
@@ -1,33 +1,32 @@
 'use strict'
 
-const isolatedFunction = require('isolated-function')
 const template = require('./template')
 
 const [nodeMajor] = process.version.slice(1).split('.').map(Number)
 
-module.exports = async ({
-  url,
-  code,
-  vmOpts,
-  browserWSEndpoint,
-  needsNetwork = template.isUsingPage(code),
-  source = template(code, needsNetwork),
-  ...opts
-}) => {
-  const permissions = needsNetwork && nodeMajor >= 25 ? ['net'] : []
-  const vmOptsAllow = vmOpts?.allow || {}
-  const [fn, teardown] = isolatedFunction(source, {
-    ...vmOpts,
-    allow: {
-      ...vmOptsAllow,
-      permissions: [...(vmOptsAllow.permissions || []), ...permissions]
-    },
-    throwError: false
-  })
-  const result = await fn(url, browserWSEndpoint, opts)
-  await teardown()
-  return result
-}
+module.exports =
+  isolatedFunction =>
+    async ({
+      url,
+      code,
+      vmOpts,
+      browserWSEndpoint,
+      needsNetwork = template.isUsingPage(code),
+      source = template(code, needsNetwork),
+      ...opts
+    }) => {
+      const permissions = needsNetwork && nodeMajor >= 25 ? ['net'] : []
+      const vmOptsAllow = vmOpts?.allow || {}
+      const fn = isolatedFunction(source, {
+        ...vmOpts,
+        allow: {
+          ...vmOptsAllow,
+          permissions: [...(vmOptsAllow.permissions || []), ...permissions]
+        },
+        throwError: false
+      })
+      return fn(url, browserWSEndpoint, opts)
+    }
 
 module.exports.isUsingPage = template.isUsingPage
 module.exports.buildTemplate = template

--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -30,7 +30,13 @@ const serializeResponse = response => ({
   fromServiceWorker: response.fromServiceWorker()
 })
 
-module.exports = ({ tmpdir } = {}) => {
+module.exports = (factoryOpts = {}) => {
+  if (typeof factoryOpts === 'function' || typeof factoryOpts === 'string') {
+    throw new TypeError(
+      'API changed: call require("@browserless/function")({ tmpdir })(code, opts)'
+    )
+  }
+  const { tmpdir } = factoryOpts
   const isolatedFunction = createIsolatedFunction({ tmpdir })
   const runFunction = createRunFunction(isolatedFunction)
 

--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -30,13 +30,7 @@ const serializeResponse = response => ({
   fromServiceWorker: response.fromServiceWorker()
 })
 
-module.exports = (factoryOpts = {}) => {
-  if (typeof factoryOpts === 'function' || typeof factoryOpts === 'string') {
-    throw new TypeError(
-      'API changed: call require("@browserless/function")({ tmpdir })(code, opts)'
-    )
-  }
-  const { tmpdir } = factoryOpts
+module.exports = ({ tmpdir } = {}) => {
   const isolatedFunction = createIsolatedFunction({ tmpdir })
   const runFunction = createRunFunction(isolatedFunction)
 

--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const { isBrowserlessError, ensureError } = require('@browserless/errors')
+const createIsolatedFunction = require('isolated-function')
 const requireOneOf = require('require-one-of')
-const runFunction = require('./function')
+const createRunFunction = require('./function')
 
 const stringify = fn => fn.toString().trim().replace(/;$/, '')
 
@@ -29,72 +30,81 @@ const serializeResponse = response => ({
   fromServiceWorker: response.fromServiceWorker()
 })
 
-module.exports = (
-  fn,
-  {
-    getBrowserless = requireOneOf(['browserless']),
-    retry = 2,
-    timeout = 30000,
-    gotoOpts,
-    ...opts
-  } = {}
-) => {
-  const code = stringify(fn)
-  const needsNetwork = runFunction.isUsingPage(code)
-  const source = runFunction.buildTemplate(code, needsNetwork)
-  let browserPromise
+module.exports = ({ tmpdir } = {}) => {
+  const isolatedFunction = createIsolatedFunction({ tmpdir })
+  const runFunction = createRunFunction(isolatedFunction)
 
-  const getBrowser = async () => {
-    if (!browserPromise) {
-      browserPromise = Promise.resolve(getBrowserless()).catch(error => {
-        browserPromise = undefined
-        throw error
-      })
+  const createFunction = (
+    fn,
+    {
+      getBrowserless = requireOneOf(['browserless']),
+      retry = 2,
+      timeout = 30000,
+      gotoOpts,
+      ...opts
+    } = {}
+  ) => {
+    const code = stringify(fn)
+    const needsNetwork = createRunFunction.isUsingPage(code)
+    const source = createRunFunction.buildTemplate(code, needsNetwork)
+    let browserPromise
+
+    const getBrowser = async () => {
+      if (!browserPromise) {
+        browserPromise = Promise.resolve(getBrowserless()).catch(error => {
+          browserPromise = undefined
+          throw error
+        })
+      }
+      return browserPromise
     }
-    return browserPromise
+
+    return async (url, fnOpts = {}) => {
+      const browser = await getBrowser()
+      const browserless = await browser.createContext()
+
+      return browserless.withPage((page, goto) => async () => {
+        const { device, response } = await goto(page, { url, timeout, ...gotoOpts })
+
+        const targetId = await getTargetId(page)
+
+        const runFunctionOpts = {
+          url,
+          code,
+          device,
+          ...opts,
+          ...fnOpts,
+          ...(response && { _response: serializeResponse(response) })
+        }
+
+        if (runFunctionOpts.code === code) {
+          runFunctionOpts.needsNetwork = needsNetwork
+          runFunctionOpts.source = source
+        }
+
+        if (runFunctionOpts.needsNetwork !== false) {
+          const browserFromPage = typeof page.browser === 'function' ? page.browser() : undefined
+          const browserWSEndpoint =
+            browserFromPage && typeof browserFromPage.wsEndpoint === 'function'
+              ? browserFromPage.wsEndpoint()
+              : undefined
+
+          if (!browserWSEndpoint) throw new Error('Browser WebSocket endpoint not found')
+          runFunctionOpts.browserWSEndpoint = browserWSEndpoint
+          runFunctionOpts.targetId = targetId
+        }
+
+        const result = await runFunction(runFunctionOpts)
+
+        if (result.isFulfilled) return result
+        const error = ensureError(result.value)
+        if (isBrowserlessError(error)) throw error
+        return result
+      })()
+    }
   }
 
-  return async (url, fnOpts = {}) => {
-    const browser = await getBrowser()
-    const browserless = await browser.createContext()
+  createFunction.teardown = () => isolatedFunction.teardown()
 
-    return browserless.withPage((page, goto) => async () => {
-      const { device, response } = await goto(page, { url, timeout, ...gotoOpts })
-
-      const targetId = await getTargetId(page)
-
-      const runFunctionOpts = {
-        url,
-        code,
-        device,
-        ...opts,
-        ...fnOpts,
-        ...(response && { _response: serializeResponse(response) })
-      }
-
-      if (runFunctionOpts.code === code) {
-        runFunctionOpts.needsNetwork = needsNetwork
-        runFunctionOpts.source = source
-      }
-
-      if (runFunctionOpts.needsNetwork !== false) {
-        const browserFromPage = typeof page.browser === 'function' ? page.browser() : undefined
-        const browserWSEndpoint =
-          browserFromPage && typeof browserFromPage.wsEndpoint === 'function'
-            ? browserFromPage.wsEndpoint()
-            : undefined
-
-        if (!browserWSEndpoint) throw new Error('Browser WebSocket endpoint not found')
-        runFunctionOpts.browserWSEndpoint = browserWSEndpoint
-        runFunctionOpts.targetId = targetId
-      }
-
-      const result = await runFunction(runFunctionOpts)
-
-      if (result.isFulfilled) return result
-      const error = ensureError(result.value)
-      if (isBrowserlessError(error)) throw error
-      return result
-    })()
-  }
+  return createFunction
 }

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -16,6 +16,20 @@ const opts = {
 
 const fileUrl = `file://${path.join(__dirname, './fixtures/example.html')}`
 
+const createBrowserlessFunction = require('..')
+
+test('throws when called with old API signature', t => {
+  t.throws(() => createBrowserlessFunction(() => 'ok', {}), {
+    instanceOf: TypeError,
+    message: /API changed/
+  })
+
+  t.throws(() => createBrowserlessFunction('() => "ok"', {}), {
+    instanceOf: TypeError,
+    message: /API changed/
+  })
+})
+
 test('code runs in strict mode', async t => {
   const code = () => {
     function isStrict () {

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -16,20 +16,6 @@ const opts = {
 
 const fileUrl = `file://${path.join(__dirname, './fixtures/example.html')}`
 
-const createBrowserlessFunction = require('..')
-
-test('throws when called with old API signature', t => {
-  t.throws(() => createBrowserlessFunction(() => 'ok', {}), {
-    instanceOf: TypeError,
-    message: /API changed/
-  })
-
-  t.throws(() => createBrowserlessFunction('() => "ok"', {}), {
-    instanceOf: TypeError,
-    message: /API changed/
-  })
-})
-
 test('code runs in strict mode', async t => {
   const code = () => {
     function isStrict () {

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -5,7 +5,7 @@ const { spawnSync } = require('child_process')
 const path = require('path')
 const test = require('ava')
 
-const browserlessFunction = require('..')
+const browserlessFunction = require('..')()
 
 const browserless = getBrowser()
 
@@ -303,24 +303,25 @@ test('response is serialized and reconstructed with callable methods', t => {
 
     Module._load = function (request, parent, isMain) {
       if (request === 'isolated-function') {
-        return (source) => {
-          const fn = new Function('return (' + source + ')')()
-          return [
-            async (...args) => {
+        return ({ tmpdir } = {}) => {
+          const instance = (source) => {
+            const fn = new Function('return (' + source + ')')()
+            return async (...args) => {
               try {
                 return { isFulfilled: true, value: await fn(...args) }
               } catch (error) {
                 return { isFulfilled: false, value: { message: error.message } }
               }
-            },
-            async () => {}
-          ]
+            }
+          }
+          instance.teardown = async () => {}
+          return instance
         }
       }
       return originalLoad(request, parent, isMain)
     }
 
-    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})
+    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})()
 
     const fakeResponse = {
       status: () => 200,
@@ -388,24 +389,25 @@ test('response is undefined when goto returns no response', t => {
 
     Module._load = function (request, parent, isMain) {
       if (request === 'isolated-function') {
-        return (source) => {
-          const fn = new Function('return (' + source + ')')()
-          return [
-            async (...args) => {
+        return ({ tmpdir } = {}) => {
+          const instance = (source) => {
+            const fn = new Function('return (' + source + ')')()
+            return async (...args) => {
               try {
                 return { isFulfilled: true, value: await fn(...args) }
               } catch (error) {
                 return { isFulfilled: false, value: { message: error.message } }
               }
-            },
-            async () => {}
-          ]
+            }
+          }
+          instance.teardown = async () => {}
+          return instance
         }
       }
       return originalLoad(request, parent, isMain)
     }
 
-    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})
+    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})()
 
     const fakeBrowserless = {
       withPage: fn => async () =>
@@ -488,12 +490,16 @@ test('prefer page browser websocket endpoint when available', t => {
 
     Module._load = function (request, parent, isMain) {
       if (request === 'isolated-function') {
-        return () => [async () => ({ isFulfilled: true, value: 'ok' }), async () => {}]
+        return ({ tmpdir } = {}) => {
+          const instance = () => async () => ({ isFulfilled: true, value: 'ok' })
+          instance.teardown = async () => {}
+          return instance
+        }
       }
       return originalLoad(request, parent, isMain)
     }
 
-    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})
+    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})()
 
     const fakeBrowserless = {
       withPage: fn => async () =>
@@ -544,7 +550,11 @@ test('reuse function code analysis across invocations', t => {
 
     Module._load = function (request, parent, isMain) {
       if (request === 'isolated-function') {
-        return () => [async () => ({ isFulfilled: true, value: 'ok' }), async () => {}]
+        return ({ tmpdir } = {}) => {
+          const instance = () => async () => ({ isFulfilled: true, value: 'ok' })
+          instance.teardown = async () => {}
+          return instance
+        }
       }
 
       if (request === 'acorn') {
@@ -560,7 +570,7 @@ test('reuse function code analysis across invocations', t => {
       return originalLoad(request, parent, isMain)
     }
 
-    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})
+    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})()
 
     const fakeBrowserless = {
       withPage: fn => async () =>
@@ -602,7 +612,11 @@ test('reuse compiled template source across invocations', t => {
 
     Module._load = function (request, parent, isMain) {
       if (request === 'isolated-function') {
-        return () => [async () => ({ isFulfilled: true, value: 'ok' }), async () => {}]
+        return ({ tmpdir } = {}) => {
+          const instance = () => async () => ({ isFulfilled: true, value: 'ok' })
+          instance.teardown = async () => {}
+          return instance
+        }
       }
 
       if (request === './template') {
@@ -621,7 +635,7 @@ test('reuse compiled template source across invocations', t => {
       return originalLoad(request, parent, isMain)
     }
 
-    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})
+    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})()
     const fakeBrowserless = {
       withPage: fn => async () =>
         fn({}, async () => ({ device: { viewport: {}, userAgent: 'ua' } }))(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the public entrypoint to a factory and alters sandbox lifecycle/teardown behavior, which can break consumers and affect resource cleanup. Core execution path remains similar but depends on updated `isolated-function` semantics.
> 
> **Overview**
> Updates `isolated-function` to `~0.1.55` and refactors `@browserless/function` to **export a factory** (`require('..')({ tmpdir })`) instead of a directly-callable creator.
> 
> Moves `isolated-function` instantiation to `index.js`, wires `tmpdir` through, and shifts `runFunction` to accept an injected isolated-function instance; adds a top-level `teardown()` hook while removing per-invocation teardown. Tests are updated to use the new factory API and to mock the new `isolated-function({ tmpdir })` shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8a45adb308a6eb94ef1d51e2362a12e0f0baf08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->