### PR TITLE
perf(driver): render WebGL via Mesa llvmpipe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,12 @@ jobs:
           version: latest
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
+      - name: Install GL runtime
+        # libgl1-mesa-dri ships on the ubuntu-24.04 runner; only install (and
+        # refresh the index) on the off chance a future image drops it.
+        run: dpkg -s libgl1-mesa-dri >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y --no-install-recommends libgl1-mesa-dri)
       - name: Test
-        run: pnpm --filter "${{ matrix.package.filter }}" exec c8 pnpm test
+        run: xvfb-run -a pnpm --filter "${{ matrix.package.filter }}" exec c8 pnpm test
       - name: Coverage
         run: pnpm --filter "${{ matrix.package.filter }}" exec c8 report --reporter=lcov --report-dir=coverage
       - name: Upload

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,8 +40,12 @@ jobs:
           version: latest
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
+      - name: Install GL runtime
+        # libgl1-mesa-dri ships on the ubuntu-24.04 runner; only install (and
+        # refresh the index) on the off chance a future image drops it.
+        run: dpkg -s libgl1-mesa-dri >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y --no-install-recommends libgl1-mesa-dri)
       - name: Test
-        run: pnpm --filter "${{ matrix.package.filter }}" exec c8 pnpm test
+        run: xvfb-run -a pnpm --filter "${{ matrix.package.filter }}" exec c8 pnpm test
       - name: Coverage
         run: pnpm --filter "${{ matrix.package.filter }}" exec c8 report --reporter=lcov --report-dir=coverage
       - name: Upload

--- a/packages/browserless/src/driver.js
+++ b/packages/browserless/src/driver.js
@@ -23,16 +23,20 @@ const defaultArgs = [
   '--disk-cache-size=33554432', // https://source.chromium.org/search?q=lang:cpp+symbol:kDiskCacheSize&ss=chromium
   '--font-render-hinting=none', // https://github.com/puppeteer/puppeteer/issues/2410#issuecomment-2886054614
   '--ignore-gpu-blocklist', // https://source.chromium.org/search?q=lang:cpp+symbol:kIgnoreGpuBlocklist&ss=chromium
-  '--in-process-gpu', // https://github.com/search?q=repo%3Achromium%2Fchromium%20in-process-gpu&type=code
   '--no-default-browser-check', // https://source.chromium.org/search?q=lang:cpp+symbol:kNoDefaultBrowserCheck&ss=chromium
   '--no-pings', // https://source.chromium.org/search?q=lang:cpp+symbol:kNoPings&ss=chromium
   '--no-sandbox', // https://source.chromium.org/search?q=lang:cpp+symbol:kNoSandbox&ss=chromium
   '--no-startup-window',
   `--enable-features=${['SharedArrayBuffer'].join(',')}`,
   '--no-zygote', // https://source.chromium.org/search?q=lang:cpp+symbol:kNoZygote&ss=chromium
-  '--disable-gpu',
-  '--use-angle=swiftshader', // https://chromium.googlesource.com/chromium/src/+/main/docs/gpu/swiftshader.md
-  '--use-gl=angle', // https://chromium.googlesource.com/chromium/src/+/main/docs/gpu/swiftshader.md
+  // Route WebGL through ANGLE -> system OpenGL, which resolves to Mesa llvmpipe
+  // (software). On a GPU-less host this renders WebGL ~4x faster than the
+  // SwiftShader fallback (measured: ~7s vs ~30s for a 3D chart). Requires Mesa
+  // (libgl1-mesa-dri) installed and a display (Xvfb) so ANGLE can bind a GL
+  // surface; see .github/workflows for the CI setup. Do NOT add
+  // --disable-gpu/--in-process-gpu: they force the SwiftShader path and disable
+  // the GL surface respectively.
+  '--use-angle=gl', // https://chromium.googlesource.com/angle/angle/+/main/doc/DevSetup.md
   `--disable-features=${[
     'AudioServiceOutOfProcess',
     'CalculateNativeWinOcclusion',

--- a/packages/goto/test/unit/evasions/index.js
+++ b/packages/goto/test/unit/evasions/index.js
@@ -8,6 +8,16 @@ const isCI = !!process.env.CI
 
 const fileUrl = `file://${path.join(__dirname, '../../fixtures/dummy.html')}`
 
+const readWebGL = (page, type) =>
+  page.evaluate(type => {
+    const ctx = document.createElement('canvas').getContext(type)
+    const debugInfo = ctx.getExtension('WEBGL_debug_renderer_info')
+    return {
+      vendor: ctx.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL),
+      renderer: ctx.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
+    }
+  }, type)
+
 test('`window.Notification` is not defined', async t => {
   const page = await getPage(t)
   t.is((await page.evaluate('typeof window.Notification'), undefined))
@@ -165,60 +175,39 @@ test('media codecs are present', async t => {
 
 test('webgl vendor is not bot', async t => {
   const page = await getPage(t)
-
-  const webgl = () =>
-    page.evaluate(() => {
-      const canvas = document.createElement('canvas')
-      const ctx = canvas.getContext('webgl')
-      const debugInfo = ctx.getExtension('WEBGL_debug_renderer_info')
-      return {
-        vendor: ctx.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL),
-        renderer: ctx.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
-      }
-    })
-
-  const expected = isCI
-    ? {
-        vendor: 'Google Inc. (Google)',
-        renderer:
-        'ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)'
-      }
-    : {
-        vendor: 'Google Inc. (Google)',
-        renderer:
-        'ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)'
-      }
-
-  t.deepEqual(await webgl(), expected)
+  const { vendor } = await readWebGL(page, 'webgl')
+  t.true(vendor.startsWith('Google Inc.'))
 })
 
 test('webgl2 vendor is not bot', async t => {
   const page = await getPage(t)
+  const { vendor } = await readWebGL(page, 'webgl2')
+  t.true(vendor.startsWith('Google Inc.'))
+})
 
-  const webgl2 = () =>
-    page.evaluate(() => {
-      const canvas = document.createElement('canvas')
-      const ctx = canvas.getContext('webgl2')
-      const debugInfo = ctx.getExtension('WEBGL_debug_renderer_info')
-      return {
-        vendor: ctx.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL),
-        renderer: ctx.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
-      }
-    })
+test('webgl renderer goes through ANGLE (Mesa llvmpipe on CI)', async t => {
+  const page = await getPage(t)
 
-  const expected = isCI
-    ? {
-        vendor: 'Google Inc. (Google)',
-        renderer:
-        'ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)'
-      }
-    : {
-        vendor: 'Google Inc. (Google)',
-        renderer:
-        'ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)'
-      }
+  for (const type of ['webgl', 'webgl2']) {
+    const { vendor, renderer } = await readWebGL(page, type)
 
-  t.deepEqual(await webgl2(), expected)
+    // Portable: WebGL must go through ANGLE, never a SwiftShader / 2D fallback.
+    t.true(vendor.startsWith('Google Inc.'), `${type}: ${vendor}`)
+    t.true(renderer.startsWith('ANGLE ('), `${type}: ${renderer}`)
+    t.false(renderer.includes('SwiftShader'), `${type}: ${renderer}`)
+
+    // --use-angle=gl binds to the host's system GL: Mesa llvmpipe on the
+    // GPU-less Linux target (CI under Xvfb), but native GL on macOS/Windows or
+    // hardware-accelerated hosts. Pin the whole llvmpipe string only on CI; the
+    // `LLVM x.y.z N bits` token tracks the runner's Mesa/LLVM build so it is
+    // normalized out, and everything else is compared exactly.
+    if (isCI) {
+      const expected = 'ANGLE (Mesa, llvmpipe (LLVM <llvm>), OpenGL 4.5)'
+      const normalized = renderer.replace(/LLVM [\d.]+ \d+ bits/, 'LLVM <llvm>')
+      t.is(vendor, 'Google Inc. (Mesa)', type)
+      t.is(normalized, expected, `${type}: ${renderer}`)
+    }
+  }
 })
 
 test('broken images have dimensions', async t => {

--- a/packages/screencast/test/index.js
+++ b/packages/screencast/test/index.js
@@ -21,10 +21,24 @@ test('capture frames', async t => {
     frames.push({ data, metadata })
   })
 
-  screencast.start()
-  await page.goto('https://example.com', { waitUntil: 'domcontentloaded' })
+  await screencast.start()
+  await page.goto('https://example.com', { waitUntil: 'load' })
+
+  // Page.startScreencast emits a frame per compositor commit. Under the GL
+  // backend a fully static page may not commit again after the initial paint,
+  // so drive a visual change each tick to force commits and poll until the
+  // screencast captures at least one frame.
+  const deadline = Date.now() + 5000
+  while (frames.length === 0 && Date.now() < deadline) {
+    await page.evaluate(() => {
+      document.body.style.background = `hsl(${Date.now() % 360}, 50%, 50%)`
+    })
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
+
   await screencast.stop()
 
+  t.true(frames.length > 0)
   frames.forEach(({ data, metadata }) => {
     t.truthy(data)
     t.is(typeof metadata, 'object')

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -52,8 +52,7 @@
   },
   "devDependencies": {
     "@browserless/test": "workspace:*",
-    "ava": "5",
-    "cheerio": "latest"
+    "ava": "5"
   },
   "engines": {
     "node": ">= 24"

--- a/packages/screenshot/test/index.js
+++ b/packages/screenshot/test/index.js
@@ -2,7 +2,6 @@
 
 const { getBrowserContext, runServer } = require('@browserless/test')
 const createScreenshot = require('..')
-const cheerio = require('cheerio')
 const test = require('ava')
 
 const isCI = !!process.env.CI
@@ -10,64 +9,35 @@ const isCI = !!process.env.CI
 test('graphics features', async t => {
   const browserless = await getBrowserContext(t)
 
-  const getGpu = browserless.withPage(page => async () => {
-    await page.goto('chrome://gpu/')
-
-    const html = await page.evaluate(() => document.querySelector('info-view').shadowRoot.innerHTML)
-    await page.close()
-
-    const $ = cheerio.load(html)
-
-    const props = []
-
-    $('#content div:first li').each((_, element) => {
-      const key = $(element).find('span:eq(2)').text().trim().slice(0, -1)
-      const value = $(element).find('span:eq(3)').text().trim()
-      props.push([key, value])
+  // Assert real WebGL capability rather than the chrome://gpu feature-status
+  // strings: those vary wildly by Mesa/LLVM version and host (e.g. CI labels
+  // WebGL "Disabled" while it still renders through ANGLE), so they don't
+  // reflect actual capability. A live getContext + ANGLE renderer does.
+  const getWebGL = browserless.withPage(page => async () => {
+    const result = await page.evaluate(() => {
+      const ctx = document.createElement('canvas').getContext('webgl')
+      if (!ctx) return null
+      const dbg = ctx.getExtension('WEBGL_debug_renderer_info')
+      return {
+        vendor: ctx.getParameter(dbg.UNMASKED_VENDOR_WEBGL),
+        renderer: ctx.getParameter(dbg.UNMASKED_RENDERER_WEBGL)
+      }
     })
-
-    return Object.fromEntries(props)
+    await page.close()
+    return result
   })
 
-  t.deepEqual(
-    await getGpu(),
-    isCI
-      ? {
-          Canvas: 'Hardware accelerated',
-          'Direct Rendering Display Compositor': 'Disabled',
-          Compositing: 'Software only. Hardware acceleration disabled',
-          'Multiple Raster Threads': 'Enabled',
-          OpenGL: 'Enabled',
-          Rasterization: 'Hardware accelerated',
-          'Raw Draw': 'Disabled',
-          'Skia Graphite': 'Disabled',
-          TreesInViz: 'Enabled',
-          'Video Decode': 'Hardware accelerated',
-          'Video Encode': 'Software only. Hardware acceleration disabled',
-          Vulkan: 'Disabled',
-          WebGL: 'Hardware accelerated but at reduced performance',
-          WebGPU: 'Software only, hardware acceleration unavailable',
-          'WebGPU interop': 'Disabled',
-          WebNN: 'Disabled'
-        }
-      : {
-          Canvas: 'Hardware accelerated',
-          'Direct Rendering Display Compositor': 'Disabled',
-          Compositing: 'Software only. Hardware acceleration disabled',
-          'Multiple Raster Threads': 'Enabled',
-          OpenGL: 'Enabled',
-          Rasterization: 'Hardware accelerated',
-          'Raw Draw': 'Disabled',
-          'Skia Graphite': 'Disabled',
-          TreesInViz: 'Disabled',
-          'Video Decode': 'Hardware accelerated',
-          'Video Encode': 'Hardware accelerated',
-          WebGL: 'Hardware accelerated but at reduced performance',
-          WebGPU: 'Software only, hardware acceleration unavailable',
-          'WebGPU interop': 'Disabled',
-          WebNN: 'Disabled'
-        }
-  )
+  const webgl = await getWebGL()
+  t.truthy(webgl)
+  t.true(webgl.vendor.startsWith('Google Inc.'))
+  // Portable: WebGL must go through ANGLE, never a silent SwiftShader / 2D
+  // fallback. The message surfaces the real renderer if the backend changes.
+  t.true(webgl.renderer.startsWith('ANGLE ('), webgl.renderer)
+  t.false(webgl.renderer.includes('SwiftShader'), webgl.renderer)
+  // --use-angle=gl resolves to Mesa llvmpipe only on the GPU-less Linux target
+  // (CI under Xvfb); on macOS/Windows/hardware GL the backend differs but is
+  // still valid, so pin llvmpipe only on CI.
+  if (isCI) t.true(webgl.renderer.includes('llvmpipe'), webgl.renderer)
 })
 
 test('dialog listener is cleaned up between screenshot calls on same page', async t => {


### PR DESCRIPTION
Swap the SwiftShader fallback for ANGLE -> system GL (--use-angle=gl), which resolves to Mesa llvmpipe. On GPU-less hosts this renders WebGL ~4x faster (measured ~7s vs ~30s for a 3D chart).

Requires Mesa (libgl1-mesa-dri) and an X display (Xvfb) so ANGLE can bind a GL surface; without one, WebGL silently falls back to a 2D view. Drops --disable-gpu/--in-process-gpu, which force SwiftShader and kill the GL surface respectively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default browser launch behavior changes for all consumers: headless Linux without Mesa/Xvfb may get weaker WebGL or 2D fallbacks instead of SwiftShader, while CI and local dev assumptions shift.
> 
> **Overview**
> Switches default Chromium launch flags from the SwiftShader stack (`--disable-gpu`, `--use-angle=swiftshader`, `--in-process-gpu`) to **`--use-angle=gl`**, routing WebGL through ANGLE → system OpenGL (Mesa llvmpipe on GPU-less Linux) for much faster software WebGL. Comments in `driver.js` document that Mesa and a display (e.g. Xvfb) are required so ANGLE can bind a GL surface.
> 
> **CI** (`main.yml`, `pull_request.yml`) conditionally ensures `libgl1-mesa-dri` is present and runs tests under **`xvfb-run`**.
> 
> **Tests** stop asserting brittle `chrome://gpu` strings or exact SwiftShader renderer text. They now check live WebGL/WebGL2 via ANGLE (no SwiftShader), with CI-only checks for Mesa llvmpipe. **Screencast** tests await `start()`, use `waitUntil: 'load'`, and animate the page until at least one frame is captured under the GL compositor. **screenshot** drops the unused `cheerio` devDependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd772aad93ea166192339f5371c877b7da99b971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->