### PR TITLE
feat(capture): screencast backend (CDP + ffmpeg) behind a backend opt

### DIFF
--- a/packages/capture/package.json
+++ b/packages/capture/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "@browserless/goto": "workspace:*",
+    "@browserless/screencast": "workspace:*",
     "debug-logfmt": "~1.4.10",
     "ws": "~8.21.0"
   },

--- a/packages/capture/src/ebml.js
+++ b/packages/capture/src/ebml.js
@@ -1,0 +1,135 @@
+'use strict'
+
+// Minimal EBML/Matroska writer used to wrap individual MJPEG frames with explicit
+// timestamps before piping them into ffmpeg (`-f matroska -i pipe:0`). This lets ffmpeg
+// derive frame timing from the stream instead of us repeating frames to fake a constant
+// frame rate. Only the subset of Matroska needed for a single live MJPEG track is emitted.
+//
+// Ported from Playwright's ebml.ts (Apache-2.0, (c) Microsoft Corporation).
+//
+// References:
+//   https://www.matroska.org/technical/elements.html
+//   https://datatracker.ietf.org/doc/html/rfc8794 (EBML)
+
+// Element IDs are written verbatim - the leading byte already encodes the length descriptor.
+const kEBML = Buffer.from('1A45DFA3', 'hex')
+const kEBMLVersion = Buffer.from('4286', 'hex')
+const kEBMLReadVersion = Buffer.from('42F7', 'hex')
+const kEBMLMaxIDLength = Buffer.from('42F2', 'hex')
+const kEBMLMaxSizeLength = Buffer.from('42F3', 'hex')
+const kDocType = Buffer.from('4282', 'hex')
+const kDocTypeVersion = Buffer.from('4287', 'hex')
+const kDocTypeReadVersion = Buffer.from('4285', 'hex')
+const kSegment = Buffer.from('18538067', 'hex')
+const kInfo = Buffer.from('1549A966', 'hex')
+const kTimestampScale = Buffer.from('2AD7B1', 'hex')
+const kMuxingApp = Buffer.from('4D80', 'hex')
+const kWritingApp = Buffer.from('5741', 'hex')
+const kTracks = Buffer.from('1654AE6B', 'hex')
+const kTrackEntry = Buffer.from('AE', 'hex')
+const kTrackNumber = Buffer.from('D7', 'hex')
+const kTrackUID = Buffer.from('73C5', 'hex')
+const kTrackType = Buffer.from('83', 'hex')
+const kFlagLacing = Buffer.from('9C', 'hex')
+const kCodecID = Buffer.from('86', 'hex')
+const kVideo = Buffer.from('E0', 'hex')
+const kPixelWidth = Buffer.from('B0', 'hex')
+const kPixelHeight = Buffer.from('BA', 'hex')
+const kCluster = Buffer.from('1F43B675', 'hex')
+const kTimestamp = Buffer.from('E7', 'hex')
+const kSimpleBlock = Buffer.from('A3', 'hex')
+
+// "Unknown size" for a streaming Segment: an 8-byte EBML vint with all data bits set.
+const kUnknownSize = Buffer.from([0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
+
+// Encodes a value as an EBML variable-length size integer (vint): the leading bits select
+// the byte length and are followed by the big-endian value.
+const vint = value => {
+  let length = 1
+  while (value >= 2 ** (7 * length) - 1) ++length
+  const buffer = Buffer.alloc(length)
+  let v = value
+  for (let i = length - 1; i >= 0; --i) {
+    buffer[i] = v & 0xff
+    v = Math.floor(v / 256)
+  }
+  buffer[0] |= 1 << (8 - length)
+  return buffer
+}
+
+// Encodes a non-negative integer as a minimal big-endian byte sequence.
+const uint = value => {
+  if (value === 0) return Buffer.from([0])
+  const bytes = []
+  let v = value
+  while (v > 0) {
+    bytes.unshift(v & 0xff)
+    v = Math.floor(v / 256)
+  }
+  return Buffer.from(bytes)
+}
+
+// A complete EBML element: id + size-as-vint + payload.
+const element = (id, payload) => Buffer.concat([id, vint(payload.length), payload])
+
+// Emits the Matroska header: EBML head, an unknown-size (streaming) Segment, stream Info with a
+// 1ms timestamp scale, and a single MJPEG video track. Frames follow as Clusters.
+const writeHeader = (width, height) => {
+  const ebml = element(
+    kEBML,
+    Buffer.concat([
+      element(kEBMLVersion, uint(1)),
+      element(kEBMLReadVersion, uint(1)),
+      element(kEBMLMaxIDLength, uint(4)),
+      element(kEBMLMaxSizeLength, uint(8)),
+      element(kDocType, Buffer.from('matroska')),
+      element(kDocTypeVersion, uint(4)),
+      element(kDocTypeReadVersion, uint(2))
+    ])
+  )
+  const info = element(
+    kInfo,
+    Buffer.concat([
+      // TimestampScale in nanoseconds per tick: 1_000_000 => timestamps in milliseconds.
+      element(kTimestampScale, uint(1000000)),
+      element(kMuxingApp, Buffer.from('browserless')),
+      element(kWritingApp, Buffer.from('browserless'))
+    ])
+  )
+  const track = element(
+    kTrackEntry,
+    Buffer.concat([
+      element(kTrackNumber, uint(1)),
+      element(kTrackUID, uint(1)),
+      element(kTrackType, uint(1)), // 1 = video.
+      element(kFlagLacing, uint(0)),
+      element(kCodecID, Buffer.from('V_MJPEG')),
+      // PixelWidth/PixelHeight are advisory: ffmpeg's mjpeg decoder uses the dimensions encoded
+      // in each JPEG frame, and the output video filters normalize to the requested size.
+      element(
+        kVideo,
+        Buffer.concat([element(kPixelWidth, uint(width)), element(kPixelHeight, uint(height))])
+      )
+    ])
+  )
+  const tracks = element(kTracks, track)
+  return Buffer.concat([ebml, kSegment, kUnknownSize, info, tracks])
+}
+
+// Emits the bytes that precede a single MJPEG frame in its own Cluster, timestamped at the given
+// absolute millisecond offset. The frame itself is NOT copied here - the caller writes this header
+// followed by the raw frame buffer, so the (potentially large) JPEG is never duplicated.
+const writeClusterHeader = (timestampMs, frameLength) => {
+  const simpleBlockHeader = Buffer.concat([
+    kSimpleBlock,
+    vint(4 + frameLength),
+    vint(1), // Track number (1).
+    Buffer.from([0x00, 0x00]), // Relative timecode (int16), always 0 within its own Cluster.
+    Buffer.from([0x80]) // Flags: keyframe.
+  ])
+  const timestamp = element(kTimestamp, uint(timestampMs))
+  const clusterPayloadLength = timestamp.length + simpleBlockHeader.length + frameLength
+  return Buffer.concat([kCluster, vint(clusterPayloadLength), timestamp, simpleBlockHeader])
+}
+
+module.exports = { writeHeader, writeClusterHeader }

--- a/packages/capture/src/ebml.js
+++ b/packages/capture/src/ebml.js
@@ -43,6 +43,7 @@ const kSimpleBlock = Buffer.from('A3', 'hex')
 const kUnknownSize = Buffer.from([0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
 
 // Per-frame SimpleBlock constants (each MJPEG frame is its own keyframe Cluster).
+const kTrackNumberVint = Buffer.from([0x81]) // vint(1) — single video track, constant per frame.
 const kRelativeTimecode = Buffer.from([0x00, 0x00]) // int16, always 0 within its Cluster.
 const kKeyframeFlag = Buffer.from([0x80])
 
@@ -127,7 +128,7 @@ const writeClusterHeader = (timestampMs, frameLength) => {
   const simpleBlockHeader = Buffer.concat([
     kSimpleBlock,
     vint(4 + frameLength),
-    vint(1), // Track number (1).
+    kTrackNumberVint,
     kRelativeTimecode,
     kKeyframeFlag
   ])

--- a/packages/capture/src/ebml.js
+++ b/packages/capture/src/ebml.js
@@ -42,6 +42,10 @@ const kSimpleBlock = Buffer.from('A3', 'hex')
 // "Unknown size" for a streaming Segment: an 8-byte EBML vint with all data bits set.
 const kUnknownSize = Buffer.from([0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
 
+// Per-frame SimpleBlock constants (each MJPEG frame is its own keyframe Cluster).
+const kRelativeTimecode = Buffer.from([0x00, 0x00]) // int16, always 0 within its Cluster.
+const kKeyframeFlag = Buffer.from([0x80])
+
 // Encodes a value as an EBML variable-length size integer (vint): the leading bits select
 // the byte length and are followed by the big-endian value.
 const vint = value => {
@@ -124,8 +128,8 @@ const writeClusterHeader = (timestampMs, frameLength) => {
     kSimpleBlock,
     vint(4 + frameLength),
     vint(1), // Track number (1).
-    Buffer.from([0x00, 0x00]), // Relative timecode (int16), always 0 within its own Cluster.
-    Buffer.from([0x80]) // Flags: keyframe.
+    kRelativeTimecode,
+    kKeyframeFlag
   ])
   const timestamp = element(kTimestamp, uint(timestampMs))
   const clusterPayloadLength = timestamp.length + simpleBlockHeader.length + frameLength

--- a/packages/capture/src/ffmpeg.js
+++ b/packages/capture/src/ffmpeg.js
@@ -100,8 +100,10 @@ const getOutputArgs = ({ type, width, height, fps, encoder }) => {
 
 // Spawn ffmpeg with the given args. Returns the child's `stdin` (the caller
 // writes the Matroska stream into it and ends it) and `output`, a promise that
-// resolves to the encoded video Buffer once ffmpeg exits cleanly.
-const spawnFfmpeg = ({ ffmpegPath = FFMPEG_PATH, args }) => {
+// resolves to the encoded video Buffer once ffmpeg exits cleanly. `timeout`
+// (ms) bounds the whole process: if ffmpeg hasn't exited by then it is killed
+// and `output` rejects, so a stuck encoder can't leave a capture open forever.
+const spawnFfmpeg = ({ ffmpegPath = FFMPEG_PATH, args, timeout }) => {
   const ffmpeg = spawn(ffmpegPath, args, { stdio: ['pipe', 'pipe', 'pipe'] })
 
   const chunks = []
@@ -111,18 +113,28 @@ const spawnFfmpeg = ({ ffmpegPath = FFMPEG_PATH, args }) => {
   ffmpeg.stdin.on('error', () => {})
 
   const output = new Promise((resolve, reject) => {
-    ffmpeg.on('error', err =>
+    const timer = timeout
+      ? setTimeout(() => {
+        ffmpeg.kill('SIGKILL')
+        reject(new Error(`ffmpeg did not finish within ${timeout}ms`))
+      }, timeout)
+      : null
+    timer?.unref()
+
+    ffmpeg.on('error', err => {
+      clearTimeout(timer)
       reject(
         new Error(
           `ffmpeg failed to start (${ffmpegPath}): ${err.message}. Install ffmpeg to use the screencast backend.`
         )
       )
-    )
-    ffmpeg.on('close', code =>
+    })
+    ffmpeg.on('close', code => {
+      clearTimeout(timer)
       code === 0
         ? resolve(Buffer.concat(chunks))
         : reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(-300)}`))
-    )
+    })
   })
 
   return { stdin: ffmpeg.stdin, output }

--- a/packages/capture/src/ffmpeg.js
+++ b/packages/capture/src/ffmpeg.js
@@ -63,7 +63,9 @@ const resolveEncoder = (encoder, container) => {
 }
 
 const getOutputArgs = ({ type, width, height, fps, encoder }) => {
-  const container = type === 'webm' ? 'webm' : 'mp4'
+  // Normalize like the extension backend (trim/lowercase/strip leading dot) so
+  // `WEBM` or `.webm` resolve to the webm container rather than defaulting to mp4.
+  const container = String(type).trim().toLowerCase().replace(/^\./, '') === 'webm' ? 'webm' : 'mp4'
   const { codec } = resolveEncoder(encoder, container)
   // Read frame timing from the Matroska stream we mux (explicit per-frame
   // timestamps) and emit a constant `fps`, duplicating frames as needed.

--- a/packages/capture/src/ffmpeg.js
+++ b/packages/capture/src/ffmpeg.js
@@ -1,0 +1,134 @@
+'use strict'
+
+// ffmpeg encoding for the screencast backend: encoder profiles, output-arg
+// construction, and a thin spawn helper. The screencast recorder feeds this a
+// Matroska stream (see ./ebml.js) on stdin and reads the encoded video on stdout.
+
+const { spawn } = require('child_process')
+
+const FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg'
+
+// Video encoder profiles, keyed by name and tagged with the container they mux
+// into. The MediaRecorder-style `codec` (e.g. avc1.640028) does not apply to
+// ffmpeg and is ignored here. Selectable per-request via the `encoder` opt so
+// combinations can be benchmarked against each other in production; defaults
+// (h264-ultrafast / vp8) are validated speed-first choices.
+const ENCODER_PROFILES = {
+  'h264-ultrafast': { container: 'mp4', codec: ['libx264', '-preset', 'ultrafast'] },
+  'h264-veryfast': { container: 'mp4', codec: ['libx264', '-preset', 'veryfast'] },
+  'h264-medium': { container: 'mp4', codec: ['libx264', '-preset', 'medium'] },
+  h265: { container: 'mp4', codec: ['libx265', '-preset', 'ultrafast', '-tag:v', 'hvc1'] },
+  av1: { container: 'mp4', codec: ['libsvtav1', '-preset', '8', '-crf', '35'] },
+  vp8: {
+    container: 'webm',
+    // vp8 realtime config (from Playwright) — predictable under load, unlike vp9
+    // realtime which drops frames.
+    codec: [
+      'libvpx',
+      '-qmin',
+      '0',
+      '-qmax',
+      '50',
+      '-crf',
+      '8',
+      '-deadline',
+      'realtime',
+      '-speed',
+      '8',
+      '-b:v',
+      '1M'
+    ]
+  },
+  vp9: {
+    container: 'webm',
+    codec: ['libvpx-vp9', '-deadline', 'realtime', '-cpu-used', '8', '-crf', '30', '-b:v', '0']
+  }
+}
+
+const DEFAULT_ENCODER_BY_CONTAINER = { mp4: 'h264-ultrafast', webm: 'vp8' }
+
+// mp4 must be fragmented to stream to stdout (non-seekable output).
+const CONTAINER_ARGS = {
+  mp4: ['-movflags', '+frag_keyframe+empty_moov+default_base_moof', '-f', 'mp4', 'pipe:1'],
+  webm: ['-f', 'webm', 'pipe:1']
+}
+
+const resolveEncoder = (encoder, container) => {
+  const profile = ENCODER_PROFILES[encoder]
+  // Fall back to the container default for an unknown encoder or one that does
+  // not mux into the requested container (e.g. vp9 requested with type=mp4).
+  return profile && profile.container === container
+    ? profile
+    : ENCODER_PROFILES[DEFAULT_ENCODER_BY_CONTAINER[container]]
+}
+
+const getOutputArgs = ({ type, width, height, fps, encoder }) => {
+  const container = type === 'webm' ? 'webm' : 'mp4'
+  const { codec } = resolveEncoder(encoder, container)
+  // Read frame timing from the Matroska stream we mux (explicit per-frame
+  // timestamps) and emit a constant `fps`, duplicating frames as needed.
+  return [
+    '-loglevel',
+    'error',
+    '-f',
+    'matroska',
+    '-fpsprobesize',
+    '0',
+    '-probesize',
+    '32',
+    '-analyzeduration',
+    '0',
+    '-i',
+    'pipe:0',
+    '-y',
+    '-an',
+    '-r',
+    String(fps),
+    '-vf',
+    `pad=${width}:${height}:0:0:gray,crop=${width}:${height}:0:0`,
+    '-threads',
+    '1',
+    '-c:v',
+    ...codec,
+    '-pix_fmt',
+    'yuv420p',
+    ...CONTAINER_ARGS[container]
+  ]
+}
+
+// Spawn ffmpeg with the given args. Returns the child's `stdin` (the caller
+// writes the Matroska stream into it and ends it) and `output`, a promise that
+// resolves to the encoded video Buffer once ffmpeg exits cleanly.
+const spawnFfmpeg = ({ ffmpegPath = FFMPEG_PATH, args }) => {
+  const ffmpeg = spawn(ffmpegPath, args, { stdio: ['pipe', 'pipe', 'pipe'] })
+
+  const chunks = []
+  let stderr = ''
+  ffmpeg.stdout.on('data', chunk => chunks.push(chunk))
+  ffmpeg.stderr.on('data', chunk => (stderr += chunk.toString()))
+  ffmpeg.stdin.on('error', () => {})
+
+  const output = new Promise((resolve, reject) => {
+    ffmpeg.on('error', err =>
+      reject(
+        new Error(
+          `ffmpeg failed to start (${ffmpegPath}): ${err.message}. Install ffmpeg to use the screencast backend.`
+        )
+      )
+    )
+    ffmpeg.on('close', code =>
+      code === 0
+        ? resolve(Buffer.concat(chunks))
+        : reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(-300)}`))
+    )
+  })
+
+  return { stdin: ffmpeg.stdin, output }
+}
+
+module.exports = {
+  FFMPEG_PATH,
+  ENCODERS: Object.keys(ENCODER_PROFILES),
+  getOutputArgs,
+  spawnFfmpeg
+}

--- a/packages/capture/src/index.js
+++ b/packages/capture/src/index.js
@@ -11,6 +11,10 @@ const {
   TYPES
 } = require('./constants')
 const runCapture = require('./capture')
+const runScreencastCapture = require('./screencast')
+
+const BACKENDS = { extension: runCapture, screencast: runScreencastCapture }
+const DEFAULT_BACKEND = 'extension'
 
 // Resolve the device (and therefore the viewport) without navigating, so the
 // recorder can be sized and started before `goto` runs. The viewport is derived
@@ -33,10 +37,13 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     return async (url, opts = {}) => {
       const duration = debug.duration({ url })
       const viewport = resolveViewport(goto, page, opts)
-      const result = await runCapture(page, opts, viewport, {
+      // `backend` selects the capture implementation: the default in-browser
+      // MediaRecorder/extension recorder, or the CDP screencast + ffmpeg backend.
+      const runBackend = BACKENDS[opts.backend] || BACKENDS[DEFAULT_BACKEND]
+      const result = await runBackend(page, opts, viewport, {
         onStarted: () => goto(page, { ...opts, url, animations: true })
       })
-      duration.info()
+      duration.info({ backend: opts.backend || DEFAULT_BACKEND })
       return result
     }
   }
@@ -45,5 +52,6 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
 module.exports.extensionPath = EXTENSION_PATH
 module.exports.extensionId = EXTENSION_ID
 module.exports.TYPES = TYPES
+module.exports.BACKENDS = Object.keys(BACKENDS)
 module.exports.DEFAULT = DEFAULT
 module.exports.DEFAULT_CODEC_BY_TYPE = DEFAULT_CODEC_BY_TYPE

--- a/packages/capture/src/index.js
+++ b/packages/capture/src/index.js
@@ -12,6 +12,7 @@ const {
 } = require('./constants')
 const runCapture = require('./capture')
 const runScreencastCapture = require('./screencast')
+const { ENCODERS } = require('./ffmpeg')
 
 const BACKENDS = { extension: runCapture, screencast: runScreencastCapture }
 const DEFAULT_BACKEND = 'extension'
@@ -53,6 +54,6 @@ module.exports.extensionPath = EXTENSION_PATH
 module.exports.extensionId = EXTENSION_ID
 module.exports.TYPES = TYPES
 module.exports.BACKENDS = Object.keys(BACKENDS)
-module.exports.ENCODERS = runScreencastCapture.ENCODERS
+module.exports.ENCODERS = ENCODERS
 module.exports.DEFAULT = DEFAULT
 module.exports.DEFAULT_CODEC_BY_TYPE = DEFAULT_CODEC_BY_TYPE

--- a/packages/capture/src/index.js
+++ b/packages/capture/src/index.js
@@ -53,5 +53,6 @@ module.exports.extensionPath = EXTENSION_PATH
 module.exports.extensionId = EXTENSION_ID
 module.exports.TYPES = TYPES
 module.exports.BACKENDS = Object.keys(BACKENDS)
+module.exports.ENCODERS = runScreencastCapture.ENCODERS
 module.exports.DEFAULT = DEFAULT
 module.exports.DEFAULT_CODEC_BY_TYPE = DEFAULT_CODEC_BY_TYPE

--- a/packages/capture/src/screencast.js
+++ b/packages/capture/src/screencast.js
@@ -1,15 +1,13 @@
 'use strict'
 
 const { setTimeout: delay } = require('timers/promises')
-const { spawn } = require('child_process')
 const fs = require('fs/promises')
 const debug = require('debug-logfmt')('browserless:capture')
 
 const createScreencast = require('@browserless/screencast')
 const { writeHeader, writeClusterHeader } = require('./ebml')
+const { getOutputArgs, spawnFfmpeg } = require('./ffmpeg')
 const { DEFAULT, NOOP } = require('./constants')
-
-const FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg'
 
 // vp8/h264 require even dimensions.
 const even = value => Math.round(value) & ~1
@@ -24,94 +22,6 @@ const getViewportSize = viewport => ({
   width: even(viewport.width),
   height: even(viewport.height)
 })
-
-// Video encoder profiles, keyed by name and tagged with the container they mux
-// into. The MediaRecorder-style `codec` (e.g. avc1.640028) does not apply to
-// ffmpeg and is ignored here. Selectable per-request via the `encoder` opt so
-// combinations can be benchmarked against each other in production; defaults
-// (h264-ultrafast / vp8) are validated speed-first choices.
-const ENCODER_PROFILES = {
-  'h264-ultrafast': { container: 'mp4', codec: ['libx264', '-preset', 'ultrafast'] },
-  'h264-veryfast': { container: 'mp4', codec: ['libx264', '-preset', 'veryfast'] },
-  'h264-medium': { container: 'mp4', codec: ['libx264', '-preset', 'medium'] },
-  h265: { container: 'mp4', codec: ['libx265', '-preset', 'ultrafast', '-tag:v', 'hvc1'] },
-  av1: { container: 'mp4', codec: ['libsvtav1', '-preset', '8', '-crf', '35'] },
-  vp8: {
-    container: 'webm',
-    // vp8 realtime config (from Playwright) — predictable under load, unlike vp9
-    // realtime which drops frames.
-    codec: [
-      'libvpx',
-      '-qmin',
-      '0',
-      '-qmax',
-      '50',
-      '-crf',
-      '8',
-      '-deadline',
-      'realtime',
-      '-speed',
-      '8',
-      '-b:v',
-      '1M'
-    ]
-  },
-  vp9: {
-    container: 'webm',
-    codec: ['libvpx-vp9', '-deadline', 'realtime', '-cpu-used', '8', '-crf', '30', '-b:v', '0']
-  }
-}
-
-const DEFAULT_ENCODER_BY_CONTAINER = { mp4: 'h264-ultrafast', webm: 'vp8' }
-
-// mp4 must be fragmented to stream to stdout (non-seekable output).
-const CONTAINER_ARGS = {
-  mp4: ['-movflags', '+frag_keyframe+empty_moov+default_base_moof', '-f', 'mp4', 'pipe:1'],
-  webm: ['-f', 'webm', 'pipe:1']
-}
-
-const resolveEncoder = (encoder, container) => {
-  const profile = ENCODER_PROFILES[encoder]
-  // Fall back to the container default for an unknown encoder or one that does
-  // not mux into the requested container (e.g. vp9 requested with type=mp4).
-  return profile && profile.container === container
-    ? profile
-    : ENCODER_PROFILES[DEFAULT_ENCODER_BY_CONTAINER[container]]
-}
-
-const getOutputArgs = ({ type, width, height, fps, encoder }) => {
-  const container = type === 'webm' ? 'webm' : 'mp4'
-  const { codec } = resolveEncoder(encoder, container)
-  // Read frame timing from the Matroska stream we mux (explicit per-frame
-  // timestamps) and emit a constant `fps`, duplicating frames as needed.
-  return [
-    '-loglevel',
-    'error',
-    '-f',
-    'matroska',
-    '-fpsprobesize',
-    '0',
-    '-probesize',
-    '32',
-    '-analyzeduration',
-    '0',
-    '-i',
-    'pipe:0',
-    '-y',
-    '-an',
-    '-r',
-    String(fps),
-    '-vf',
-    `pad=${width}:${height}:0:0:gray,crop=${width}:${height}:0:0`,
-    '-threads',
-    '1',
-    '-c:v',
-    ...codec,
-    '-pix_fmt',
-    'yuv420p',
-    ...CONTAINER_ARGS[container]
-  ]
-}
 
 // Maps incoming frames onto a constant-fps grid by their real (compositor swap)
 // timestamp, and muxes them into a Matroska stream for ffmpeg. Ported from the
@@ -159,38 +69,18 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
     type = DEFAULT.type,
     encoder,
     quality = 90,
-    ffmpegPath = FFMPEG_PATH
+    ffmpegPath
   } = opts
 
   const { width, height } = getViewportSize(viewport)
 
-  const ffmpeg = spawn(ffmpegPath, getOutputArgs({ type, width, height, fps, encoder }), {
-    stdio: ['pipe', 'pipe', 'pipe']
+  const { stdin, output } = spawnFfmpeg({
+    ffmpegPath,
+    args: getOutputArgs({ type, width, height, fps, encoder })
   })
 
-  const chunks = []
-  let stderr = ''
-  ffmpeg.stdout.on('data', chunk => chunks.push(chunk))
-  ffmpeg.stderr.on('data', chunk => (stderr += chunk.toString()))
-  ffmpeg.stdin.on('error', NOOP)
-
-  const exited = new Promise((resolve, reject) => {
-    ffmpeg.on('error', err =>
-      reject(
-        new Error(
-          `ffmpeg failed to start (${ffmpegPath}): ${err.message}. Install ffmpeg to use the screencast backend.`
-        )
-      )
-    )
-    ffmpeg.on('close', code =>
-      code === 0
-        ? resolve(Buffer.concat(chunks))
-        : reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(-300)}`))
-    )
-  })
-
-  const muxer = createFrameMuxer({ stdin: ffmpeg.stdin, fps, durationMs: duration })
-  ffmpeg.stdin.write(writeHeader(width, height))
+  const muxer = createFrameMuxer({ stdin, fps, durationMs: duration })
+  stdin.write(writeHeader(width, height))
 
   const screencast = createScreencast(page, {
     format: 'jpeg',
@@ -228,10 +118,10 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
   } finally {
     await screencast.stop().catch(NOOP)
     muxer.flush()
-    ffmpeg.stdin.end()
+    stdin.end()
   }
 
-  const buffer = await exited
+  const buffer = await output
   // Let navigation settle before returning so the caller doesn't tear the page
   // down mid-navigation (goto has its own timeout, so this can't hang).
   await navigation
@@ -250,6 +140,3 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
 
   return buffer
 }
-
-module.exports.ENCODERS = Object.keys(ENCODER_PROFILES)
-module.exports.getOutputArgs = getOutputArgs

--- a/packages/capture/src/screencast.js
+++ b/packages/capture/src/screencast.js
@@ -82,7 +82,12 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
 
   const { stdin, output } = spawnFfmpeg({
     ffmpegPath,
-    args: getOutputArgs({ type, width, height, fps, encoder })
+    args: getOutputArgs({ type, width, height, fps, encoder }),
+    // Bound the whole process: the recording window (`duration`) plus generous
+    // headroom for the post-`stdin.end()` encode flush. Mirrors the extension
+    // backend's `duration * 1.5` safety timeout so a stuck ffmpeg can't hang the
+    // capture indefinitely.
+    timeout: Math.ceil(duration * 2) + 10_000
   })
 
   const muxer = createFrameMuxer({ stdin, fps, durationMs: duration })

--- a/packages/capture/src/screencast.js
+++ b/packages/capture/src/screencast.js
@@ -83,10 +83,9 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
   const { stdin, output } = spawnFfmpeg({
     ffmpegPath,
     args: getOutputArgs({ type, width, height, fps, encoder }),
-    // Bound the whole process: the recording window (`duration`) plus generous
-    // headroom for the post-`stdin.end()` encode flush. Mirrors the extension
-    // backend's `duration * 1.5` safety timeout so a stuck ffmpeg can't hang the
-    // capture indefinitely.
+    // Bound the whole process so a stuck ffmpeg can't hang the capture: the
+    // recording window (`duration`) plus generous headroom for the post-
+    // `stdin.end()` encode flush (slower than realtime for heavy encoders).
     timeout: Math.ceil(duration * 2) + 10_000
   })
 
@@ -121,13 +120,11 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
     // and intro animations are captured from the first frame. Navigation runs
     // concurrently — it does not extend the recording window (so the clip stays
     // bounded to `duration` on slow loads), but a failure ends it early.
-    navigation = (onStarted ? Promise.resolve().then(onStarted) : Promise.resolve()).catch(
-      error => {
-        captureError = error
-        recordingWindow.abort()
-      }
-    )
-    await delay(duration, undefined, { signal: recordingWindow.signal }).catch(() => {})
+    navigation = Promise.resolve(onStarted?.()).catch(error => {
+      captureError = error
+      recordingWindow.abort()
+    })
+    await delay(duration, undefined, { signal: recordingWindow.signal }).catch(NOOP)
   } catch (error) {
     captureError = captureError || error
   } finally {
@@ -150,9 +147,7 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
   if (captureError) throw captureError
 
   if (buffer.length === 0) {
-    throw new Error(
-      'No video data was captured. Increase `duration` or verify playback in the tab.'
-    )
+    throw new Error('No video data was captured. Increase `duration` or verify the page renders.')
   }
 
   if (outputPath) {

--- a/packages/capture/src/screencast.js
+++ b/packages/capture/src/screencast.js
@@ -25,12 +25,66 @@ const getViewportSize = viewport => ({
   height: even(viewport.height)
 })
 
-// Output encoder is chosen by container `type`; the MediaRecorder-style `codec`
-// (e.g. avc1.640028) does not apply to ffmpeg and is ignored here.
-const getOutputArgs = ({ type, width, height, fps }) => {
+// Video encoder profiles, keyed by name and tagged with the container they mux
+// into. The MediaRecorder-style `codec` (e.g. avc1.640028) does not apply to
+// ffmpeg and is ignored here. Selectable per-request via the `encoder` opt so
+// combinations can be benchmarked against each other in production; defaults
+// (h264-ultrafast / vp8) are validated speed-first choices.
+const ENCODER_PROFILES = {
+  'h264-ultrafast': { container: 'mp4', codec: ['libx264', '-preset', 'ultrafast'] },
+  'h264-veryfast': { container: 'mp4', codec: ['libx264', '-preset', 'veryfast'] },
+  'h264-medium': { container: 'mp4', codec: ['libx264', '-preset', 'medium'] },
+  h265: { container: 'mp4', codec: ['libx265', '-preset', 'ultrafast', '-tag:v', 'hvc1'] },
+  av1: { container: 'mp4', codec: ['libsvtav1', '-preset', '8', '-crf', '35'] },
+  vp8: {
+    container: 'webm',
+    // vp8 realtime config (from Playwright) — predictable under load, unlike vp9
+    // realtime which drops frames.
+    codec: [
+      'libvpx',
+      '-qmin',
+      '0',
+      '-qmax',
+      '50',
+      '-crf',
+      '8',
+      '-deadline',
+      'realtime',
+      '-speed',
+      '8',
+      '-b:v',
+      '1M'
+    ]
+  },
+  vp9: {
+    container: 'webm',
+    codec: ['libvpx-vp9', '-deadline', 'realtime', '-cpu-used', '8', '-crf', '30', '-b:v', '0']
+  }
+}
+
+const DEFAULT_ENCODER_BY_CONTAINER = { mp4: 'h264-ultrafast', webm: 'vp8' }
+
+// mp4 must be fragmented to stream to stdout (non-seekable output).
+const CONTAINER_ARGS = {
+  mp4: ['-movflags', '+frag_keyframe+empty_moov+default_base_moof', '-f', 'mp4', 'pipe:1'],
+  webm: ['-f', 'webm', 'pipe:1']
+}
+
+const resolveEncoder = (encoder, container) => {
+  const profile = ENCODER_PROFILES[encoder]
+  // Fall back to the container default for an unknown encoder or one that does
+  // not mux into the requested container (e.g. vp9 requested with type=mp4).
+  return profile && profile.container === container
+    ? profile
+    : ENCODER_PROFILES[DEFAULT_ENCODER_BY_CONTAINER[container]]
+}
+
+const getOutputArgs = ({ type, width, height, fps, encoder }) => {
+  const container = type === 'webm' ? 'webm' : 'mp4'
+  const { codec } = resolveEncoder(encoder, container)
   // Read frame timing from the Matroska stream we mux (explicit per-frame
   // timestamps) and emit a constant `fps`, duplicating frames as needed.
-  const base = [
+  return [
     '-loglevel',
     'error',
     '-f',
@@ -50,49 +104,13 @@ const getOutputArgs = ({ type, width, height, fps }) => {
     '-vf',
     `pad=${width}:${height}:0:0:gray,crop=${width}:${height}:0:0`,
     '-threads',
-    '1'
-  ]
-
-  if (type === 'webm') {
-    // vp8 realtime config (from Playwright) — predictable under load, unlike vp9
-    // realtime which drops frames.
-    return base.concat([
-      '-c:v',
-      'libvpx',
-      '-qmin',
-      '0',
-      '-qmax',
-      '50',
-      '-crf',
-      '8',
-      '-deadline',
-      'realtime',
-      '-speed',
-      '8',
-      '-b:v',
-      '1M',
-      '-pix_fmt',
-      'yuv420p',
-      '-f',
-      'webm',
-      'pipe:1'
-    ])
-  }
-
-  // mp4 (h264). Fragmented so it can be streamed to stdout (non-seekable).
-  return base.concat([
+    '1',
     '-c:v',
-    'libx264',
-    '-preset',
-    'ultrafast',
+    ...codec,
     '-pix_fmt',
     'yuv420p',
-    '-movflags',
-    '+frag_keyframe+empty_moov+default_base_moof',
-    '-f',
-    'mp4',
-    'pipe:1'
-  ])
+    ...CONTAINER_ARGS[container]
+  ]
 }
 
 // Maps incoming frames onto a constant-fps grid by their real (compositor swap)
@@ -139,13 +157,14 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
     duration = DEFAULT.duration,
     fps = DEFAULT.fps,
     type = DEFAULT.type,
+    encoder,
     quality = 90,
     ffmpegPath = FFMPEG_PATH
   } = opts
 
   const { width, height } = getViewportSize(viewport)
 
-  const ffmpeg = spawn(ffmpegPath, getOutputArgs({ type, width, height, fps }), {
+  const ffmpeg = spawn(ffmpegPath, getOutputArgs({ type, width, height, fps, encoder }), {
     stdio: ['pipe', 'pipe', 'pipe']
   })
 
@@ -231,3 +250,6 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
 
   return buffer
 }
+
+module.exports.ENCODERS = Object.keys(ENCODER_PROFILES)
+module.exports.getOutputArgs = getOutputArgs

--- a/packages/capture/src/screencast.js
+++ b/packages/capture/src/screencast.js
@@ -1,0 +1,245 @@
+'use strict'
+
+const { setTimeout: delay } = require('timers/promises')
+const { spawn } = require('child_process')
+const fs = require('fs/promises')
+const debug = require('debug-logfmt')('browserless:capture')
+
+const createScreencast = require('@browserless/screencast')
+const { writeHeader, writeClusterHeader } = require('./ebml')
+const { DEFAULT, NOOP } = require('./constants')
+
+const FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg'
+
+// vp8/h264 require even dimensions.
+const even = value => value & ~1
+
+// CDP `Page.startScreencast` delivers frames at the CSS-pixel layout viewport,
+// NOT device pixels (unlike tab capture, which is retina/device-px). Size the
+// output to the CSS viewport so frames fill it exactly without padding/upscaling.
+// Net effect: the screencast backend is half the linear resolution of the
+// extension backend for a 2x-DPR device.
+const getScaledSize = viewport => ({
+  width: even(Math.round(viewport.width)),
+  height: even(Math.round(viewport.height))
+})
+
+// Output encoder is chosen by container `type`; the MediaRecorder-style `codec`
+// (e.g. avc1.640028) does not apply to ffmpeg and is ignored here.
+const getOutputArgs = ({ type, width, height, fps }) => {
+  // Read frame timing from the Matroska stream we mux (explicit per-frame
+  // timestamps) and emit a constant `fps`, duplicating frames as needed.
+  const base = [
+    '-loglevel',
+    'error',
+    '-f',
+    'matroska',
+    '-fpsprobesize',
+    '0',
+    '-probesize',
+    '32',
+    '-analyzeduration',
+    '0',
+    '-i',
+    'pipe:0',
+    '-y',
+    '-an',
+    '-r',
+    String(fps),
+    '-vf',
+    `pad=${width}:${height}:0:0:gray,crop=${width}:${height}:0:0`,
+    '-threads',
+    '1'
+  ]
+
+  if (type === 'webm') {
+    // vp8 realtime config (from Playwright) — predictable under load, unlike vp9
+    // realtime which drops frames.
+    return base.concat([
+      '-c:v',
+      'libvpx',
+      '-qmin',
+      '0',
+      '-qmax',
+      '50',
+      '-crf',
+      '8',
+      '-deadline',
+      'realtime',
+      '-speed',
+      '8',
+      '-b:v',
+      '1M',
+      '-pix_fmt',
+      'yuv420p',
+      '-f',
+      'webm',
+      'pipe:1'
+    ])
+  }
+
+  // mp4 (h264). Fragmented so it can be streamed to stdout (non-seekable).
+  return base.concat([
+    '-c:v',
+    'libx264',
+    '-preset',
+    'ultrafast',
+    '-pix_fmt',
+    'yuv420p',
+    '-movflags',
+    '+frag_keyframe+empty_moov+default_base_moof',
+    '-f',
+    'mp4',
+    'pipe:1'
+  ])
+}
+
+// Maps incoming frames onto a constant-fps grid by their real (compositor swap)
+// timestamp, and muxes them into a Matroska stream for ffmpeg. Ported from the
+// timing logic in Playwright's FfmpegVideoRecorder (Apache-2.0).
+const createFrameMuxer = ({ stdin, fps, durationMs }) => {
+  let firstTs
+  let last = null
+
+  const emit = (buffer, frameNumber) => {
+    const timestampMs = Math.max(0, Math.round((frameNumber * 1000) / fps))
+    stdin.write(writeClusterHeader(timestampMs, buffer.length))
+    stdin.write(buffer)
+  }
+
+  return {
+    write: (buffer, tsSeconds) => {
+      if (firstTs === undefined) firstTs = tsSeconds
+      // Hard-bound the clip to `duration`; async screencast stop can deliver a
+      // few frames past the deadline that would otherwise lengthen the video.
+      if ((tsSeconds - firstTs) * 1000 > durationMs) return
+      const frameNumber = Math.floor((tsSeconds - firstTs) * fps)
+      // A frame held on screen (no repaint) keeps its slot, so its real duration
+      // is preserved instead of being collapsed.
+      if (last && frameNumber !== last.frameNumber) emit(last.buffer, last.frameNumber)
+      last = { buffer, frameNumber, tsSeconds }
+    },
+    flush: () => {
+      if (!last) return
+      emit(last.buffer, last.frameNumber)
+      // Hold the last frame out to the full requested duration. Screencast is
+      // change-driven (no frame after the last repaint), so without this a page
+      // that goes static produces a clip shorter than `duration`. ffmpeg `-r`
+      // duplicates the held frame to fill the gap.
+      const endFrameNumber = Math.floor((durationMs / 1000) * fps)
+      if (endFrameNumber > last.frameNumber) emit(last.buffer, endFrameNumber)
+    },
+    hasFrames: () => last !== null
+  }
+}
+
+module.exports = async (page, opts, viewport, { onStarted } = {}) => {
+  const {
+    path: outputPath,
+    duration = DEFAULT.duration,
+    fps = DEFAULT.fps,
+    type = DEFAULT.type,
+    quality = 90,
+    ffmpegPath = FFMPEG_PATH
+  } = opts
+
+  const { width, height } = getScaledSize(viewport)
+
+  const ffmpeg = spawn(ffmpegPath, getOutputArgs({ type, width, height, fps }), {
+    stdio: ['pipe', 'pipe', 'pipe']
+  })
+
+  const chunks = []
+  let stderr = ''
+  ffmpeg.stdout.on('data', chunk => chunks.push(chunk))
+  ffmpeg.stderr.on('data', chunk => (stderr += chunk.toString()))
+  ffmpeg.stdin.on('error', NOOP)
+
+  const exited = new Promise((resolve, reject) => {
+    ffmpeg.on('error', err =>
+      reject(
+        new Error(
+          `ffmpeg failed to start (${ffmpegPath}): ${err.message}. Install ffmpeg to use the screencast backend.`
+        )
+      )
+    )
+    ffmpeg.on('close', code =>
+      code === 0
+        ? resolve(Buffer.concat(chunks))
+        : reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(-300)}`))
+    )
+  })
+
+  const muxer = createFrameMuxer({ stdin: ffmpeg.stdin, fps, durationMs: duration })
+  ffmpeg.stdin.write(writeHeader(width, height))
+
+  const screencast = createScreencast(page, {
+    format: 'jpeg',
+    quality,
+    maxWidth: width,
+    maxHeight: height,
+    everyNthFrame: 1
+  })
+
+  // metadata.timestamp is the compositor frame-swap wall time, in seconds.
+  screencast.onFrame((data, metadata) =>
+    muxer.write(Buffer.from(data, 'base64'), metadata.timestamp)
+  )
+
+  let captureError
+  let navigation = Promise.resolve()
+  try {
+    // Apply the viewport before the first frame so the screencast captures at the
+    // intended size from the start (goto re-applies it idempotently during nav).
+    await page.setViewport(viewport).catch(NOOP)
+    await debugDuration('screencast.start', () => screencast.start())
+
+    // The screencast is rolling: only now kick off navigation so the page's load
+    // and intro animations are captured from the first frame. Navigation runs
+    // concurrently and is NOT awaited here, so the recording window stays bounded
+    // to `duration` regardless of how long the page takes to load.
+    navigation = (onStarted ? Promise.resolve().then(onStarted) : Promise.resolve()).catch(
+      error => {
+        captureError = error
+      }
+    )
+    await delay(duration)
+  } catch (error) {
+    captureError = captureError || error
+  } finally {
+    await screencast.stop().catch(NOOP)
+    muxer.flush()
+    ffmpeg.stdin.end()
+  }
+
+  const buffer = await exited
+  // Let navigation settle before returning so the caller doesn't tear the page
+  // down mid-navigation (goto has its own timeout, so this can't hang).
+  await navigation
+  if (captureError) throw captureError
+
+  if (buffer.length === 0) {
+    throw new Error(
+      'No video data was captured. Increase `duration` or verify playback in the tab.'
+    )
+  }
+
+  if (outputPath) {
+    await fs.writeFile(outputPath, buffer)
+    debug('screencast.writeFile', { outputPath, bytes: buffer.length })
+  }
+
+  return buffer
+}
+
+const debugDuration = async (label, fn) => {
+  const d = debug.duration(label)
+  try {
+    const value = await fn()
+    d()
+    return value
+  } catch (error) {
+    d({ error: error && error.message })
+    throw error
+  }
+}

--- a/packages/capture/src/screencast.js
+++ b/packages/capture/src/screencast.js
@@ -72,6 +72,12 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
     ffmpegPath
   } = opts
 
+  // The screencast backend captures video only (CDP screencast has no audio);
+  // mirror the extension backend's "must capture something" guard.
+  if (opts.video === false) {
+    throw new TypeError('The screencast backend captures video; `video` cannot be disabled.')
+  }
+
   const { width, height } = getViewportSize(viewport)
 
   const { stdin, output } = spawnFfmpeg({
@@ -97,6 +103,9 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
 
   let captureError
   let navigation = Promise.resolve()
+  // Bounds the recording window; aborted early if navigation fails so a goto
+  // error surfaces immediately instead of after the full `duration`.
+  const recordingWindow = new AbortController()
   try {
     // Apply the viewport before the first frame so the screencast captures at the
     // intended size from the start (goto re-applies it idempotently during nav).
@@ -105,14 +114,15 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
 
     // The screencast is rolling: only now kick off navigation so the page's load
     // and intro animations are captured from the first frame. Navigation runs
-    // concurrently and is NOT awaited here, so the recording window stays bounded
-    // to `duration` regardless of how long the page takes to load.
+    // concurrently — it does not extend the recording window (so the clip stays
+    // bounded to `duration` on slow loads), but a failure ends it early.
     navigation = (onStarted ? Promise.resolve().then(onStarted) : Promise.resolve()).catch(
       error => {
         captureError = error
+        recordingWindow.abort()
       }
     )
-    await delay(duration)
+    await delay(duration, undefined, { signal: recordingWindow.signal }).catch(() => {})
   } catch (error) {
     captureError = captureError || error
   } finally {
@@ -121,7 +131,14 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
     stdin.end()
   }
 
-  const buffer = await output
+  let buffer
+  try {
+    buffer = await output
+  } catch (error) {
+    // Prefer the underlying capture/navigation failure over a downstream ffmpeg
+    // error (a non-zero exit is expected when an early abort leaves little data).
+    throw captureError || error
+  }
   // Let navigation settle before returning so the caller doesn't tear the page
   // down mid-navigation (goto has its own timeout, so this can't hang).
   await navigation

--- a/packages/capture/src/screencast.js
+++ b/packages/capture/src/screencast.js
@@ -12,16 +12,17 @@ const { DEFAULT, NOOP } = require('./constants')
 const FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg'
 
 // vp8/h264 require even dimensions.
-const even = value => value & ~1
+const even = value => Math.round(value) & ~1
 
 // CDP `Page.startScreencast` delivers frames at the CSS-pixel layout viewport,
 // NOT device pixels (unlike tab capture, which is retina/device-px). Size the
 // output to the CSS viewport so frames fill it exactly without padding/upscaling.
 // Net effect: the screencast backend is half the linear resolution of the
-// extension backend for a 2x-DPR device.
-const getScaledSize = viewport => ({
-  width: even(Math.round(viewport.width)),
-  height: even(Math.round(viewport.height))
+// extension backend for a 2x-DPR device. (Distinct from capture.js's device-px
+// `getScaledSize`, hence the different name.)
+const getViewportSize = viewport => ({
+  width: even(viewport.width),
+  height: even(viewport.height)
 })
 
 // Output encoder is chosen by container `type`; the MediaRecorder-style `codec`
@@ -117,7 +118,7 @@ const createFrameMuxer = ({ stdin, fps, durationMs }) => {
       // A frame held on screen (no repaint) keeps its slot, so its real duration
       // is preserved instead of being collapsed.
       if (last && frameNumber !== last.frameNumber) emit(last.buffer, last.frameNumber)
-      last = { buffer, frameNumber, tsSeconds }
+      last = { buffer, frameNumber }
     },
     flush: () => {
       if (!last) return
@@ -128,8 +129,7 @@ const createFrameMuxer = ({ stdin, fps, durationMs }) => {
       // duplicates the held frame to fill the gap.
       const endFrameNumber = Math.floor((durationMs / 1000) * fps)
       if (endFrameNumber > last.frameNumber) emit(last.buffer, endFrameNumber)
-    },
-    hasFrames: () => last !== null
+    }
   }
 }
 
@@ -143,7 +143,7 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
     ffmpegPath = FFMPEG_PATH
   } = opts
 
-  const { width, height } = getScaledSize(viewport)
+  const { width, height } = getViewportSize(viewport)
 
   const ffmpeg = spawn(ffmpegPath, getOutputArgs({ type, width, height, fps }), {
     stdio: ['pipe', 'pipe', 'pipe']
@@ -192,7 +192,7 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
     // Apply the viewport before the first frame so the screencast captures at the
     // intended size from the start (goto re-applies it idempotently during nav).
     await page.setViewport(viewport).catch(NOOP)
-    await debugDuration('screencast.start', () => screencast.start())
+    await screencast.start()
 
     // The screencast is rolling: only now kick off navigation so the page's load
     // and intro animations are captured from the first frame. Navigation runs
@@ -230,16 +230,4 @@ module.exports = async (page, opts, viewport, { onStarted } = {}) => {
   }
 
   return buffer
-}
-
-const debugDuration = async (label, fn) => {
-  const d = debug.duration(label)
-  try {
-    const value = await fn()
-    d()
-    return value
-  } catch (error) {
-    d({ error: error && error.message })
-    throw error
-  }
 }

--- a/packages/capture/test/ebml.js
+++ b/packages/capture/test/ebml.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const test = require('ava')
+
+const { writeHeader, writeClusterHeader } = require('../src/ebml')
+
+test('writeHeader starts with the EBML magic and declares matroska/MJPEG', t => {
+  const header = writeHeader(1280, 800)
+  t.true(Buffer.isBuffer(header))
+  // EBML magic.
+  t.is(header.subarray(0, 4).toString('hex'), '1a45dfa3')
+  // DocType "matroska" and the MJPEG codec id are present in the header.
+  t.true(header.includes(Buffer.from('matroska')))
+  t.true(header.includes(Buffer.from('V_MJPEG')))
+})
+
+test('writeClusterHeader encodes the cluster timestamp', t => {
+  const frameLength = 1234
+  const cluster = writeClusterHeader(500, frameLength)
+  t.true(Buffer.isBuffer(cluster))
+  // Cluster element id.
+  t.is(cluster.subarray(0, 4).toString('hex'), '1f43b675')
+  // The cluster carries a Timestamp element (E7) holding 500 (0x01F4).
+  const ts = Buffer.from([0xe7, 0x82, 0x01, 0xf4])
+  t.true(cluster.includes(ts))
+  // SimpleBlock (A3) declares its size as 4 (block header) + frameLength.
+  t.true(cluster.includes(Buffer.from([0xa3])))
+})
+
+test('cluster header does not embed the frame payload (no duplication)', t => {
+  // The frame buffer is written separately by the caller, so the header length
+  // must be independent of frameLength beyond the size vints.
+  const small = writeClusterHeader(0, 10)
+  const large = writeClusterHeader(0, 10_000_000)
+  // Only the SimpleBlock size vint grows; the header never carries 10MB.
+  t.true(small.length < 32)
+  t.true(large.length < 32)
+})

--- a/packages/capture/test/ffmpeg.js
+++ b/packages/capture/test/ffmpeg.js
@@ -2,7 +2,7 @@
 
 const test = require('ava')
 
-const { getOutputArgs, ENCODERS } = require('../src/screencast')
+const { getOutputArgs, ENCODERS } = require('../src/ffmpeg')
 
 const argsFor = opts => getOutputArgs({ width: 1280, height: 800, fps: 60, ...opts })
 

--- a/packages/capture/test/ffmpeg.js
+++ b/packages/capture/test/ffmpeg.js
@@ -11,6 +11,13 @@ test('defaults to libx264 for mp4 and libvpx (vp8) for webm', t => {
   t.true(argsFor({ type: 'webm' }).includes('libvpx'))
 })
 
+test('normalizes `type` (case / leading dot) when picking the container', t => {
+  for (const type of ['webm', 'WEBM', '.webm', ' webm ']) {
+    t.true(argsFor({ type }).includes('libvpx'), `expected webm for ${JSON.stringify(type)}`)
+  }
+  t.true(argsFor({ type: '.mp4' }).includes('libx264'))
+})
+
 test('encoder opt selects the requested codec', t => {
   t.true(argsFor({ type: 'mp4', encoder: 'av1' }).includes('libsvtav1'))
   t.true(argsFor({ type: 'mp4', encoder: 'h264-medium' }).join(' ').includes('-preset medium'))

--- a/packages/capture/test/ffmpeg.js
+++ b/packages/capture/test/ffmpeg.js
@@ -2,7 +2,7 @@
 
 const test = require('ava')
 
-const { getOutputArgs, ENCODERS } = require('../src/ffmpeg')
+const { getOutputArgs, spawnFfmpeg, ENCODERS } = require('../src/ffmpeg')
 
 const argsFor = opts => getOutputArgs({ width: 1280, height: 800, fps: 60, ...opts })
 
@@ -45,4 +45,10 @@ test('exports the encoder profile names', t => {
   t.true(ENCODERS.includes('h264-ultrafast'))
   t.true(ENCODERS.includes('vp8'))
   t.true(ENCODERS.includes('av1'))
+})
+
+test('spawnFfmpeg kills the process and rejects when it exceeds the timeout', async t => {
+  // `sleep` stands in for a hung encoder that never exits on its own.
+  const { output } = spawnFfmpeg({ ffmpegPath: 'sleep', args: ['10'], timeout: 100 })
+  await t.throwsAsync(() => output, { message: /did not finish within 100ms/ })
 })

--- a/packages/capture/test/index.js
+++ b/packages/capture/test/index.js
@@ -278,6 +278,18 @@ test('an unknown backend falls back to the default extension recorder', async t 
   t.true(Buffer.isBuffer(result))
 })
 
+test('screencast backend rejects when `video` is disabled', async t => {
+  const createCapture = loadCapture()
+  const { page } = createFixture()
+  const capture = createCapture({ goto: createGoto() })
+  // Screencast is video-only; it must error rather than silently produce video.
+  await t.throwsAsync(
+    () =>
+      capture(page)('https://example.com', { backend: 'screencast', video: false, duration: 20 }),
+    { instanceOf: TypeError, message: /video.*cannot be disabled/ }
+  )
+})
+
 test('sizes constraints from the resolved device viewport', async t => {
   const createCapture = loadCapture()
   let startRecordingPayload

--- a/packages/capture/test/index.js
+++ b/packages/capture/test/index.js
@@ -260,6 +260,22 @@ test('exports capture format defaults', t => {
 
   t.deepEqual(createCapture.TYPES, ['webm', 'mp4'])
   t.is(createCapture.DEFAULT.type, 'mp4')
+  t.deepEqual(createCapture.BACKENDS, ['extension', 'screencast'])
+})
+
+test('an unknown backend falls back to the default extension recorder', async t => {
+  const createCapture = loadCapture()
+  const { page } = createFixture()
+  const capture = createCapture({ goto: createGoto() })
+  // The mock harness only implements the extension flow; a bogus backend must
+  // resolve to it rather than throwing.
+  const result = await capture(page)('https://example.com', {
+    duration: 20,
+    audio: false,
+    video: true,
+    backend: 'does-not-exist'
+  })
+  t.true(Buffer.isBuffer(result))
 })
 
 test('sizes constraints from the resolved device viewport', async t => {

--- a/packages/capture/test/screencast.js
+++ b/packages/capture/test/screencast.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const test = require('ava')
+
+const { getOutputArgs, ENCODERS } = require('../src/screencast')
+
+const argsFor = opts => getOutputArgs({ width: 1280, height: 800, fps: 60, ...opts })
+
+test('defaults to libx264 for mp4 and libvpx (vp8) for webm', t => {
+  t.true(argsFor({ type: 'mp4' }).includes('libx264'))
+  t.true(argsFor({ type: 'webm' }).includes('libvpx'))
+})
+
+test('encoder opt selects the requested codec', t => {
+  t.true(argsFor({ type: 'mp4', encoder: 'av1' }).includes('libsvtav1'))
+  t.true(argsFor({ type: 'mp4', encoder: 'h264-medium' }).join(' ').includes('-preset medium'))
+  t.true(argsFor({ type: 'webm', encoder: 'vp9' }).includes('libvpx-vp9'))
+})
+
+test('an encoder incompatible with the container falls back to the container default', t => {
+  // vp9 only muxes into webm; requesting it for mp4 must not produce a webm codec.
+  t.true(argsFor({ type: 'mp4', encoder: 'vp9' }).includes('libx264'))
+  // h264 for webm falls back to vp8.
+  t.true(argsFor({ type: 'webm', encoder: 'h264-medium' }).includes('libvpx'))
+})
+
+test('an unknown encoder falls back to the container default', t => {
+  t.true(argsFor({ type: 'mp4', encoder: 'nope' }).includes('libx264'))
+})
+
+test('mp4 output is fragmented so it can stream to stdout', t => {
+  const args = argsFor({ type: 'mp4' }).join(' ')
+  t.true(args.includes('+frag_keyframe+empty_moov'))
+  t.true(args.endsWith('pipe:1'))
+})
+
+test('exports the encoder profile names', t => {
+  t.true(ENCODERS.includes('h264-ultrafast'))
+  t.true(ENCODERS.includes('vp8'))
+  t.true(ENCODERS.includes('av1'))
+})


### PR DESCRIPTION
Adds an alternative animated-capture backend, selectable via `opts.backend` (`'extension'` | `'screencast'`), defaulting to the existing extension recorder. Built to A/B against the current MediaRecorder/extension backend in production.

## How it works
- Captures CDP `Page.startScreencast` frames (push-based, change-driven, carrying real **compositor swap timestamps**) via the existing `@browserless/screencast` package.
- Muxes each MJPEG frame into a minimal **Matroska stream with explicit per-frame timestamps** (`src/ebml.js`, ported from Playwright, Apache-2.0).
- Pipes to **ffmpeg** with `-r <fps>` → constant frame rate output. **VFR-in → CFR-out**: dropped/late frames degrade smoothness, never playback speed.
- Holds the last frame to the full `duration` (screencast is change-driven, so a static page would otherwise produce a short clip) and hard-bounds the clip to `duration`.

## Measured (local, superpower.com, 3s)
| | extension (default) | screencast |
|---|---|---|
| Resolution | 2560×1600 (device-px) | 1280×800 (CSS-px) |
| Frame rate | ~28 fps, variable timing | **CFR 60/1**, exact |
| Duration | 2.98s | 3.03s |
| Encoder | Chromium (in-browser) | ffmpeg (libx264 / vp8) |
| Chrome extension | required | **not required** |

## Trade-offs to evaluate in the A/B
- **+** Clean constant fps, correct playback speed, no extension, engine-uniform.
- **−** CSS-pixel resolution (half the linear res of tab capture on a 2×-DPR device); requires system `ffmpeg` and external encode CPU.

## Notes
- Default behaviour unchanged (`backend` defaults to extension; unknown values fall back).
- Depends on system `ffmpeg` (`FFMPEG_PATH` override). The consuming api adds `ffmpeg` to its image and gates the backend behind an internal `x-animated-backend` header.
- Adds EBML unit tests + a backend-fallback test. 27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New subprocess and external ffmpeg dependency on an alternate capture path; default extension capture is unchanged, with timeouts and encoder fallbacks limiting hang risk.
> 
> **Overview**
> Adds an optional **`screencast`** capture path alongside the default extension/MediaRecorder flow, selected via `opts.backend` (`'extension'` | `'screencast'`). Unknown values still fall back to **extension**; default behavior is unchanged.
> 
> The screencast path uses CDP `Page.startScreencast` (via `@browserless/screencast`), muxes JPEG frames into a minimal **Matroska** stream with per-frame timestamps (`ebml.js`), and pipes that into **ffmpeg** for mp4/webm output with selectable **`encoder`** profiles. Frame timing is mapped to a constant fps grid from compositor timestamps; the clip is capped at `duration`, the last frame is held to the full length, and ffmpeg runs under a timeout so a stuck encode cannot hang capture.
> 
> **Trade-off:** output is sized to the **CSS viewport** (not device pixels), so on 2× DPR it is lower resolution than tab capture. **Video only** — `video: false` is rejected for this backend. The package exports **`BACKENDS`** and **`ENCODERS`**; unit tests cover EBML, ffmpeg args/spawn timeout, backend fallback, and the video guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b80c88f17e2d3f4e55295fffa8ee7d25c54a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->