### PR TITLE
refactor(goto): use waitForNetworkIdle in waitUntilAuto

### DIFF
--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -228,18 +228,11 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
 
   // related https://github.com/puppeteer/puppeteer/issues/1353
   const _waitUntilAuto = (page, { timeout }) => {
-    return Promise.all(
-      [
-        {
-          fn: () => page.waitForNavigation({ waitUntil: 'networkidle2' }),
-          debug: 'waitUntilAuto:waitForNavigation'
-        },
-        {
-          fn: () => page.evaluate(() => window.history.pushState(null, null, null)),
-          debug: 'waitUntilAuto:pushState'
-        }
-      ].map(({ fn, debug }) => run({ fn: fn(), debug, timeout }))
-    )
+    return run({
+      fn: page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 }),
+      debug: 'waitUntilAuto:networkIdle',
+      timeout
+    })
   }
 
   const goto = async (

--- a/packages/goto/test/index.js
+++ b/packages/goto/test/index.js
@@ -62,6 +62,55 @@ test('handle page disconnections', async t => {
   await intercept('chrome://version')
 })
 
+test('waitUntil auto waits for delayed content', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await runServer(t, ({ req, res }) => {
+    if (req.url === '/data.json') {
+      return setTimeout(() => {
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify({ loaded: true }))
+      }, 300)
+    }
+    res.setHeader('content-type', 'text/html')
+    res.end(`<html><body>
+      <div id="result">waiting</div>
+      <script>
+        fetch('/data.json').then(r => r.json()).then(d => {
+          document.getElementById('result').textContent = d.loaded ? 'done' : 'fail'
+        })
+      </script>
+    </body></html>`)
+  })
+
+  const getText = browserless.evaluate(async (page, response) =>
+    page.evaluate(() => document.getElementById('result').textContent)
+  )
+
+  const text = await getText(url, { waitUntil: 'auto' })
+  t.is(text, 'done')
+})
+
+test('waitUntil auto does not pollute browser history', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end('<html><body><h1>ok</h1></body></html>')
+  })
+
+  const getHistoryLengths = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url, waitUntil: 'load', adblock: false })
+    const withoutAuto = await page.evaluate(() => window.history.length)
+
+    await goto(page, { url, waitUntil: 'auto', adblock: false })
+    const withAuto = await page.evaluate(() => window.history.length)
+
+    return { withoutAuto, withAuto }
+  })
+
+  const { withoutAuto, withAuto } = await getHistoryLengths()
+  t.is(withAuto, withoutAuto)
+})
+
 test('handle page.goto hanging', async t => {
   const browserless = await getBrowserContext(t)
 

--- a/packages/goto/test/unit/wait-until-auto.js
+++ b/packages/goto/test/unit/wait-until-auto.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const test = require('ava')
+const createGoto = require('../../src')
+
+test('waitUntilAuto calls page.waitForNetworkIdle with networkidle2 defaults', async t => {
+  const calls = []
+
+  const page = {
+    waitForNetworkIdle: opts => {
+      calls.push(opts)
+      return Promise.resolve()
+    }
+  }
+
+  const goto = createGoto({ timeout: 10000 })
+  await goto.waitUntilAuto(page, { timeout: 5000 })
+
+  t.is(calls.length, 1)
+  t.deepEqual(calls[0], { idleTime: 500, concurrency: 2 })
+})
+
+test('waitUntilAuto respects timeout', async t => {
+  const page = {
+    waitForNetworkIdle: () => new Promise(resolve => setTimeout(resolve, 10000))
+  }
+
+  const goto = createGoto({ timeout: 10000 })
+  const { isRejected } = await goto.waitUntilAuto(page, { timeout: 50 })
+
+  t.true(isRejected)
+})
+
+test('waitUntilAuto resolves when network becomes idle', async t => {
+  const page = {
+    waitForNetworkIdle: () => Promise.resolve()
+  }
+
+  const goto = createGoto({ timeout: 10000 })
+  const result = await goto.waitUntilAuto(page, { timeout: 5000 })
+
+  t.false(result.isRejected)
+})
+
+test('waitUntilAuto is overridable via goto options', async t => {
+  let customCalled = false
+
+  const goto = createGoto({ timeout: 10000 })
+
+  const noop = () => Promise.resolve()
+  const page = {
+    setViewport: noop,
+    setExtraHTTPHeaders: noop,
+    setUserAgent: noop,
+    emulateMediaFeatures: noop,
+    addStyleTag: noop,
+    goto: () => Promise.resolve(null),
+    waitForNetworkIdle: noop,
+    _client: () => ({ send: noop })
+  }
+
+  await goto(page, {
+    url: 'about:blank',
+    waitUntil: 'auto',
+    adblock: false,
+    waitUntilAuto: async () => {
+      customCalled = true
+    }
+  })
+
+  t.true(customCalled)
+})

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -84,7 +84,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
               quality: 30
             })
             isWhite = await isWhiteScreenshot(screenshot)
-            if (retry === 1) await goto.waitUntilAuto(page, { timeout: opts.timeout })
+            if (isWhite) await goto.waitUntilAuto(page, { timeout: opts.timeout })
             debug('retry', { waitUntil, isWhite, retry, duration: screenshotTime() })
           } while (isWhite && timePdf() < timeout)
 


### PR DESCRIPTION
pushState hack polluted browser history and relied on implicit ordering between waitForNavigation and evaluate. waitForNetworkIdle (Puppeteer 10.2+) does the same with explicit idleTime/concurrency and no side effects.

Also fix pdf retry to wait for network on every white screenshot, not just the second — matching screenshot module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default post-load waiting for `waitUntil: 'auto'` across goto and PDF flows, which can shift timing for dynamic pages but removes history side effects.
> 
> **Overview**
> **`waitUntil: 'auto'`** no longer pairs `waitForNavigation('networkidle2')` with a `history.pushState` workaround. It now waits via **`page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 })`**, still honoring the existing timeout/`run` wrapper, which removes history pollution and implicit race ordering.
> 
> **PDF generation** with `waitUntil: 'auto'` now calls **`goto.waitUntilAuto` on every white screenshot retry** (when `isWhite`), not only on the second attempt—aligned with screenshot behavior so blank renders get more chances to load.
> 
> Coverage adds integration checks (delayed `fetch` DOM updates, stable `history.length`) and unit tests for network-idle options, timeouts, and the **`waitUntilAuto` override** hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7716fbf28e44fca05992a9daef610526b8f84ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->