### PR TITLE
fix: extend auto waituntil timeout

### DIFF
--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -65,5 +65,8 @@
     ],
     "timeout": "2m",
     "workerThreads": false
+  },
+  "peerDependencies": {
+    "puppeteer": "25"
   }
 }

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -538,7 +538,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       }
 
       if (isWaitUntilAuto) {
-        await waitUntilAuto(page, { response, timeout: actionTimeout * 2 })
+        await waitUntilAuto(page, { response, timeout: gotoTimeout })
       }
 
       if (flattenShadowDOM) {

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -34,6 +34,7 @@
     "@browserless/screenshot": "workspace:*",
     "@kikobeats/time-span": "~1.0.12",
     "debug-logfmt": "~1.4.10",
+    "p-reflect": "~2.1.0",
     "pretty-ms": "~7.0.1"
   },
   "engines": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Packaging and timeout tuning only; no auth or data-path changes, though goto auto-wait behavior may differ on slow pages.
> 
> **Overview**
> Declares **`puppeteer` v25** as a peer dependency on `@browserless/goto`, matching its runtime import from `puppeteer` without bundling it as a direct dependency.
> 
> Adds **`p-reflect`** to `@browserless/pdf` because the PDF entrypoint requires it directly.
> 
> For **`waitUntil: 'auto'`**, the post-navigation network-idle wait now uses **`gotoTimeout`** instead of **`actionTimeout * 2`**, so auto-wait shares the same timeout budget as navigation and related waits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bba0d4b8a4bcff568debb0eb9e08e51bad75d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->