### PR TITLE
fix: avoid 'response.status is not a function' on goto timeout

### DIFF
--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -22,6 +22,8 @@ const getTargetId = async page => {
   }
 }
 
+const isHttpResponse = response => response != null && typeof response.status === 'function'
+
 const serializeResponse = response => ({
   status: response.status(),
   statusText: response.statusText(),
@@ -78,7 +80,7 @@ module.exports = ({ tmpdir } = {}) => {
           device,
           ...opts,
           ...fnOpts,
-          ...(response && { _response: serializeResponse(response) })
+          ...(isHttpResponse(response) && { _response: serializeResponse(response) })
         }
 
         if (runFunctionOpts.code === code) {
@@ -134,3 +136,6 @@ module.exports = ({ tmpdir } = {}) => {
 
   return createFunction
 }
+
+module.exports.isHttpResponse = isHttpResponse
+module.exports.serializeResponse = serializeResponse

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -784,3 +784,19 @@ test('concurrent page functions return the correct page for each request', async
     t.is(results[i].value, urls[i], `request ${i} should return its own URL`)
   }
 })
+
+test('isHttpResponse rejects non-response values', t => {
+  const { isHttpResponse } = require('..')
+
+  // a real puppeteer HTTPResponse exposes `status` as a method
+  t.true(isHttpResponse({ status: () => 200 }))
+
+  // goto can yield no navigation response (timeout / same-document nav)
+  t.false(isHttpResponse(null))
+  t.false(isHttpResponse(undefined))
+
+  // a `p-reflect` settlement object must NOT be treated as a response:
+  // it is truthy but `status` is not callable, which used to crash
+  // serializeResponse with "response.status is not a function"
+  t.false(isHttpResponse({ isFulfilled: true, isRejected: false, value: undefined }))
+})

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -64,7 +64,10 @@ const stopLoadingOnTimeout = (page, timeout) => {
   return {
     promise: new Promise(resolve => {
       timeoutId = globalThis.setTimeout(() => {
-        pReflect(page._client().send('Page.stopLoading')).then(resolve)
+        // resolve with `undefined` (no navigation response): `pReflect` would
+        // otherwise leak its `{ isFulfilled, value, ... }` settlement object as
+        // the race winner, which downstream treats as an HTTPResponse.
+        pReflect(page._client().send('Page.stopLoading')).then(() => resolve())
       }, timeout)
 
       if (typeof timeoutId.unref === 'function') timeoutId.unref()

--- a/packages/goto/test/index.js
+++ b/packages/goto/test/index.js
@@ -122,6 +122,25 @@ test('handle page.goto hanging', async t => {
   t.true(html.includes('<body></body>'))
 })
 
+test('goto timeout resolves response as undefined (not a settlement object)', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await runServer(t, () => {
+    // accept the connection but never send headers/body: page.goto gets no
+    // navigation response, so stopLoadingOnTimeout wins the race on timeout
+    return new Promise(() => {})
+  })
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const { response } = await goto(page, { url, timeout: 1500, adblock: false })
+    return response
+  })
+
+  const response = await run()
+  // on timeout there is no navigation response: must be falsy, never the
+  // `{ isFulfilled, value, ... }` object that `pReflect` would otherwise leak
+  t.falsy(response)
+})
+
 test('abortTypes keeps behavior with duplicated resource types', async t => {
   const browserless = await getBrowserContext(t)
   const url = await runServer(t, ({ res }) => {


### PR DESCRIPTION
When a navigation times out, stopLoadingOnTimeout won the goto race and leaked p-reflect's settlement object ({ isFulfilled, value, ... }) as the response. Downstream @browserless/function treated it as an HTTPResponse and crashed in serializeResponse with 'response.status is not a function', surfacing as an unexpected EFATAL/500 for otherwise valid function= calls.

- goto: resolve the timeout branch with undefined (no navigation response), matching the HTTPResponse|null contract consumers already guard for
- function: only serialize real HTTPResponse objects (isHttpResponse guard)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core navigation timeout and function response serialization paths; behavior change is intentional (undefined vs leaked object) but affects all timed-out navigations used by page functions.
> 
> **Overview**
> Fixes **EFATAL/500** on `function=` calls when navigation times out: the timeout branch no longer surfaces a **`p-reflect` settlement object** as `goto`’s `response`.
> 
> In **`@browserless/goto`**, `stopLoadingOnTimeout` now resolves the race with **`undefined`** (after `Page.stopLoading`) instead of the `{ isFulfilled, value, … }` object from `pReflect`, matching the expected **HTTPResponse | null/undefined** contract.
> 
> In **`@browserless/function`**, `_response` is only passed through **`serializeResponse`** when **`isHttpResponse`** is true (callable `status`), so stray truthy values cannot crash with **`response.status is not a function`**. Helpers are exported for tests; goto and function packages add regression tests for timeout and settlement-object cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2773b5673856407c5eff686bae86749adc4961f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->