### PR TITLE
fix(lighthouse): retry context teardown masked as perf-mark error

### DIFF
--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -32,6 +32,7 @@
     "web-vitals"
   ],
   "dependencies": {
+    "@browserless/errors": "workspace:*",
     "lighthouse": "~13.4.0"
   },
   "devDependencies": {

--- a/packages/lighthouse/src/lighthouse.js
+++ b/packages/lighthouse/src/lighthouse.js
@@ -1,8 +1,26 @@
 'use strict'
 
+const errors = require('@browserless/errors')
 const lighthouse = require('lighthouse/core/index.cjs')
 
+// Lighthouse instruments each phase with performance marks (via marky). When
+// the browser context is torn down mid-run, lighthouse's teardown calls
+// `performance.measure` for a phase whose start mark never fired, throwing a
+// `SyntaxError: The "start lh:…" performance mark has not been set`. That
+// message masks the real cause (a destroyed context), so it would otherwise
+// escape the retry machinery as an opaque error. Map it back to a
+// context-disconnected error to let `withPage` recreate the context and retry.
+const isPerfMarkError = error =>
+  error?.message?.endsWith('performance mark has not been set') ?? false
+
 module.exports = async ({ url, config, flags, page }) => {
-  const { lhr, report } = await lighthouse(url, flags, config, page)
-  return config.settings.output === 'json' ? lhr : report
+  try {
+    const { lhr, report } = await lighthouse(url, flags, config, page)
+    return config.settings.output === 'json' ? lhr : report
+  } catch (error) {
+    if (isPerfMarkError(error)) throw errors.contextDisconnected()
+    throw error
+  }
 }
+
+module.exports.isPerfMarkError = isPerfMarkError

--- a/packages/lighthouse/test/lighthouse.js
+++ b/packages/lighthouse/test/lighthouse.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const test = require('ava')
+
+const { isPerfMarkError } = require('../src/lighthouse')
+const errors = require('@browserless/errors')
+
+test('isPerfMarkError detects marky teardown errors', t => {
+  const error = new SyntaxError('The "start lh:runner:gather" performance mark has not been set')
+  t.true(isPerfMarkError(error))
+})
+
+test('isPerfMarkError ignores unrelated errors', t => {
+  t.false(isPerfMarkError(new Error('boom')))
+  t.false(isPerfMarkError(undefined))
+  t.false(isPerfMarkError({}))
+})
+
+test('contextDisconnected is retryable by withPage', t => {
+  // the error perf-mark failures are mapped to must carry the code withPage's
+  // pRetry treats as retryable, so the context is recreated and the run retried
+  const error = errors.contextDisconnected()
+  t.is(error.code, 'EBRWSRCONTEXTCONNRESET')
+})


### PR DESCRIPTION
## Problem

When the browser context is torn down mid-run (e.g. CPU-saturation context drops, the same root cause behind production `EBRWSRCONTEXTCONNRESET` spikes), lighthouse's marky instrumentation tears down by calling `performance.measure` for a phase whose **start** mark never fired. Node throws:

```
SyntaxError: The "start lh:runner:gather" performance mark has not been set
```

That message **masks the real cause** (a destroyed context). Because it isn't recognized as a context-teardown error, it escapes the retry machinery entirely and surfaces as:

- a misleading **500 / `EFATAL`** for the whole request, and
- **Sentry noise** — production showed it fragmented across five separate phantom issue groups (`lh:runner:gather`, `lh:driver:navigate`, `lh:gather:getBenchmarkIndex`, `lh:driver:connect`, `lh:prepare:navigationMode`).

Note: #799 does **not** cover this path — it wraps only `page.screenshot` / `page.pdf` captures, and its `isContextDestroyed` predicate never sees the masked `SyntaxError`.

## Fix

In `@browserless/lighthouse`, catch the run and, when the failure is the marky perf-mark `SyntaxError`, rethrow `errors.contextDisconnected()` (code `EBRWSRCONTEXTCONNRESET`). That code is already retryable by `withPage`'s `pRetry`, so the context is recreated and the run retried.

**Net effect:** transient teardowns recover via retry; the misleading `SyntaxError` issue groups disappear; genuinely persistent failures get correctly attributed to `EBRWSRCONTEXTCONNRESET` instead of five phantom groups.

## Tests

- `isPerfMarkError` detects the marky teardown message and ignores unrelated errors.
- Asserts the mapped error carries the `EBRWSRCONTEXTCONNRESET` code `withPage` retries on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling in the Lighthouse package with no auth or data changes; behavior only improves recovery on transient context drops.
> 
> **Overview**
> When a Lighthouse run loses its browser context mid-flight, marky teardown can surface a misleading `SyntaxError` about an unset performance mark instead of a disconnect. That error bypassed `withPage` retry and showed up as opaque 500s and fragmented Sentry noise.
> 
> The Lighthouse wrapper now catches that pattern and rethrows `errors.contextDisconnected()` (`EBRWSRCONTEXTCONNRESET`), which `withPage` already treats as retryable. **`@browserless/errors`** is added as a dependency, **`isPerfMarkError`** is exported for tests, and unit tests cover detection and the retry code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50963660b0fde512a2c4261e4c2f3f70623532be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->