### PR TITLE
fix: retry capture in-place on navigation race

### DIFF
--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -82,3 +82,36 @@ test('waitUntil auto should honor custom waitForDom', async t => {
 
   t.deepEqual(domStabilityArgs, { timeout: 2500, idle: 250 })
 })
+
+test('retries pdf generation when navigation destroys the execution context', async t => {
+  let pdfCalls = 0
+  let waitUntilAutoCalls = 0
+
+  const page = {
+    screenshot: async () => noWhiteScreenshot,
+    evaluate: async () => ({ status: 'idle' }),
+    pdf: async () => {
+      if (pdfCalls++ === 0) {
+        throw new Error('Execution context was destroyed, most likely because of a navigation.')
+      }
+      return Buffer.from('pdf-ok')
+    }
+  }
+
+  const goto = async (page, opts = {}) => {
+    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
+    return { response: {} }
+  }
+
+  goto.timeouts = { action: () => 100000 }
+  goto.waitUntilAuto = async () => {
+    waitUntilAutoCalls += 1
+  }
+
+  const pdf = createPdf({ goto })(page)
+  const buffer = await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
+
+  t.deepEqual(buffer, Buffer.from('pdf-ok'))
+  t.is(pdfCalls, 2)
+  t.is(waitUntilAutoCalls, 1)
+})

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -45,6 +45,30 @@ browserlessError.contextDisconnected = createBrowserlessError({
   message: 'The browser context is not connected.'
 })
 
+const getErrorMessage = rawError => {
+  const error = isObject(rawError) && 'error' in rawError ? rawError.error : rawError
+  if (typeof error === 'string') return error
+  return isObject(error) && typeof error.message === 'string' ? error.message : ''
+}
+
+// Whether the error means the page navigated away (the execution context /
+// browser context was torn down mid-operation). These are transient on SPAs
+// that navigate client-side: waiting for navigation to settle and retrying the
+// operation in-place typically succeeds.
+const isContextDestroyed = rawError => {
+  const errorMessage = getErrorMessage(rawError)
+  return (
+    [
+      'Protocol error (Target.createTarget): Failed to find browser context with id',
+      'Protocol error (Target.createTarget): Target closed',
+      'Protocol error (Target.createBrowserContext): Target closed'
+    ].some(message => errorMessage.startsWith(message)) ||
+    errorMessage.includes('Session closed') ||
+    errorMessage.includes('Attempted to use detached Frame') ||
+    errorMessage.includes('Execution context was destroyed')
+  )
+}
+
 browserlessError.ensureError = rawError => {
   if (isObject(rawError) && rawError.__parsed) return rawError
 
@@ -54,16 +78,7 @@ browserlessError.ensureError = rawError => {
 
   const errorMessage = isObject(error) && typeof error.message === 'string' ? error.message : ''
 
-  if (
-    [
-      'Protocol error (Target.createTarget): Failed to find browser context with id',
-      'Protocol error (Target.createTarget): Target closed',
-      'Protocol error (Target.createBrowserContext): Target closed'
-    ].some(message => errorMessage.startsWith(message)) ||
-    errorMessage.includes('Session closed') ||
-    errorMessage.includes('Attempted to use detached Frame') ||
-    errorMessage.includes('Execution context was destroyed')
-  ) {
+  if (isContextDestroyed(error)) {
     return browserlessError.contextDisconnected()
   }
 
@@ -92,3 +107,4 @@ const isBrowserlessError = error => error.name === ERROR_NAME
 
 module.exports = browserlessError
 module.exports.isBrowserlessError = isBrowserlessError
+module.exports.isContextDestroyed = isContextDestroyed

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -122,6 +122,34 @@ test('contextDisconnected from "Execution context was destroyed"', t => {
   t.is(error.code, 'EBRWSRCONTEXTCONNRESET')
 })
 
+test('isContextDestroyed', t => {
+  t.true(
+    errors.isContextDestroyed({
+      message: 'Execution context was destroyed, most likely because of a navigation.'
+    })
+  )
+  t.true(
+    errors.isContextDestroyed({ message: 'Session closed. Most likely the page has been closed.' })
+  )
+  t.true(errors.isContextDestroyed({ message: "Attempted to use detached Frame 'BF1'." }))
+  t.true(
+    errors.isContextDestroyed({
+      message: 'Protocol error (Target.createTarget): Target closed'
+    })
+  )
+  t.true(
+    errors.isContextDestroyed(
+      'Execution context was destroyed, most likely because of a navigation.'
+    )
+  )
+  t.true(errors.isContextDestroyed({ error: { message: 'Execution context was destroyed' } }))
+
+  t.false(errors.isContextDestroyed({ message: 'Evaluation failed: boom' }))
+  t.false(errors.isContextDestroyed({ message: 'Navigation timeout of 30000 ms exceeded' }))
+  t.false(errors.isContextDestroyed('boom'))
+  t.false(errors.isContextDestroyed(null))
+})
+
 test('ensureError handles non-object input', t => {
   const errorFromString = errors.ensureError('boom')
   t.true(errorFromString instanceof Error)

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -3,6 +3,7 @@
 const timeSpan = require('@kikobeats/time-span')({ format: n => Math.round(n) })
 const pReflect = require('p-reflect')
 const {
+  captureWithNavigationRetry,
   isWhiteScreenshot,
   waitForDomStability,
   resolveWaitForDom,
@@ -41,12 +42,16 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       const waitForDomOpts = resolveWaitForDom(waitForDom)
 
       const generatePdf = page =>
-        page.pdf({
-          ...opts,
-          margin: getMargin(margin),
-          printBackground,
-          scale
-        })
+        captureWithNavigationRetry(
+          () =>
+            page.pdf({
+              ...opts,
+              margin: getMargin(margin),
+              printBackground,
+              scale
+            }),
+          { page, goto, timeout: goto.timeouts.action(opts.timeout) }
+        )
 
       const waitForDomStabilityResult = async page => {
         if (!waitForDomOpts) return
@@ -77,12 +82,16 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
           do {
             ++retry
             const screenshotTime = timeSpan()
-            const screenshot = await page.screenshot({
-              ...opts,
-              optimizeForSpeed: true,
-              type: 'jpeg',
-              quality: 30
-            })
+            const screenshot = await captureWithNavigationRetry(
+              () =>
+                page.screenshot({
+                  ...opts,
+                  optimizeForSpeed: true,
+                  type: 'jpeg',
+                  quality: 30
+                }),
+              { page, goto, timeout }
+            )
             isWhite = await isWhiteScreenshot(screenshot)
             if (isWhite) await goto.waitUntilAuto(page, { timeout: opts.timeout })
             debug('retry', { waitUntil, isWhite, retry, duration: screenshotTime() })

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -32,6 +32,7 @@
     "web-capture"
   ],
   "dependencies": {
+    "@browserless/errors": "workspace:*",
     "@browserless/goto": "workspace:*",
     "@kikobeats/content-type": "~1.0.4",
     "@kikobeats/time-span": "~1.0.12",

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const debug = require('debug-logfmt')('browserless:screenshot')
+const { isContextDestroyed } = require('@browserless/errors')
 const createGoto = require('@browserless/goto')
 const pReflect = require('p-reflect')
 
@@ -10,9 +11,24 @@ const timeSpan = require('./time-span')
 const overlay = require('./overlay')
 const { waitForDomStability, resolveWaitForDom, DEFAULT_WAIT_FOR_DOM } = require('./wait-for-dom')
 
-const createElapsed = () => {
-  const start = Date.now()
-  return () => Date.now() - start
+const timeSpanMs = require('@kikobeats/time-span')()
+
+// Retry a page capture (screenshot/pdf) that races with a client-side
+// navigation. When the execution context is destroyed mid-capture, the page is
+// navigating: wait for it to settle via `waitUntilAuto` and retry in-place,
+// bounded by `timeout`, rather than failing the whole request. SPAs (e.g.
+// scribd) navigate client-side after load, so the initial capture often races.
+const captureWithNavigationRetry = async (capture, { page, goto, timeout }) => {
+  const elapsed = timeSpanMs()
+  while (true) {
+    try {
+      return await capture()
+    } catch (error) {
+      if (!isContextDestroyed(error) || elapsed() >= timeout) throw error
+      debug('captureWithNavigationRetry', { error: error.message })
+      await goto.waitUntilAuto(page, { timeout })
+    }
+  }
 }
 
 const getPageSnapshot = page =>
@@ -170,13 +186,17 @@ module.exports = ({ goto, ...gotoOpts }) => {
 
       const takeScreenshot = async opts => {
         const timeout = goto.timeouts.action(opts.timeout)
-        const elapsed = createElapsed()
+        const elapsed = timeSpanMs()
         let retry = 0
         let isWhite = false
         let isReady = false
 
         do {
-          screenshot = await page.screenshot(opts)
+          screenshot = await captureWithNavigationRetry(() => page.screenshot(opts), {
+            page,
+            goto,
+            timeout
+          })
           isWhite = await isWhiteScreenshot(screenshot)
           const snapshotResult = await pReflect(getPageSnapshot(page))
           const pageSnapshot = snapshotResult.isRejected ? {} : snapshotResult.value
@@ -210,7 +230,10 @@ module.exports = ({ goto, ...gotoOpts }) => {
         if (waitUntil !== 'auto') {
           ;({ response } = await goto(page, { ...opts, url, waitUntil }))
           const screenshotOpts = await beforeScreenshot(page, response, opts)
-          screenshot = await page.screenshot({ ...opts, ...screenshotOpts })
+          screenshot = await captureWithNavigationRetry(
+            () => page.screenshot({ ...opts, ...screenshotOpts }),
+            { page, goto, timeout: goto.timeouts.action(opts.timeout) }
+          )
           debug('screenshot', { waitUntil, duration: timeScreenshot() })
         } else {
           ;({ response } = await goto(page, { ...opts, url, waitUntil, waitUntilAuto }))
@@ -242,6 +265,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
   }
 }
 
+module.exports.captureWithNavigationRetry = captureWithNavigationRetry
 module.exports.isWhiteScreenshot = isWhiteScreenshot
 module.exports.waitForDomStability = waitForDomStability
 module.exports.resolveWaitForDom = resolveWaitForDom

--- a/packages/screenshot/test/white-retry.js
+++ b/packages/screenshot/test/white-retry.js
@@ -89,6 +89,49 @@ const createPage = (screenshots, { pageSnapshots = [] } = {}) => {
   }
 }
 
+test('retries capture when navigation destroys the execution context', async t => {
+  const isWhiteScreenshotMock = async () => false
+  const { createScreenshot, restore } = loadCreateScreenshot(isWhiteScreenshotMock)
+  t.teardown(restore)
+
+  const goto = createGoto()
+  const page = createPage([])
+
+  // first capture races with a client-side navigation, second succeeds
+  let calls = 0
+  page.screenshot = async () => {
+    if (calls++ === 0) {
+      throw new Error('Execution context was destroyed, most likely because of a navigation.')
+    }
+    return Buffer.from('shot-ok')
+  }
+
+  const screenshot = createScreenshot({ goto })(page)
+  const result = await screenshot('https://example.com', { waitUntil: 'auto', codeScheme: false })
+
+  t.deepEqual(result, Buffer.from('shot-ok'))
+  t.is(calls, 2)
+  t.is(goto.getWaitUntilAutoCalls(), 1)
+})
+
+test('does not retry capture on a non-navigation error', async t => {
+  const isWhiteScreenshotMock = async () => false
+  const { createScreenshot, restore } = loadCreateScreenshot(isWhiteScreenshotMock)
+  t.teardown(restore)
+
+  const goto = createGoto()
+  const page = createPage([])
+  page.screenshot = async () => {
+    throw new Error('boom')
+  }
+
+  const screenshot = createScreenshot({ goto })(page)
+  await t.throwsAsync(screenshot('https://example.com', { waitUntil: 'auto', codeScheme: false }), {
+    message: 'boom'
+  })
+  t.is(goto.getWaitUntilAutoCalls(), 0)
+})
+
 test('retries white screenshots until non-white image', async t => {
   const responses = [true, true, false]
   const isWhiteScreenshotMock = async () => responses.shift() ?? false


### PR DESCRIPTION
Following #793, 'Execution context was destroyed' is classified as EBRWSRCONTEXTCONNRESET so withPage retries it. But withPage retries by recreating the browser context and re-navigating from scratch, which for client-side SPAs (e.g. scribd) re-triggers the very navigation that destroyed the context — so all attempts race and exhaust, surfacing as an unexpected EFATAL/500 (~1.1k/week in production).

Add captureWithNavigationRetry: when the final capture (page.pdf / page.screenshot) throws a context-destroyed error, wait for the in-flight navigation to settle via waitUntilAuto and retry the capture in-place on the already-loaded page, bounded by the action timeout. This is a cheaper, more effective first rung before withPage's full context recreation.

Detection is centralized in a new errors.isContextDestroyed predicate (reused by ensureError) so screenshot/pdf share one source of truth.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core screenshot/PDF capture error handling for production traffic (~1.1k/week failures cited); bounded retries should reduce false 500s but could extend request duration near the action timeout on repeatedly racing navigations.
> 
> **Overview**
> Adds **`captureWithNavigationRetry`** so `page.screenshot` and `page.pdf` can recover when a client-side navigation tears down the execution context mid-capture. On those errors it calls **`waitUntilAuto`** on the current page and retries the same capture until the action timeout, instead of failing immediately and forcing **`withPage`** to recreate the browser context and reload (which often re-triggers the same SPA navigation).
> 
> **`errors.isContextDestroyed`** centralizes detection of navigation/context teardown messages (including string and nested `{ error }` shapes) and is reused by **`ensureError`** and the capture retry loop. PDF and screenshot paths wrap their final captures (and PDF’s white-check JPEG screenshots) with this helper; **`@browserless/screenshot`** now depends on **`@browserless/errors`**.
> 
> Tests cover successful in-place retry, no retry on unrelated errors, and PDF behavior when **`page.pdf`** fails once with “Execution context was destroyed”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d132fbdd8bf85007b598768f2496af32fee3e24b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->