### PR TITLE
perf(capture): default mp4 encoder h264-ultrafast → veryfast

### DIFF
--- a/packages/capture/src/recorder/ffmpeg.js
+++ b/packages/capture/src/recorder/ffmpeg.js
@@ -11,8 +11,10 @@ const FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg'
 // Video encoder profiles, keyed by name and tagged with the container they mux
 // into. The MediaRecorder-style `codec` (e.g. avc1.640028) does not apply to
 // ffmpeg and is ignored here. Selectable per-request via the `encoder` opt so
-// combinations can be benchmarked against each other in production; defaults
-// (h264-ultrafast / vp8) are validated speed-first choices.
+// combinations can be benchmarked against each other in production. The mp4
+// default is `h264-veryfast`: benchmarking showed `ultrafast` produced ~5x
+// larger files for the same end-to-end latency (its only edge — lower CPU — did
+// not translate into faster requests), so veryfast is the better default.
 const ENCODER_PROFILES = {
   'h264-ultrafast': { container: 'mp4', codec: ['libx264', '-preset', 'ultrafast'] },
   'h264-veryfast': { container: 'mp4', codec: ['libx264', '-preset', 'veryfast'] },
@@ -45,7 +47,7 @@ const ENCODER_PROFILES = {
   }
 }
 
-const DEFAULT_ENCODER_BY_CONTAINER = { mp4: 'h264-ultrafast', webm: 'vp8' }
+const DEFAULT_ENCODER_BY_CONTAINER = { mp4: 'h264-veryfast', webm: 'vp8' }
 
 // mp4 must be fragmented to stream to stdout (non-seekable output).
 const CONTAINER_ARGS = {

--- a/packages/capture/test/ffmpeg.js
+++ b/packages/capture/test/ffmpeg.js
@@ -11,6 +11,10 @@ test('defaults to libx264 for mp4 and libvpx (vp8) for webm', t => {
   t.true(argsFor({ type: 'webm' }).includes('libvpx'))
 })
 
+test('mp4 default preset is veryfast (not the bloated ultrafast)', t => {
+  t.true(argsFor({ type: 'mp4' }).join(' ').includes('-preset veryfast'))
+})
+
 test('normalizes `type` (case / leading dot) when picking the container', t => {
   for (const type of ['webm', 'WEBM', '.webm', ' webm ']) {
     t.true(argsFor({ type }).includes('libvpx'), `expected webm for ${JSON.stringify(type)}`)


### PR DESCRIPTION
Benchmarking the screencast pipeline showed h264-ultrafast produced ~5x larger files than veryfast for the same end-to-end latency — its only edge (lower CPU) did not translate into faster requests. Make h264-veryfast the mp4 container default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to default ffmpeg args for mp4; explicit encoder choices and webm defaults are unchanged.
> 
> **Overview**
> Switches the **default mp4 H.264 preset** from `ultrafast` to `veryfast` in `DEFAULT_ENCODER_BY_CONTAINER`, so screencast captures that do not pass an `encoder` option now emit **smaller files** at similar end-to-end latency. Comments document the benchmark rationale (~5× size inflation from `ultrafast` without faster requests).
> 
> The `h264-ultrafast` profile remains available for explicit `encoder` selection. A unit test locks in that mp4 defaults include `-preset veryfast`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d89ee7082b0e0c0267442da62cfe4544dd837374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->