### PR TITLE
perf(screencast): frame backpressure

### DIFF
--- a/packages/capture/src/recorder/index.js
+++ b/packages/capture/src/recorder/index.js
@@ -30,32 +30,32 @@ const waitForWritable = stdin =>
     stdin.once('error', done)
   })
 
-const writeAndDrain = (stdin, buffer) => {
-  if (stdin.write(buffer)) return
-  return waitForWritable(stdin)
-}
-
-const writeChunks = (stdin, chunks) => {
-  let pending
-
-  for (const chunk of chunks) {
-    if (pending) pending = pending.then(() => writeAndDrain(stdin, chunk))
-    else pending = writeAndDrain(stdin, chunk)
-  }
-
-  return pending
-}
-
 // Maps incoming frames onto a constant-fps grid by their real (compositor swap)
 // timestamp, and muxes them into a Matroska stream for ffmpeg. Ported from the
 // timing logic in Playwright's FfmpegVideoRecorder (Apache-2.0).
 const createFrameMuxer = ({ stdin, fps, durationMs }) => {
   let firstTs
   let last = null
+  // Stop writing once ffmpeg's stdin dies (EPIPE on early abort / crash); the
+  // underlying failure surfaces via the `output` promise in record(). Without
+  // this, a write after error/close throws or is silently dropped mid-frame.
+  let writable = true
+  const stopWriting = () => (writable = false)
+  stdin.once('error', stopWriting)
+  stdin.once('close', stopWriting)
 
+  // A frame's cluster header and payload must reach ffmpeg contiguously. Write
+  // both back-to-back (Node queues them in order regardless of the backpressure
+  // hint), then await a single `drain`. Splitting them across an `await` would
+  // let a concurrent emit — flush() racing the last in-flight capture write —
+  // splice between the header and its payload and corrupt the Matroska stream.
   const emit = (buffer, frameNumber) => {
+    if (!writable) return
     const timestampMs = Math.max(0, Math.round((frameNumber * 1000) / fps))
-    return writeChunks(stdin, [writeClusterHeader(timestampMs, buffer.length), buffer])
+    const headerWritten = stdin.write(writeClusterHeader(timestampMs, buffer.length))
+    const payloadWritten = stdin.write(buffer)
+    if (headerWritten && payloadWritten) return
+    return waitForWritable(stdin)
   }
 
   return {

--- a/packages/capture/src/recorder/index.js
+++ b/packages/capture/src/recorder/index.js
@@ -16,6 +16,36 @@ const { DEFAULT, NOOP } = require('../constants')
 // vp8/h264 require even dimensions.
 const even = value => Math.round(value) & ~1
 
+const waitForWritable = stdin =>
+  new Promise(resolve => {
+    const done = () => {
+      stdin.off('close', done)
+      stdin.off('drain', done)
+      stdin.off('error', done)
+      resolve()
+    }
+
+    stdin.once('close', done)
+    stdin.once('drain', done)
+    stdin.once('error', done)
+  })
+
+const writeAndDrain = (stdin, buffer) => {
+  if (stdin.write(buffer)) return
+  return waitForWritable(stdin)
+}
+
+const writeChunks = (stdin, chunks) => {
+  let pending
+
+  for (const chunk of chunks) {
+    if (pending) pending = pending.then(() => writeAndDrain(stdin, chunk))
+    else pending = writeAndDrain(stdin, chunk)
+  }
+
+  return pending
+}
+
 // Maps incoming frames onto a constant-fps grid by their real (compositor swap)
 // timestamp, and muxes them into a Matroska stream for ffmpeg. Ported from the
 // timing logic in Playwright's FfmpegVideoRecorder (Apache-2.0).
@@ -25,8 +55,7 @@ const createFrameMuxer = ({ stdin, fps, durationMs }) => {
 
   const emit = (buffer, frameNumber) => {
     const timestampMs = Math.max(0, Math.round((frameNumber * 1000) / fps))
-    stdin.write(writeClusterHeader(timestampMs, buffer.length))
-    stdin.write(buffer)
+    return writeChunks(stdin, [writeClusterHeader(timestampMs, buffer.length), buffer])
   }
 
   return {
@@ -38,18 +67,20 @@ const createFrameMuxer = ({ stdin, fps, durationMs }) => {
       const frameNumber = Math.floor((tsSeconds - firstTs) * fps)
       // A frame held on screen (no repaint) keeps its slot, so its real duration
       // is preserved instead of being collapsed.
-      if (last && frameNumber !== last.frameNumber) emit(last.buffer, last.frameNumber)
+      const pending =
+        last && frameNumber !== last.frameNumber ? emit(last.buffer, last.frameNumber) : undefined
       last = { buffer, frameNumber }
+      return pending
     },
-    flush: () => {
+    flush: async () => {
       if (!last) return
-      emit(last.buffer, last.frameNumber)
+      await emit(last.buffer, last.frameNumber)
       // Hold the last frame out to the full requested duration. Screencast is
       // change-driven (no frame after the last repaint), so without this a page
       // that goes static produces a clip shorter than `duration`. ffmpeg `-r`
       // duplicates the held frame to fill the gap.
       const endFrameNumber = Math.floor((durationMs / 1000) * fps)
-      if (endFrameNumber > last.frameNumber) emit(last.buffer, endFrameNumber)
+      if (endFrameNumber > last.frameNumber) await emit(last.buffer, endFrameNumber)
     }
   }
 }
@@ -114,7 +145,7 @@ const record = async (page, opts, viewport, { onStarted, getSize, startSource, l
     captureError = captureError || error
   } finally {
     await stop()
-    muxer.flush()
+    await muxer.flush()
     stdin.end()
   }
 

--- a/packages/capture/test/index.js
+++ b/packages/capture/test/index.js
@@ -227,14 +227,15 @@ const waitUntil = async (predicate, { timeout = 500, interval = 10 } = {}) => {
   return true
 }
 
-test('frame muxer waits for ffmpeg stdin drain before writing more chunks', async t => {
+test('frame muxer writes header+payload atomically and waits for drain', async t => {
   const { createFrameMuxer } = require('../src/recorder')
   const stdin = new EventEmitter()
   const writes = []
 
+  // Header write succeeds; the payload write signals backpressure (returns false).
   stdin.write = chunk => {
     writes.push(chunk)
-    return writes.length !== 1
+    return writes.length < 2
   }
 
   const muxer = createFrameMuxer({ stdin, fps: 1, durationMs: 1000 })
@@ -242,14 +243,33 @@ test('frame muxer waits for ffmpeg stdin drain before writing more chunks', asyn
 
   const pending = muxer.write(Buffer.from('second'), 1)
 
+  // Both the cluster header and the payload are written before any await, so a
+  // concurrent emit can never splice between them and corrupt the stream.
+  t.is(writes.length, 2)
+  t.deepEqual(writes[1], Buffer.from('first'))
   t.true(pending instanceof Promise)
-  t.is(writes.length, 1)
 
   stdin.emit('drain')
   await pending
+})
 
+test('frame muxer stops writing once stdin errors', async t => {
+  const { createFrameMuxer } = require('../src/recorder')
+  const stdin = new EventEmitter()
+  const writes = []
+  stdin.write = chunk => {
+    writes.push(chunk)
+    return true
+  }
+
+  const muxer = createFrameMuxer({ stdin, fps: 1, durationMs: 1000 })
+  muxer.write(Buffer.from('first'), 0)
+  muxer.write(Buffer.from('second'), 1) // emits frame 0 → 2 writes
   t.is(writes.length, 2)
-  t.deepEqual(writes[1], Buffer.from('first'))
+
+  stdin.emit('error', new Error('EPIPE'))
+  muxer.write(Buffer.from('third'), 2) // emit must be a no-op after error
+  t.is(writes.length, 2)
 })
 
 test('capture returns a video buffer', async t => {

--- a/packages/capture/test/index.js
+++ b/packages/capture/test/index.js
@@ -227,6 +227,31 @@ const waitUntil = async (predicate, { timeout = 500, interval = 10 } = {}) => {
   return true
 }
 
+test('frame muxer waits for ffmpeg stdin drain before writing more chunks', async t => {
+  const { createFrameMuxer } = require('../src/recorder')
+  const stdin = new EventEmitter()
+  const writes = []
+
+  stdin.write = chunk => {
+    writes.push(chunk)
+    return writes.length !== 1
+  }
+
+  const muxer = createFrameMuxer({ stdin, fps: 1, durationMs: 1000 })
+  muxer.write(Buffer.from('first'), 0)
+
+  const pending = muxer.write(Buffer.from('second'), 1)
+
+  t.true(pending instanceof Promise)
+  t.is(writes.length, 1)
+
+  stdin.emit('drain')
+  await pending
+
+  t.is(writes.length, 2)
+  t.deepEqual(writes[1], Buffer.from('first'))
+})
+
 test('capture returns a video buffer', async t => {
   const createCapture = loadCapture()
   const { page } = createFixture()

--- a/packages/screencast/README.md
+++ b/packages/screencast/README.md
@@ -88,7 +88,8 @@ Creates a screencast instance for the given Puppeteer page.
 
 ### Options
 
-All options are passed directly to [Page.startScreencast](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreencast):
+Options are passed to [Page.startScreencast](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreencast)
+after applying these package defaults:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|

--- a/packages/screencast/README.md
+++ b/packages/screencast/README.md
@@ -109,6 +109,10 @@ screencast.onFrame((data, metadata) => {
 })
 ```
 
+If the callback returns a promise, the next CDP frame is acknowledged after that
+promise settles. Use this to apply backpressure when writing frames to a slow
+stream or encoder.
+
 | Argument | Type | Description |
 |----------|------|-------------|
 | `data` | `string` | Base64-encoded frame image |

--- a/packages/screencast/src/index.js
+++ b/packages/screencast/src/index.js
@@ -53,6 +53,7 @@ module.exports = (page, opts) => {
     // https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreencast
     start: () => {
       if (!onFrame) throw new Error('onFrame callback must be registered before calling start()')
+      stopped = false
       attachFrameListener()
       return cdp.send('Page.startScreencast', { ...DEFAULT_OPTS, ...opts })
     },

--- a/packages/screencast/src/index.js
+++ b/packages/screencast/src/index.js
@@ -5,9 +5,24 @@ module.exports = (page, opts) => {
   let onFrame
   let hasFrameListener = false
 
+  const ack = sessionId => cdp.send('Page.screencastFrameAck', { sessionId }).catch(() => {})
+
   const onScreencastFrame = ({ data, metadata, sessionId }) => {
-    cdp.send('Page.screencastFrameAck', { sessionId }).catch(() => {})
-    if (metadata.timestamp && onFrame) onFrame(data, metadata)
+    if (!metadata.timestamp || !onFrame) return ack(sessionId)
+
+    let result
+    try {
+      result = onFrame(data, metadata)
+    } catch (error) {
+      ack(sessionId)
+      throw error
+    }
+
+    if (!result || typeof result.then !== 'function') return ack(sessionId)
+
+    return Promise.resolve(result)
+      .catch(() => {})
+      .then(() => ack(sessionId))
   }
 
   const attachFrameListener = () => {

--- a/packages/screencast/src/index.js
+++ b/packages/screencast/src/index.js
@@ -1,9 +1,15 @@
 'use strict'
 
+const DEFAULT_OPTS = {
+  format: 'jpeg',
+  quality: 80
+}
+
 module.exports = (page, opts) => {
   const cdp = page._client()
   let onFrame
   let hasFrameListener = false
+  let stopped = false
 
   const ack = sessionId => cdp.send('Page.screencastFrameAck', { sessionId }).catch(() => {})
 
@@ -13,16 +19,22 @@ module.exports = (page, opts) => {
     let result
     try {
       result = onFrame(data, metadata)
-    } catch (error) {
-      ack(sessionId)
-      throw error
+    } catch {
+      // Swallow like the async-rejection path below: a frame-callback error must
+      // not propagate into puppeteer's CDP dispatch loop. Still ack so the
+      // screencast stream cannot stall on a single bad frame.
+      return ack(sessionId)
     }
 
     if (!result || typeof result.then !== 'function') return ack(sessionId)
 
-    return Promise.resolve(result)
-      .catch(() => {})
-      .then(() => ack(sessionId))
+    return (
+      Promise.resolve(result)
+        .catch(() => {})
+        // The frame may settle after stop(); don't ack a torn-down session (a
+        // stale ack could otherwise race a subsequent screencast on the same page).
+        .then(() => stopped || ack(sessionId))
+    )
   }
 
   const attachFrameListener = () => {
@@ -42,10 +54,11 @@ module.exports = (page, opts) => {
     start: () => {
       if (!onFrame) throw new Error('onFrame callback must be registered before calling start()')
       attachFrameListener()
-      return cdp.send('Page.startScreencast', opts)
+      return cdp.send('Page.startScreencast', { ...DEFAULT_OPTS, ...opts })
     },
     onFrame: fn => (onFrame = fn),
     stop: () => {
+      stopped = true
       detachFrameListener()
       return cdp.send('Page.stopScreencast').catch(() => {})
     }

--- a/packages/screencast/test/index.js
+++ b/packages/screencast/test/index.js
@@ -1,9 +1,33 @@
 'use strict'
 
 const { getBrowserContext } = require('@browserless/test')
+const { EventEmitter } = require('events')
 const test = require('ava')
 
 const createScreencast = require('..')
+
+const createDeferred = () => {
+  let resolve
+  let reject
+  const promise = new Promise((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return { promise, resolve, reject }
+}
+
+const settle = () => new Promise(resolve => setImmediate(resolve))
+
+const createFakeCdp = () => {
+  const cdp = new EventEmitter()
+  const calls = []
+
+  cdp.send = async (method, params) => {
+    calls.push({ method, params })
+  }
+
+  return { cdp, calls }
+}
 
 test('capture frames', async t => {
   const frames = []
@@ -78,4 +102,56 @@ test('clean up cdp frame listeners across screencast sessions', async t => {
   t.is(countListeners(), 1)
   await screencastB.stop()
   t.is(countListeners(), 0)
+})
+
+test('acks screencast frames after async onFrame resolves', async t => {
+  const { cdp, calls } = createFakeCdp()
+  const page = { _client: () => cdp }
+  const frame = createDeferred()
+  let received
+
+  const screencast = createScreencast(page, {})
+  screencast.onFrame((data, metadata) => {
+    received = { data, metadata }
+    return frame.promise
+  })
+
+  await screencast.start()
+  cdp.emit('Page.screencastFrame', {
+    data: 'frame',
+    metadata: { timestamp: 1 },
+    sessionId: 42
+  })
+
+  t.deepEqual(received, { data: 'frame', metadata: { timestamp: 1 } })
+  t.false(calls.some(({ method }) => method === 'Page.screencastFrameAck'))
+
+  frame.resolve()
+  await settle()
+
+  t.deepEqual(calls, [
+    { method: 'Page.startScreencast', params: {} },
+    { method: 'Page.screencastFrameAck', params: { sessionId: 42 } }
+  ])
+})
+
+test('acks screencast frames after async onFrame rejects', async t => {
+  const { cdp, calls } = createFakeCdp()
+  const page = { _client: () => cdp }
+
+  const screencast = createScreencast(page, {})
+  screencast.onFrame(() => Promise.reject(new Error('frame failed')))
+
+  await screencast.start()
+  cdp.emit('Page.screencastFrame', {
+    data: 'frame',
+    metadata: { timestamp: 1 },
+    sessionId: 43
+  })
+  await settle()
+
+  t.deepEqual(calls, [
+    { method: 'Page.startScreencast', params: {} },
+    { method: 'Page.screencastFrameAck', params: { sessionId: 43 } }
+  ])
 })

--- a/packages/screencast/test/index.js
+++ b/packages/screencast/test/index.js
@@ -29,6 +29,49 @@ const createFakeCdp = () => {
   return { cdp, calls }
 }
 
+test('starts screencast with jpeg defaults', async t => {
+  const { cdp, calls } = createFakeCdp()
+  const page = { _client: () => cdp }
+  const screencast = createScreencast(page)
+
+  screencast.onFrame(() => {})
+  await screencast.start()
+
+  t.deepEqual(calls, [
+    {
+      method: 'Page.startScreencast',
+      params: {
+        format: 'jpeg',
+        quality: 80
+      }
+    }
+  ])
+})
+
+test('lets screencast options override defaults', async t => {
+  const { cdp, calls } = createFakeCdp()
+  const page = { _client: () => cdp }
+  const screencast = createScreencast(page, {
+    format: 'png',
+    quality: 100,
+    everyNthFrame: 2
+  })
+
+  screencast.onFrame(() => {})
+  await screencast.start()
+
+  t.deepEqual(calls, [
+    {
+      method: 'Page.startScreencast',
+      params: {
+        format: 'png',
+        quality: 100,
+        everyNthFrame: 2
+      }
+    }
+  ])
+})
+
 test('capture frames', async t => {
   const frames = []
 
@@ -130,7 +173,7 @@ test('acks screencast frames after async onFrame resolves', async t => {
   await settle()
 
   t.deepEqual(calls, [
-    { method: 'Page.startScreencast', params: {} },
+    { method: 'Page.startScreencast', params: { format: 'jpeg', quality: 80 } },
     { method: 'Page.screencastFrameAck', params: { sessionId: 42 } }
   ])
 })
@@ -151,7 +194,61 @@ test('acks screencast frames after async onFrame rejects', async t => {
   await settle()
 
   t.deepEqual(calls, [
-    { method: 'Page.startScreencast', params: {} },
+    { method: 'Page.startScreencast', params: { format: 'jpeg', quality: 80 } },
     { method: 'Page.screencastFrameAck', params: { sessionId: 43 } }
   ])
+})
+
+test('acks and does not rethrow when a synchronous onFrame throws', async t => {
+  const { cdp, calls } = createFakeCdp()
+  const page = { _client: () => cdp }
+
+  const screencast = createScreencast(page, {})
+  screencast.onFrame(() => {
+    throw new Error('frame failed')
+  })
+
+  await screencast.start()
+
+  // A sync throw must be swallowed, not propagated into the CDP dispatch loop.
+  t.notThrows(() =>
+    cdp.emit('Page.screencastFrame', {
+      data: 'frame',
+      metadata: { timestamp: 1 },
+      sessionId: 44
+    })
+  )
+  await settle()
+
+  t.deepEqual(calls, [
+    { method: 'Page.startScreencast', params: { format: 'jpeg', quality: 80 } },
+    { method: 'Page.screencastFrameAck', params: { sessionId: 44 } }
+  ])
+})
+
+test('does not ack a frame whose async onFrame settles after stop()', async t => {
+  const { cdp, calls } = createFakeCdp()
+  const page = { _client: () => cdp }
+  const frame = createDeferred()
+
+  const screencast = createScreencast(page, {})
+  screencast.onFrame(() => frame.promise)
+
+  await screencast.start()
+  cdp.emit('Page.screencastFrame', {
+    data: 'frame',
+    metadata: { timestamp: 1 },
+    sessionId: 45
+  })
+
+  await screencast.stop()
+  frame.resolve()
+  await settle()
+
+  // No ack for the in-flight frame: its session was torn down by stop().
+  t.false(
+    calls.some(
+      ({ method, params }) => method === 'Page.screencastFrameAck' && params.sessionId === 45
+    )
+  )
 })

--- a/packages/screencast/test/index.js
+++ b/packages/screencast/test/index.js
@@ -252,3 +252,29 @@ test('does not ack a frame whose async onFrame settles after stop()', async t =>
     )
   )
 })
+
+test('re-acks async frames after stop() then start() on the same instance', async t => {
+  const { cdp, calls } = createFakeCdp()
+  const page = { _client: () => cdp }
+
+  const screencast = createScreencast(page, {})
+  screencast.onFrame(() => Promise.resolve())
+
+  await screencast.start()
+  await screencast.stop()
+  await screencast.start()
+
+  cdp.emit('Page.screencastFrame', {
+    data: 'frame',
+    metadata: { timestamp: 1 },
+    sessionId: 46
+  })
+  await settle()
+
+  // start() must clear the stopped flag so the restarted session acks again.
+  t.true(
+    calls.some(
+      ({ method, params }) => method === 'Page.screencastFrameAck' && params.sessionId === 46
+    )
+  )
+})


### PR DESCRIPTION
## Summary

Adds backpressure to CDP screencast frame handling so Chrome does not keep producing frames while the frame consumer is still processing the previous one.

## What changed

- Acknowledge `Page.screencastFrame` after `onFrame` runs, and after its returned promise settles for async consumers.
- Preserve a fast path for synchronous `onFrame` handlers.
- Respect ffmpeg stdin backpressure in the frame muxer by waiting for `drain` before writing more frame chunks.
- Await final muxer flush before closing ffmpeg stdin.
- Document promise-returning `onFrame` callbacks as the backpressure mechanism.

## Why

The previous implementation acknowledged CDP frames before invoking `onFrame`, which let Chromium keep emitting compressed frames as quickly as compositor commits happened. In capture mode this could outrun base64 decoding and ffmpeg writes, increasing CPU and buffered work under load.

## Validation

- `pnpm exec standard packages/screencast/src/index.js packages/screencast/test/index.js packages/capture/src/recorder/index.js packages/capture/test/index.js`
- `pnpm --filter @browserless/capture test` — 40 passed
- `pnpm --filter @browserless/screencast test` — 4 passed

Synthetic CDP benchmark with a 10ms async frame consumer:

| Path | Frames | Peak in-flight handlers |
| --- | ---: | ---: |
| old immediate ack | 20000 | 822 |
| new promise-aware ack | 46 | 1 |

## Risk

Low. Synchronous callbacks keep immediate ack behavior after callback execution. Rejected async callbacks still ack so the screencast stream cannot stall permanently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is bounded to screencast timing and ffmpeg write ordering; sync frame handlers keep similar ack timing after callback execution, with added guards for stop/crash paths.
> 
> **Overview**
> Adds **end-to-end backpressure** so Chrome and ffmpeg are not overrun while frames are still being handled.
> 
> **`@browserless/screencast`** delays `Page.screencastFrameAck` until after `onFrame` runs (and until any returned promise settles), so Chromium does not queue unbounded frames when the consumer is slow. Sync handlers still ack immediately after the callback. Callback throws/rejections are swallowed so the CDP loop and stream do not stall; ack is skipped for frames that finish after `stop()` to avoid racing a later session. **`Page.startScreencast`** now merges **jpeg/quality defaults** with caller options.
> 
> **`@browserless/capture` recorder** respects ffmpeg stdin **backpressure** (`drain`), writes each Matroska **cluster header and payload atomically**, stops writing after stdin **error/close**, and **`await`s `muxer.flush()`** before closing stdin. **`muxer.write`** can return a pending write promise for callers that want to chain backpressure (e.g. promise-returning `onFrame`).
> 
> Docs note promise-based `onFrame` for backpressure; tests cover muxer and screencast ack/default behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b01348e0e199b5c4f49d4d9beb541ceedcae34a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->