### PR TITLE
fix(goto): don’t forward sec-fetch-* headers

### DIFF
--- a/packages/browserless/package.json
+++ b/packages/browserless/package.json
@@ -35,10 +35,10 @@
     "web-scraping"
   ],
   "dependencies": {
-    "@browserless/errors": "^13.0.0",
-    "@browserless/goto": "^13.0.7",
-    "@browserless/pdf": "^13.0.7",
-    "@browserless/screenshot": "^13.0.7",
+    "@browserless/errors": "workspace:*",
+    "@browserless/goto": "workspace:*",
+    "@browserless/pdf": "workspace:*",
+    "@browserless/screenshot": "workspace:*",
     "debug-logfmt": "~1.4.10",
     "kill-process-group": "~1.0.13",
     "p-reflect": "~2.1.0",

--- a/packages/capture/package.json
+++ b/packages/capture/package.json
@@ -30,7 +30,7 @@
     "webm"
   ],
   "dependencies": {
-    "@browserless/goto": "^13.0.7",
+    "@browserless/goto": "workspace:*",
     "debug-logfmt": "~1.4.10",
     "ws": "~8.21.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,9 +34,9 @@
     "web-scraping"
   ],
   "dependencies": {
-    "@browserless/capture": "^13.0.7",
+    "@browserless/capture": "workspace:*",
     "beauty-error": "~1.2.22",
-    "browserless": "^13.0.7",
+    "browserless": "workspace:*",
     "dark-mode": "~3.0.0",
     "dset": "~3.1.4",
     "mri": "~1.2.0",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -31,7 +31,7 @@
     "vm"
   ],
   "dependencies": {
-    "@browserless/errors": "^13.0.0",
+    "@browserless/errors": "workspace:*",
     "@cloudflare/puppeteer": "~1.1.0",
     "acorn": "~8.16.0",
     "acorn-walk": "~8.3.5",

--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -30,7 +30,7 @@
     "puppeteer"
   ],
   "dependencies": {
-    "@browserless/devices": "^13.0.0",
+    "@browserless/devices": "workspace:*",
     "@duckduckgo/autoconsent": "~14.89.0",
     "@ghostery/adblocker-puppeteer": "~2.17.0",
     "debug-logfmt": "~1.4.10",

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -251,7 +251,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       authenticate,
       click,
       colorScheme,
-      headers = {},
+      headers: rawHeaders = {},
       html,
       javascript = true,
       mediaType,
@@ -362,13 +362,13 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
     }
 
     const device = getDevice({
-      headers,
+      headers: rawHeaders,
       device: args.device ?? defaultDevice,
       viewport: args.viewport
     })
 
-    if (device.userAgent && !headers['user-agent']) {
-      headers['user-agent'] = device.userAgent
+    if (device.userAgent && !rawHeaders['user-agent']) {
+      rawHeaders['user-agent'] = device.userAgent
     }
 
     if (!isEmpty(device.viewport) && !shallowEqualObjects(defaultViewport, device.viewport)) {
@@ -379,6 +379,15 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
           debug: 'viewport'
         })
       )
+    }
+
+    // sec-fetch-* headers are per-request metadata the browser computes
+    // automatically (same-origin vs cross-site, navigation vs subresource, etc.).
+    // setExtraHTTPHeaders would stamp a single static value on every request,
+    // overriding Chrome's correct per-request values for cross-origin sub-resources.
+    const headers = {}
+    for (const key of Object.keys(rawHeaders)) {
+      if (!key.startsWith('sec-fetch-')) headers[key] = rawHeaders[key]
     }
 
     const headersKeys = Object.keys(headers)
@@ -409,21 +418,21 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       }
 
       if (cookie) {
-        const extraHTTPHeaders = {}
-        const extraHTTPHeadersKeys = []
+        const httpHeaders = {}
+        const httpHeadersKeys = []
 
         for (const key of headersKeys) {
           if (key === 'cookie') continue
-          extraHTTPHeaders[key] = headers[key]
-          extraHTTPHeadersKeys.push(key)
+          httpHeaders[key] = headers[key]
+          httpHeadersKeys.push(key)
         }
 
-        if (extraHTTPHeadersKeys.length > 0) {
+        if (httpHeadersKeys.length > 0) {
           prePromises.push(
             run({
-              fn: page.setExtraHTTPHeaders(extraHTTPHeaders),
+              fn: page.setExtraHTTPHeaders(httpHeaders),
               timeout: actionTimeout,
-              debug: { headers: extraHTTPHeadersKeys }
+              debug: { headers: httpHeadersKeys }
             })
           )
         }

--- a/packages/goto/test/unit/headers/index.js
+++ b/packages/goto/test/unit/headers/index.js
@@ -142,6 +142,92 @@ test('does not forward cookie through extra headers', async t => {
   t.true(cookies.some(({ name, value }) => name === 'yummy_cookie' && value === 'choco'))
 })
 
+test('sec-fetch-* headers are not forwarded via setExtraHTTPHeaders', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+  let extraHTTPHeaders
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const originalSetExtraHTTPHeaders = page.setExtraHTTPHeaders.bind(page)
+    page.setExtraHTTPHeaders = headers => {
+      extraHTTPHeaders = headers
+      return originalSetExtraHTTPHeaders(headers)
+    }
+
+    const { response } = await goto(page, {
+      url,
+      headers: {
+        'x-foo': 'bar',
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'navigate',
+        'sec-fetch-dest': 'document',
+        'sec-fetch-user': '?1'
+      }
+    })
+
+    return { body: await response.json() }
+  })
+
+  const { body } = await run()
+
+  t.truthy(extraHTTPHeaders)
+  t.is(extraHTTPHeaders['x-foo'], 'bar')
+  t.false(Object.prototype.hasOwnProperty.call(extraHTTPHeaders, 'sec-fetch-site'))
+  t.false(Object.prototype.hasOwnProperty.call(extraHTTPHeaders, 'sec-fetch-mode'))
+  t.false(Object.prototype.hasOwnProperty.call(extraHTTPHeaders, 'sec-fetch-dest'))
+  t.false(Object.prototype.hasOwnProperty.call(extraHTTPHeaders, 'sec-fetch-user'))
+  t.is(body.headers['x-foo'], 'bar')
+})
+
+test('sec-fetch-* headers are not sent to cross-origin subrequests', async t => {
+  const browserless = await getBrowserContext(t)
+  let subrequestHeaders
+
+  const subrequestUrl = (
+    await runServer(t, ({ req, res }) => {
+      if (req.method === 'OPTIONS') {
+        res.setHeader('access-control-allow-origin', '*')
+        res.setHeader('access-control-allow-methods', 'GET,POST,OPTIONS')
+        res.statusCode = 204
+        return res.end()
+      }
+
+      subrequestHeaders = req.headers
+      res.setHeader('access-control-allow-origin', '*')
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ ok: true }))
+    })
+  ).replace('127.0.0.1', 'localhost')
+
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(`
+      <script>
+        fetch('${subrequestUrl}').finally(() => {
+          window.__subrequest_complete = true
+        })
+      </script>
+    `)
+  })
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, {
+      url,
+      waitForFunction: () => window.__subrequest_complete === true,
+      headers: {
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'navigate',
+        'sec-fetch-dest': 'document'
+      }
+    })
+  })
+
+  await run()
+
+  t.truthy(subrequestHeaders)
+  t.not(subrequestHeaders['sec-fetch-site'], 'same-origin')
+})
+
 test('cookies are not sent to subrequests via extra headers', async t => {
   const browserless = await getBrowserContext(t)
   let subrequestHeaders

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -30,8 +30,8 @@
     "website-to-pdf"
   ],
   "dependencies": {
-    "@browserless/goto": "^13.0.7",
-    "@browserless/screenshot": "^13.0.7",
+    "@browserless/goto": "workspace:*",
+    "@browserless/screenshot": "workspace:*",
     "@kikobeats/time-span": "~1.0.12",
     "debug-logfmt": "~1.4.10",
     "pretty-ms": "~7.0.1"

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -32,7 +32,7 @@
     "web-capture"
   ],
   "dependencies": {
-    "@browserless/goto": "^13.0.7",
+    "@browserless/goto": "workspace:*",
     "@kikobeats/content-type": "~1.0.4",
     "@kikobeats/time-span": "~1.0.12",
     "automad-prism-themes": "~0.3.7",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Targeted navigation header fix with tests; workspace dependency pins are tooling-only with no runtime behavior change beyond goto header filtering.
> 
> **Overview**
> **`@browserless/goto`** no longer passes **`sec-fetch-*`** headers through **`setExtraHTTPHeaders`**. User-supplied headers are kept as **`rawHeaders`** for device/user-agent logic, then any key starting with **`sec-fetch-`** is dropped before extra HTTP headers are applied so Chrome can set correct per-request metadata (e.g. cross-origin **`fetch`** is not stuck with navigation-style **`same-origin`** values).
> 
> Monorepo packages switch internal **`@browserless/*`** and **`browserless`** dependencies from pinned **`^13.x`** versions to **`workspace:*`**. New unit tests in **`packages/goto/test/unit/headers`** cover filtering and cross-origin subrequests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fba542a604e56ba3f8a6572d2d74e5d0017511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->