### PR TITLE
fix: error EPROTOCOL is retriable

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -147,7 +147,8 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
               debug('onFailedAttempt', { name: error.name, code: error.code, isRejected })
               if (error.name === 'AbortError') throw error
               if (isRejected || isDestroyedForced) throw new AbortError()
-              const isRetryable = error.code === 'EBRWSRCONTEXTCONNRESET'
+              const isRetryable =
+                error.code === 'EBRWSRCONTEXTCONNRESET' || error.code === 'EPROTOCOL'
               if (!isRetryable) throw error
               _contextPromise = createBrowserContext(contextOpts)
               const { message, attemptNumber, retriesLeft } = error

--- a/packages/browserless/test/index.js
+++ b/packages/browserless/test/index.js
@@ -454,6 +454,68 @@ test('withPage retries transient context disconnections', async t => {
   t.is(attempts, 2)
 })
 
+test('withPage retries transient protocol errors', async t => {
+  const browserlessFactory = require('..')
+  const { protocolError } = require('@browserless/errors')
+  const { driver } = browserlessFactory
+
+  const originalSpawn = driver.spawn
+  const originalClose = driver.close
+  let pid = 4050
+
+  driver.spawn = () => {
+    let isClosed = false
+
+    const page = {
+      _client: () => ({ id: () => 'page-id' }),
+      close: () => Promise.resolve().then(() => (isClosed = true)),
+      isClosed: () => isClosed
+    }
+
+    const browserContext = {
+      id: `ctx-${pid}`,
+      close: () => Promise.resolve(),
+      newPage: () => Promise.resolve(page)
+    }
+
+    return Promise.resolve({
+      process: () => ({ pid: ++pid }),
+      connected: true,
+      once: () => {},
+      version: () => Promise.resolve('mock'),
+      createBrowserContext: () => Promise.resolve(browserContext),
+      close: () => Promise.resolve(),
+      disconnect: () => Promise.resolve()
+    })
+  }
+
+  driver.close = subprocess => Promise.resolve(subprocess.close && subprocess.close())
+
+  t.teardown(() => {
+    driver.spawn = originalSpawn
+    driver.close = originalClose
+  })
+
+  const browser = browserlessFactory({ timeout: 3000 })
+  t.teardown(browser.close)
+  const browserless = await browser.createContext({ retry: 1 })
+
+  let attempts = 0
+  const evaluate = browserless.withPage(
+    () => async () => {
+      attempts += 1
+      if (attempts === 1) throw protocolError({ message: 'Target closed' })
+      return 'ok'
+    },
+    { timeout: 3000 }
+  )
+
+  const result = await evaluate()
+
+  t.is(result, 'ok')
+  t.is(attempts, 2)
+})
+
 test('withPage retries on "Session closed" error', async t => {
   const browserlessFactory = require('..')
   const { driver } = browserlessFactory


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrows retry behavior to a known error code with a matching test; no auth or data paths touched.
> 
> **Overview**
> **`withPage`** now treats Chrome DevTools **protocol failures** (`EPROTOCOL`) as **transient**, alongside existing context disconnect retries (`EBRWSRCONTEXTCONNRESET`). On those errors it **recreates the browser context** and retries via `p-retry` instead of failing immediately.
> 
> A unit test asserts that a first-attempt `protocolError` (e.g. “Target closed”) is retried and succeeds on the second attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820703f0114e5aacc56bfdb31c81e0369b769283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->