### PR TITLE
fix(report): read loaded Mesa version from libgallium .so

### DIFF
--- a/packages/browserless/src/report.js
+++ b/packages/browserless/src/report.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { execFile } = require('child_process')
-const { readFileSync, existsSync } = require('fs')
+const { readFileSync, readdirSync, existsSync } = require('fs')
 const { promisify } = require('util')
 const os = require('os')
 
@@ -225,9 +225,38 @@ const parseRenderer = renderer => {
   }
 }
 
-// ANGLE hides the underlying Mesa version, so read it from the installed driver
-// package. Best-effort: null off Debian/Ubuntu (e.g. macOS dev) or if dpkg fails.
+// Directories where the loaded Mesa Gallium driver may live. The multiarch path
+// is resolved at runtime so this works on amd64 and arm64 without a hardcode.
+const GALLIUM_LIB_DIRS = [
+  `/usr/lib/${process.arch === 'arm64' ? 'aarch64' : 'x86_64'}-linux-gnu`,
+  '/usr/lib',
+  '/usr/local/lib'
+]
+
+// Modern Mesa ships the version in the shared-object filename, e.g.
+// `libgallium-26.1.3.so`. Pure so it can be unit-tested without a filesystem.
+const parseGalliumVersion = filenames => {
+  for (const name of filenames) {
+    const m = /^libgallium-(\d+\.\d+(?:\.\d+)?)\.so$/.exec(name)
+    if (m) return m[1]
+  }
+  return null
+}
+
+// ANGLE hides the underlying Mesa version. Read it from the ACTUALLY loaded
+// Gallium driver (`libgallium-<ver>.so`) first — when Mesa is side-loaded over
+// the distro package (our Docker image COPYs a source build over apt's), dpkg
+// still reports the stale apt version while this reflects what Chromium loads.
+// Fall back to the dpkg package version, then null (e.g. macOS dev, no Mesa).
 const readMesaVersion = async () => {
+  for (const dir of GALLIUM_LIB_DIRS) {
+    try {
+      const version = parseGalliumVersion(readdirSync(dir))
+      if (version) return version
+    } catch {
+      // dir absent / unreadable — try the next candidate.
+    }
+  }
   try {
     // Default output is `<name>\t<version>`; take the version field.
     const { stdout } = await execFileAsync('dpkg-query', ['-W', 'libgl1-mesa-dri'], {
@@ -449,4 +478,5 @@ const report =
 
 module.exports = report
 module.exports.parseRenderer = parseRenderer
+module.exports.parseGalliumVersion = parseGalliumVersion
 module.exports.detectBuild = detectBuild

--- a/packages/browserless/test/index.js
+++ b/packages/browserless/test/index.js
@@ -7,7 +7,7 @@ const path = require('path')
 const ava = require('ava')
 
 const { runServer, createBrowser, getBrowserContext, getBrowser } = require('@browserless/test')
-const { detectBuild } = require('../src/report')
+const { detectBuild, parseGalliumVersion } = require('../src/report')
 
 const test = process.env.CI ? ava.serial : ava
 
@@ -38,6 +38,20 @@ test('detectBuild distinguishes testing builds from branded Chrome', t => {
   t.is(detectBuild('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'), null)
   t.is(detectBuild('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'), null)
   t.is(detectBuild('/usr/bin/google-chrome-stable'), null)
+})
+
+test('parseGalliumVersion reads the loaded Mesa version from the .so filename', t => {
+  // Source-built Mesa side-loaded over the distro package: the version comes from
+  // the actual driver, NOT dpkg (which would report the stale apt package).
+  t.is(
+    parseGalliumVersion(['libGLX_mesa.so.0', 'libgallium-26.1.3.so', 'libEGL_mesa.so.0']),
+    '26.1.3'
+  )
+  // Two-component versions are valid too.
+  t.is(parseGalliumVersion(['libgallium-25.0.so']), '25.0')
+  // No versioned gallium driver present -> null (caller falls back to dpkg).
+  t.is(parseGalliumVersion(['libgallium.so', 'libGLX_mesa.so.0']), null)
+  t.is(parseGalliumVersion([]), null)
 })
 
 require('@browserless/test/suite')(getBrowser())


### PR DESCRIPTION
## Problem

`report()` misreports the Mesa version when Mesa is side-loaded over the distro package. `readMesaVersion()` shelled out to `dpkg-query -W libgl1-mesa-dri`, which returns the **apt package** version — not the driver Chromium actually loads.

In the microlink Docker image, a source-built Mesa is COPYd over apt's files but the dpkg database is never updated. Result: `report()` showed `mesa: 23.2.1` on an image actually running **Mesa 26.1.3** (LLVM 19, OpenGL 4.6). The WebGL `unmaskedRenderer` string already proved the real driver: `ANGLE (Mesa, llvmpipe (LLVM 19.1.7 256 bits), OpenGL 4.6)` — apt's 23.2.1 links LLVM 15 and caps at OpenGL 4.5.

## Fix

Read the version from the **actually loaded** Gallium driver's versioned filename (`libgallium-<ver>.so`) first, falling back to `dpkg-query` when no versioned `.so` exists (older Mesa) and then `null` (e.g. macOS dev, no Mesa).

- `parseGalliumVersion(filenames)` — pure, exported, unit-tested helper.
- `readMesaVersion()` scans the multiarch lib dirs (arch resolved at runtime) and uses the parser; dpkg stays as fallback.

## Verification

- Unit test for `parseGalliumVersion` passes.
- Against a live prod pod: new logic returns `26.1.3` (real loaded driver) where dpkg returns `23.2.1-1ubuntu3.1~22.04.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only change to how Mesa version is detected in report(); dpkg remains fallback and failures still return null.
> 
> **Overview**
> Fixes **`report()`** reporting a stale Mesa version when a newer Gallium driver is side-loaded over the distro package (e.g. Docker COPY without updating dpkg).
> 
> **`readMesaVersion()`** now scans multiarch **`/usr/lib`** paths (amd64/arm64 at runtime) for **`libgallium-<ver>.so`** via new pure helper **`parseGalliumVersion`**, and only falls back to **`dpkg-query libgl1-mesa-dri`**, then **`null`**. **`parseGalliumVersion`** is exported and covered by unit tests in **`packages/browserless/test/index.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8938a2b2c8cce148bdea05242fd4d495927e369c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->