### PR TITLE
fix: retry on 'Execution context was destroyed' navigation error

### DIFF
--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -61,7 +61,8 @@ browserlessError.ensureError = rawError => {
       'Protocol error (Target.createBrowserContext): Target closed'
     ].some(message => errorMessage.startsWith(message)) ||
     errorMessage.includes('Session closed') ||
-    errorMessage.includes('Attempted to use detached Frame')
+    errorMessage.includes('Attempted to use detached Frame') ||
+    errorMessage.includes('Execution context was destroyed')
   ) {
     return browserlessError.contextDisconnected()
   }

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -112,6 +112,16 @@ test('contextDisconnected from "Attempted to use detached Frame"', t => {
   t.is(error.code, 'EBRWSRCONTEXTCONNRESET')
 })
 
+test('contextDisconnected from "Execution context was destroyed"', t => {
+  const error = errors.ensureError({
+    message: 'Execution context was destroyed, most likely because of a navigation.'
+  })
+
+  t.true(error instanceof Error)
+  t.is(error.name, 'BrowserlessError')
+  t.is(error.code, 'EBRWSRCONTEXTCONNRESET')
+})
+
 test('ensureError handles non-object input', t => {
   const errorFromString = errors.ensureError('boom')
   t.true(errorFromString instanceof Error)


### PR DESCRIPTION
This Puppeteer error is a transient navigation race (same family as 'Session closed' / 'detached Frame'). It was left unclassified, so it surfaced as an unexpected EFATAL/500 instead of retrying.

Classify it as contextDisconnected (EBRWSRCONTEXTCONNRESET) so withPage retries it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error-string classification in `@browserless/errors`; no auth, data, or API surface changes beyond enabling existing retry behavior.
> 
> **Overview**
> Treats Puppeteer’s **“Execution context was destroyed”** message like other transient navigation races (**Session closed**, detached frame) by mapping it to **`contextDisconnected`** (`EBRWSRCONTEXTCONNRESET`) in `ensureError`.
> 
> That lets **`withPage`** retry instead of surfacing an unclassified fatal/500. Adds an AVA test for this message shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cea75fe22b1a402665eff0e21fcc4b191275177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->