### PR TITLE
perf(capture): optimize EBML cluster headers

### DIFF
--- a/packages/capture/benchmarks/ebml-cluster-header.js
+++ b/packages/capture/benchmarks/ebml-cluster-header.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const { writeClusterHeader } = require('../src/recorder/ebml')
+
+const ITERATIONS = Number(process.env.ITERATIONS || 1_000_000)
+const WARMUP = Number(process.env.WARMUP || 100_000)
+const FRAME_LENGTHS = Object.freeze([1200, 8192, 65_535, 250_000, 1_000_000])
+
+const run = iterations => {
+  let bytes = 0
+  const start = process.hrtime.bigint()
+
+  for (let i = 0; i < iterations; i++) {
+    const header = writeClusterHeader(i % 3_600_000, FRAME_LENGTHS[i % FRAME_LENGTHS.length])
+    bytes += header.length
+  }
+
+  const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6
+  return {
+    iterations,
+    elapsedMs,
+    nsPerOp: (elapsedMs * 1e6) / iterations,
+    opsPerSec: iterations / (elapsedMs / 1000),
+    bytes
+  }
+}
+
+run(WARMUP)
+if (global.gc) global.gc()
+const before = process.memoryUsage()
+const result = run(ITERATIONS)
+if (global.gc) global.gc()
+const after = process.memoryUsage()
+
+console.log(
+  JSON.stringify(
+    {
+      iterations: result.iterations,
+      elapsedMs: Number(result.elapsedMs.toFixed(2)),
+      nsPerOp: Number(result.nsPerOp.toFixed(1)),
+      opsPerSec: Math.round(result.opsPerSec),
+      bytes: result.bytes,
+      heapDelta: after.heapUsed - before.heapUsed,
+      externalDelta: after.external - before.external
+    },
+    null,
+    2
+  )
+)

--- a/packages/capture/src/recorder/ebml.js
+++ b/packages/capture/src/recorder/ebml.js
@@ -35,7 +35,6 @@ const kCodecID = Buffer.from('86', 'hex')
 const kVideo = Buffer.from('E0', 'hex')
 const kPixelWidth = Buffer.from('B0', 'hex')
 const kPixelHeight = Buffer.from('BA', 'hex')
-const kTimestamp = Buffer.from('E7', 'hex')
 const kClusterId = 0x1f43b675
 const kTimestampId = 0xe7
 const kSimpleBlockId = 0xa3
@@ -43,10 +42,9 @@ const kSimpleBlockId = 0xa3
 // "Unknown size" for a streaming Segment: an 8-byte EBML vint with all data bits set.
 const kUnknownSize = Buffer.from([0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
 
-// Per-frame SimpleBlock constants (each MJPEG frame is its own keyframe Cluster).
-const kTrackNumberVint = Buffer.from([0x81]) // vint(1) — single video track, constant per frame.
-const kRelativeTimecode = Buffer.from([0x00, 0x00]) // int16, always 0 within its Cluster.
-const kKeyframeFlag = Buffer.from([0x80])
+// Per-frame SimpleBlock body that follows the block-size vint (each MJPEG frame is its own keyframe
+// Cluster): vint(1) track number, int16 relative timecode (always 0 within its Cluster), keyframe flag.
+const kSimpleBlockTrailer = Buffer.from([0x81, 0x00, 0x00, 0x80])
 
 // Encodes a value as an EBML variable-length size integer (vint): the leading bits select
 // the byte length and are followed by the big-endian value.
@@ -153,9 +151,8 @@ const writeClusterHeader = (timestampMs, frameLength) => {
   const blockSizeLength = vintLength(blockPayloadLength)
   const timestampLength = uintLength(timestampMs)
   const timestampSizeLength = vintLength(timestampLength)
-  const timestampElementLength = kTimestamp.length + timestampSizeLength + timestampLength
-  const simpleBlockHeaderLength =
-    1 + blockSizeLength + kTrackNumberVint.length + kRelativeTimecode.length + kKeyframeFlag.length
+  const timestampElementLength = 1 + timestampSizeLength + timestampLength
+  const simpleBlockHeaderLength = 1 + blockSizeLength + kSimpleBlockTrailer.length
   const clusterPayloadLength = timestampElementLength + simpleBlockHeaderLength + frameLength
   const clusterSizeLength = vintLength(clusterPayloadLength)
   const buffer = Buffer.allocUnsafe(
@@ -171,10 +168,7 @@ const writeClusterHeader = (timestampMs, frameLength) => {
   offset = writeUInt(buffer, offset, timestampMs, timestampLength)
   buffer[offset++] = kSimpleBlockId
   offset = writeVint(buffer, offset, blockPayloadLength, blockSizeLength)
-  buffer[offset++] = 0x81
-  buffer[offset++] = 0x00
-  buffer[offset++] = 0x00
-  buffer[offset++] = 0x80
+  offset += kSimpleBlockTrailer.copy(buffer, offset)
 
   return buffer
 }

--- a/packages/capture/src/recorder/ebml.js
+++ b/packages/capture/src/recorder/ebml.js
@@ -35,9 +35,10 @@ const kCodecID = Buffer.from('86', 'hex')
 const kVideo = Buffer.from('E0', 'hex')
 const kPixelWidth = Buffer.from('B0', 'hex')
 const kPixelHeight = Buffer.from('BA', 'hex')
-const kCluster = Buffer.from('1F43B675', 'hex')
 const kTimestamp = Buffer.from('E7', 'hex')
-const kSimpleBlock = Buffer.from('A3', 'hex')
+const kClusterId = 0x1f43b675
+const kTimestampId = 0xe7
+const kSimpleBlockId = 0xa3
 
 // "Unknown size" for a streaming Segment: an 8-byte EBML vint with all data bits set.
 const kUnknownSize = Buffer.from([0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
@@ -49,29 +50,52 @@ const kKeyframeFlag = Buffer.from([0x80])
 
 // Encodes a value as an EBML variable-length size integer (vint): the leading bits select
 // the byte length and are followed by the big-endian value.
-const vint = value => {
+const vintLength = value => {
   let length = 1
   while (value >= 2 ** (7 * length) - 1) ++length
-  const buffer = Buffer.alloc(length)
+  return length
+}
+
+const writeVint = (buffer, offset, value, length = vintLength(value)) => {
   let v = value
   for (let i = length - 1; i >= 0; --i) {
-    buffer[i] = v & 0xff
+    buffer[offset + i] = v & 0xff
     v = Math.floor(v / 256)
   }
-  buffer[0] |= 1 << (8 - length)
+  buffer[offset] |= 1 << (8 - length)
+  return offset + length
+}
+
+const vint = value => {
+  const buffer = Buffer.allocUnsafe(vintLength(value))
+  writeVint(buffer, 0, value, buffer.length)
   return buffer
 }
 
 // Encodes a non-negative integer as a minimal big-endian byte sequence.
-const uint = value => {
-  if (value === 0) return Buffer.from([0])
-  const bytes = []
+const uintLength = value => {
+  let length = 1
   let v = value
-  while (v > 0) {
-    bytes.unshift(v & 0xff)
+  while (v >= 256) {
+    ++length
     v = Math.floor(v / 256)
   }
-  return Buffer.from(bytes)
+  return length
+}
+
+const writeUInt = (buffer, offset, value, length = uintLength(value)) => {
+  let v = value
+  for (let i = length - 1; i >= 0; --i) {
+    buffer[offset + i] = v & 0xff
+    v = Math.floor(v / 256)
+  }
+  return offset + length
+}
+
+const uint = value => {
+  const buffer = Buffer.allocUnsafe(uintLength(value))
+  writeUInt(buffer, 0, value, buffer.length)
+  return buffer
 }
 
 // A complete EBML element: id + size-as-vint + payload.
@@ -125,16 +149,34 @@ const writeHeader = (width, height) => {
 // absolute millisecond offset. The frame itself is NOT copied here - the caller writes this header
 // followed by the raw frame buffer, so the (potentially large) JPEG is never duplicated.
 const writeClusterHeader = (timestampMs, frameLength) => {
-  const simpleBlockHeader = Buffer.concat([
-    kSimpleBlock,
-    vint(4 + frameLength),
-    kTrackNumberVint,
-    kRelativeTimecode,
-    kKeyframeFlag
-  ])
-  const timestamp = element(kTimestamp, uint(timestampMs))
-  const clusterPayloadLength = timestamp.length + simpleBlockHeader.length + frameLength
-  return Buffer.concat([kCluster, vint(clusterPayloadLength), timestamp, simpleBlockHeader])
+  const blockPayloadLength = 4 + frameLength
+  const blockSizeLength = vintLength(blockPayloadLength)
+  const timestampLength = uintLength(timestampMs)
+  const timestampSizeLength = vintLength(timestampLength)
+  const timestampElementLength = kTimestamp.length + timestampSizeLength + timestampLength
+  const simpleBlockHeaderLength =
+    1 + blockSizeLength + kTrackNumberVint.length + kRelativeTimecode.length + kKeyframeFlag.length
+  const clusterPayloadLength = timestampElementLength + simpleBlockHeaderLength + frameLength
+  const clusterSizeLength = vintLength(clusterPayloadLength)
+  const buffer = Buffer.allocUnsafe(
+    4 + clusterSizeLength + timestampElementLength + simpleBlockHeaderLength
+  )
+
+  let offset = 0
+  buffer.writeUInt32BE(kClusterId, offset)
+  offset += 4
+  offset = writeVint(buffer, offset, clusterPayloadLength, clusterSizeLength)
+  buffer[offset++] = kTimestampId
+  offset = writeVint(buffer, offset, timestampLength, timestampSizeLength)
+  offset = writeUInt(buffer, offset, timestampMs, timestampLength)
+  buffer[offset++] = kSimpleBlockId
+  offset = writeVint(buffer, offset, blockPayloadLength, blockSizeLength)
+  buffer[offset++] = 0x81
+  buffer[offset++] = 0x00
+  buffer[offset++] = 0x00
+  buffer[offset++] = 0x80
+
+  return buffer
 }
 
 module.exports = { writeHeader, writeClusterHeader }

--- a/packages/capture/test/ebml.js
+++ b/packages/capture/test/ebml.js
@@ -27,6 +27,18 @@ test('writeClusterHeader encodes the cluster timestamp', t => {
   t.true(cluster.includes(Buffer.from([0xa3])))
 })
 
+test('writeClusterHeader keeps a stable byte layout', t => {
+  t.deepEqual(writeClusterHeader(0, 10), Buffer.from('1f43b67593e78100a38e81000080', 'hex'))
+  t.deepEqual(
+    writeClusterHeader(500, 1234),
+    Buffer.from('1f43b67544dde78201f4a344d681000080', 'hex')
+  )
+  t.deepEqual(
+    writeClusterHeader(3_600_000, 10_000_000),
+    Buffer.from('1f43b6751098968ee78336ee80a31098968481000080', 'hex')
+  )
+})
+
 test('cluster header does not embed the frame payload (no duplication)', t => {
   // The frame buffer is written separately by the caller, so the header length
   // must be independent of frameLength beyond the size vints.


### PR DESCRIPTION
## Summary

- Encode per-frame EBML cluster headers directly into one `Buffer` instead of composing several tiny buffers with `Buffer.concat`.
- Keep the public `writeClusterHeader(timestampMs, frameLength)` contract unchanged.
- Add exact-byte regression coverage and a focused EBML micro-benchmark.

## Benchmark

Command: `node --expose-gc packages/capture/benchmarks/ebml-cluster-header.js`

- Before: ~426-432 ns/op after warmup for 1,000,000 cluster headers.
- After: ~69-72 ns/op for the same workload.
- Net: roughly 6x faster for the pure per-frame EBML header path.

## Validation

- `pnpm exec standard packages/capture/src/recorder/ebml.js packages/capture/test/ebml.js packages/capture/benchmarks/ebml-cluster-header.js`
- `pnpm --filter @browserless/capture test` (42 tests passed)
- Direct byte comparison against the previous implementation for representative VINT/timestamp boundary cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor on the capture EBML hot path with exact-byte tests; public API and recorder usage are unchanged.
> 
> **Overview**
> **`writeClusterHeader`** no longer builds cluster/SimpleBlock bytes through chained **`Buffer.concat`** and small intermediate buffers. It precomputes element sizes, allocates one **`Buffer`**, and writes cluster id, vints, timestamp, and the fixed SimpleBlock trailer in place via new **`writeVint`** / **`writeUInt`** helpers (existing **`vint`** / **`uint`** now delegate to those).
> 
> The **`writeClusterHeader(timestampMs, frameLength)`** contract is unchanged for the recorder pipe path. **Exact hex regression tests** cover representative timestamp and frame-size boundaries, and a new **`ebml-cluster-header`** micro-benchmark measures throughput and heap deltas for repeated header encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0336e0abd936b8e94ff881ab410631ae93dc4e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->