### PR TITLE
feat(goto): add opt-in flattenShadowDOM option

### DIFF
--- a/packages/browserless/index.d.ts
+++ b/packages/browserless/index.d.ts
@@ -32,7 +32,7 @@ export interface Context {
   context: () => Promise<BrowserContext>
   browser: () => Promise<Browser>
   evaluate: <T>(fn: (page: Page, response?: HTTPResponse | undefined, error?: Error) => T | Promise<T>, gotoOpts?: GotoOptions) => Promise<T>
-  goto: (page: Page, url: string, opts?: GotoOptions) => Promise<GotoResult>
+  goto: (page: Page, opts: GotoOptions & { url: string }) => Promise<GotoResult>
   html: (url: string, opts?: GotoOptions) => Promise<string>
   page: (name?: string) => Promise<Page>
   pdf: (page: Page, opts?: PDFOptions) => Promise<Buffer>
@@ -47,6 +47,7 @@ export interface GotoOptions {
   waitUntil?: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2'
   timeout?: number
   headers?: Record<string, string>
+  flattenShadowDOM?: boolean
   [key: string]: unknown
 }
 

--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -198,7 +198,7 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
       browser: getBrowser,
       evaluate,
       goto,
-      html: evaluate(page => page.content()),
+      html: evaluate(page => page.content(), { flattenShadowDOM: true }),
       page: createPage,
       pdf: withPage(createPdf({ goto })),
       screenshot: withPage(createScreenshot({ goto })),

--- a/packages/browserless/test/shadow-dom.js
+++ b/packages/browserless/test/shadow-dom.js
@@ -1,0 +1,291 @@
+'use strict'
+
+const test = require('ava')
+
+const { runServer, getBrowserContext } = require('@browserless/test')
+
+const getUrl = t =>
+  runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(`<!DOCTYPE html>
+<html>
+<head>
+  <script>
+    class MyRow extends HTMLElement {
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' })
+        const name = this.getAttribute('name') || ''
+        const value = this.getAttribute('value') || ''
+        shadow.innerHTML = '<div class="row"><span>' + name + '</span><span>' + value + '</span></div>'
+      }
+    }
+    customElements.define('my-row', MyRow)
+  </script>
+</head>
+<body>
+  <h1>Shadow DOM Table</h1>
+  <div id="table">
+    <my-row name="Alice" value="100"></my-row>
+    <my-row name="Bob" value="200"></my-row>
+    <my-row name="Charlie" value="300"></my-row>
+  </div>
+</body>
+</html>`)
+  })
+
+const getNestedUrl = t =>
+  runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(`<!DOCTYPE html>
+<html>
+<head>
+  <script>
+    class InnerItem extends HTMLElement {
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' })
+        shadow.innerHTML = '<span class="label">' + this.getAttribute('label') + '</span>'
+      }
+    }
+    class OuterList extends HTMLElement {
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' })
+        shadow.innerHTML = '<div class="list">' +
+          '<inner-item label="nested-a"></inner-item>' +
+          '<inner-item label="nested-b"></inner-item>' +
+        '</div>'
+      }
+    }
+    customElements.define('inner-item', InnerItem)
+    customElements.define('outer-list', OuterList)
+  </script>
+</head>
+<body>
+  <outer-list></outer-list>
+</body>
+</html>`)
+  })
+
+test('shadow DOM content is flattened into page.content()', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const html = await browserless.html(url, { flattenShadowDOM: true })
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.true(withoutScripts.includes('<span>Alice</span>'))
+  t.true(withoutScripts.includes('<span>Bob</span>'))
+  t.true(withoutScripts.includes('<span>Charlie</span>'))
+  t.true(withoutScripts.includes('<span>100</span>'))
+  t.true(withoutScripts.includes('<span>200</span>'))
+  t.true(withoutScripts.includes('<span>300</span>'))
+})
+
+test('nested shadow DOMs are flattened recursively', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getNestedUrl(t)
+
+  const html = await browserless.html(url, { flattenShadowDOM: true })
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.true(withoutScripts.includes('nested-a'))
+  t.true(withoutScripts.includes('nested-b'))
+  t.true(withoutScripts.includes('<span class="label">'))
+})
+
+test('shadow DOM is flattened by default for html serialization', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const html = await browserless.html(url)
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.true(withoutScripts.includes('<div class="row">'))
+  t.true(withoutScripts.includes('<span>Alice</span>'))
+})
+
+test('shadow DOM flattening is off by default for goto', async t => {
+  const browserless = await getBrowserContext(t)
+  const page = await browserless.page()
+  const url = await getUrl(t)
+
+  await browserless.goto(page, { url })
+  const html = await page.content()
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.false(withoutScripts.includes('<div class="row">'))
+})
+
+test('shadow DOM flattening can be disabled', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const html = await browserless.html(url, { flattenShadowDOM: false })
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.false(withoutScripts.includes('<div class="row">'))
+})
+
+const getSlottedUrl = t =>
+  runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(`<!DOCTYPE html>
+<html>
+<head>
+  <script>
+    class MyCard extends HTMLElement {
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' })
+        shadow.innerHTML = '<div class="card"><h2><slot name="title"></slot></h2><div class="body"><slot></slot></div></div>'
+      }
+    }
+    customElements.define('my-card', MyCard)
+  </script>
+</head>
+<body>
+  <my-card>
+    <span slot="title">Card Title</span>
+    <p>Card body content here</p>
+  </my-card>
+</body>
+</html>`)
+  })
+
+const getSlottedShadowHostUrl = t =>
+  runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(`<!DOCTYPE html>
+<html>
+<head>
+  <script>
+    class MyCard extends HTMLElement {
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' })
+        shadow.innerHTML = '<section><slot></slot></section>'
+      }
+    }
+    class InnerBadge extends HTMLElement {
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' })
+        shadow.innerHTML = '<strong>Nested shadow badge</strong>'
+      }
+    }
+    customElements.define('my-card', MyCard)
+    customElements.define('inner-badge', InnerBadge)
+  </script>
+</head>
+<body>
+  <my-card>
+    <inner-badge></inner-badge>
+  </my-card>
+</body>
+</html>`)
+  })
+
+test('slotted light-DOM content is preserved after flattening', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getSlottedUrl(t)
+
+  const html = await browserless.html(url, { flattenShadowDOM: true })
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.true(withoutScripts.includes('<div class="card">'))
+  t.true(withoutScripts.includes('<h2><span slot="title">Card Title</span></h2>'))
+  t.false(withoutScripts.includes('<slot'))
+  t.true(withoutScripts.includes('Card Title'))
+  t.true(withoutScripts.includes('Card body content here'))
+})
+
+test('slotted shadow hosts are flattened before cloning', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getSlottedShadowHostUrl(t)
+
+  const html = await browserless.html(url, { flattenShadowDOM: true })
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.true(withoutScripts.includes('<section>'))
+  t.true(withoutScripts.includes('<inner-badge><strong>Nested shadow badge</strong></inner-badge>'))
+  t.false(withoutScripts.includes('<slot'))
+})
+
+const getEmptySlotUrl = t =>
+  runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(`<!DOCTYPE html>
+<html>
+<head>
+  <script>
+    class MyPanel extends HTMLElement {
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' })
+        shadow.innerHTML = '<div class="panel"><slot name="header"></slot><div class="body"><slot></slot></div><slot name="footer"></slot></div>'
+      }
+    }
+    customElements.define('my-panel', MyPanel)
+  </script>
+</head>
+<body>
+  <my-panel>
+    <p>Main content</p>
+  </my-panel>
+</body>
+</html>`)
+  })
+
+const getFallbackSlotUrl = t =>
+  runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(`<!DOCTYPE html>
+<html>
+<head>
+  <script>
+    class MyWidget extends HTMLElement {
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' })
+        shadow.innerHTML = '<div class="widget"><slot name="label"><span class="default-label">Default</span></slot></div>'
+      }
+    }
+    customElements.define('my-widget', MyWidget)
+  </script>
+</head>
+<body>
+  <my-widget></my-widget>
+</body>
+</html>`)
+  })
+
+test('empty slots with no assigned nodes are removed', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getEmptySlotUrl(t)
+
+  const html = await browserless.html(url, { flattenShadowDOM: true })
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.false(withoutScripts.includes('<slot'))
+  t.true(withoutScripts.includes('Main content'))
+  t.true(withoutScripts.includes('<div class="panel">'))
+})
+
+test('slots with fallback content use the fallback when no nodes are assigned', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getFallbackSlotUrl(t)
+
+  const html = await browserless.html(url, { flattenShadowDOM: true })
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.false(withoutScripts.includes('<slot'))
+  t.true(withoutScripts.includes('<span class="default-label">Default</span>'))
+})
+
+test('custom element attributes are preserved after flattening', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const html = await browserless.html(url, { flattenShadowDOM: true })
+
+  t.true(html.includes('name="Alice"'))
+  t.true(html.includes('value="100"'))
+  t.true(html.includes('name="Bob"'))
+  t.true(html.includes('value="200"'))
+  t.true(html.includes('name="Charlie"'))
+  t.true(html.includes('value="300"'))
+})

--- a/packages/goto/README.md
+++ b/packages/goto/README.md
@@ -71,6 +71,7 @@ const { response, device, error } = await goto(page, {
 | `javascript` | `boolean` | `true` | Enable/disable JavaScript |
 | `animations` | `boolean` | `false` | Enable CSS animations |
 | `colorScheme` | `string` | — | `'light'` or `'dark'` preference |
+| `flattenShadowDOM` | `boolean` | `false` (`true` for `html()`) | Serialize open shadow DOM into HTML (mutates the page DOM; closed shadow roots are skipped) |
 | `mediaType` | `string` | — | CSS media type (`'screen'`, `'print'`) |
 | `timezone` | `string` | — | Timezone to emulate |
 | `authenticate` | `object` | — | HTTP authentication credentials |

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -251,6 +251,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       authenticate,
       click,
       colorScheme,
+      flattenShadowDOM = false,
       headers: rawHeaders = {},
       html,
       javascript = true,
@@ -481,7 +482,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
             return Promise.race([page.goto(url, { waitUntil, ...args }), promise])
           })()
 
-      const { value: response, reason: error } = await run({
+      let { value: response, reason: error } = await run({
         fn: navigationPromise,
         timeout: gotoTimeout,
         debug: { fn: html ? 'html' : 'url', waitUntil }
@@ -545,6 +546,65 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
 
       if (isWaitUntilAuto) {
         await waitUntilAuto(page, { response, timeout: actionTimeout * 2 })
+      }
+
+      if (flattenShadowDOM) {
+        const { isRejected, reason: flattenError } = await run({
+          fn: page.evaluate(() => {
+            ;(function flatten (root) {
+              const replaceSlot = (slot, nodes) => {
+                const parent = slot.parentNode
+                if (!parent) return
+                for (const node of nodes) parent.insertBefore(node, slot)
+                slot.remove()
+              }
+
+              const flattenNode = node => {
+                if (node.nodeType !== window.Node.ELEMENT_NODE) return
+                if (node.shadowRoot) flattenElement(node)
+                flattenChildren(node)
+              }
+
+              const flattenChildren = root => {
+                for (const el of root.querySelectorAll('*')) {
+                  if (el.shadowRoot) flattenElement(el)
+                  if (el.localName !== 'slot') continue
+
+                  const slot = el
+                  const nodes = slot.assignedNodes({ flatten: true })
+                  if (nodes.length > 0) {
+                    const clones = nodes.map(node => {
+                      flattenNode(node)
+                      return node.cloneNode(true)
+                    })
+
+                    replaceSlot(slot, clones)
+                  } else {
+                    const fallback = [...slot.childNodes]
+                    fallback.forEach(flattenNode)
+                    if (fallback.length > 0) {
+                      replaceSlot(
+                        slot,
+                        fallback.map(n => n.cloneNode(true))
+                      )
+                    } else slot.remove()
+                  }
+                }
+              }
+
+              const flattenElement = el => {
+                flattenChildren(el.shadowRoot)
+                el.innerHTML = el.shadowRoot.innerHTML
+              }
+
+              flattenChildren(root)
+            })(document.body)
+          }),
+          timeout: actionTimeout,
+          debug: 'flattenShadowDOM'
+        })
+
+        if (isRejected) error = error || flattenError || new Error('flattenShadowDOM failed')
       }
 
       return { response, device, error }


### PR DESCRIPTION
page.content() cannot serialize shadow DOM markup. 

The new option `flattenShadowDOM` recursively flattens shadow roots into the light DOM so serialized HTML includes all content. 

Off by default to avoid ~8ms overhead on the 95% of pages that don't use shadow DOM.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling flattenShadowDOM mutates the page DOM and changes default html() output for shadow-heavy sites; goto stays opt-in with closed roots still omitted.
> 
> **Overview**
> Adds **`flattenShadowDOM`** to `@browserless/goto` so navigation can **mutate the live page** after load: open shadow roots are inlined into the light DOM, **slots** are resolved (assigned nodes, fallbacks, or removal when empty), and nested shadow hosts are handled recursively. **Closed** shadow roots are not touched. Failures surface on the existing **`error`** field from `goto`.
> 
> **`browserless.html()`** now passes **`flattenShadowDOM: true`** by default (overridable with `flattenShadowDOM: false`); plain **`goto`** keeps the default **`false`** to avoid extra work on typical pages. Types add the option on **`GotoOptions`** and tighten **`Context.goto`** to **`(page, opts: GotoOptions & { url: string })`**.
> 
> Docs and a new **`shadow-dom`** test suite cover flattening, nesting, slots, and attribute preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe21a9112bcca9fcbaee4d40d06f66ff2d715ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->