### PR TITLE
refactor: expose DEFAULT_OPTS

### DIFF
--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -1,16 +1,25 @@
 'use strict'
 
 const timeSpan = require('@kikobeats/time-span')({ format: n => Math.round(n) })
+const debug = require('debug-logfmt')('browserless:pdf')
+const createGoto = require('@browserless/goto')
 const pReflect = require('p-reflect')
+
 const {
   captureWithNavigationRetry,
   isWhiteScreenshot,
   waitForDomStability,
   resolveWaitForDom,
-  DEFAULT_WAIT_FOR_DOM
+  SCREENSHOT_DEFAULT_OPTS
 } = require('@browserless/screenshot')
-const debug = require('debug-logfmt')('browserless:pdf')
-const createGoto = require('@browserless/goto')
+
+const PDF_DEFAULT_OPTS = {
+  waitForDom: SCREENSHOT_DEFAULT_OPTS.waitForDom,
+  margin: '0.35cm',
+  scale: 0.65,
+  printBackground: true,
+  waitUntil: 'auto'
+}
 
 const getMargin = unit => {
   if (!unit) return unit
@@ -26,83 +35,97 @@ const getMargin = unit => {
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
 
-  return function pdf (page) {
-    return async (
-      url,
-      {
-        margin = '0.35cm',
-        scale = 0.65,
-        printBackground = true,
-        waitUntil = 'auto',
-        waitForDom = DEFAULT_WAIT_FOR_DOM,
-        ...opts
-      } = {}
-    ) => {
-      let pdfBuffer
-      const waitForDomOpts = resolveWaitForDom(waitForDom)
+  // Render an already-prepared page to a PDF buffer. Split out from the load so
+  // a single load can be reused across page-range chunks (microlink-api's
+  // parallel renderer) without re-navigating.
+  const render = (page, opts = {}) => {
+    const {
+      margin = PDF_DEFAULT_OPTS.margin,
+      scale = PDF_DEFAULT_OPTS.scale,
+      printBackground = PDF_DEFAULT_OPTS.printBackground,
+      waitUntil,
+      waitForDom,
+      ...rest
+    } = opts
+    return captureWithNavigationRetry(
+      () => page.pdf({ ...rest, margin: getMargin(margin), printBackground, scale }),
+      { page, goto, timeout: goto.timeouts.action(rest.timeout) }
+    )
+  }
 
-      const generatePdf = page =>
-        captureWithNavigationRetry(
+  // Navigate `page` to `url` and wait until it is ready to print: DOM stability
+  // plus, in `auto` mode, a screenshot poll that re-waits while the first paint
+  // is still blank.
+  const prepare = async (page, url, opts = {}) => {
+    const {
+      margin,
+      scale,
+      printBackground,
+      waitUntil = PDF_DEFAULT_OPTS.waitUntil,
+      waitForDom = PDF_DEFAULT_OPTS.waitForDom,
+      ...rest
+    } = opts
+    const waitForDomOpts = resolveWaitForDom(waitForDom)
+
+    const waitForDomStabilityResult = async page => {
+      if (!waitForDomOpts) return
+
+      const result = await pReflect(page.evaluate(waitForDomStability, waitForDomOpts))
+      debug(
+        'waitForDomStability',
+        result.isRejected
+          ? { ...waitForDomOpts, error: result.reason.message || result.reason }
+          : { ...waitForDomOpts, ...result.value }
+      )
+    }
+
+    if (waitUntil !== 'auto') {
+      await goto(page, { ...rest, url, waitUntil })
+      await waitForDomStabilityResult(page)
+      return
+    }
+
+    await goto(page, { ...rest, url, waitUntil, waitUntilAuto })
+    async function waitUntilAuto (page) {
+      await waitForDomStabilityResult(page)
+      const timeout = goto.timeouts.action(rest.timeout)
+      let isWhite = false
+      let retry = -1
+
+      const timePdf = timeSpan()
+
+      do {
+        ++retry
+        const screenshotTime = timeSpan()
+        const screenshot = await captureWithNavigationRetry(
           () =>
-            page.pdf({
-              ...opts,
-              margin: getMargin(margin),
-              printBackground,
-              scale
+            page.screenshot({
+              ...rest,
+              optimizeForSpeed: true,
+              type: 'jpeg',
+              quality: 30
             }),
-          { page, goto, timeout: goto.timeouts.action(opts.timeout) }
+          { page, goto, timeout }
         )
+        isWhite = await isWhiteScreenshot(screenshot)
+        if (isWhite) await goto.waitUntilAuto(page, { timeout: rest.timeout })
+        debug('retry', { waitUntil, isWhite, retry, duration: screenshotTime() })
+      } while (isWhite && timePdf() < timeout)
 
-      const waitForDomStabilityResult = async page => {
-        if (!waitForDomOpts) return
-
-        const result = await pReflect(page.evaluate(waitForDomStability, waitForDomOpts))
-        debug(
-          'waitForDomStability',
-          result.isRejected
-            ? { ...waitForDomOpts, error: result.reason.message || result.reason }
-            : { ...waitForDomOpts, ...result.value }
-        )
-      }
-
-      if (waitUntil !== 'auto') {
-        await goto(page, { ...opts, url, waitUntil })
-        await waitForDomStabilityResult(page)
-        pdfBuffer = await generatePdf(page)
-      } else {
-        await goto(page, { ...opts, url, waitUntil, waitUntilAuto })
-        async function waitUntilAuto (page) {
-          await waitForDomStabilityResult(page)
-          const timeout = goto.timeouts.action(opts.timeout)
-          let isWhite = false
-          let retry = -1
-
-          const timePdf = timeSpan()
-
-          do {
-            ++retry
-            const screenshotTime = timeSpan()
-            const screenshot = await captureWithNavigationRetry(
-              () =>
-                page.screenshot({
-                  ...opts,
-                  optimizeForSpeed: true,
-                  type: 'jpeg',
-                  quality: 30
-                }),
-              { page, goto, timeout }
-            )
-            isWhite = await isWhiteScreenshot(screenshot)
-            if (isWhite) await goto.waitUntilAuto(page, { timeout: opts.timeout })
-            debug('retry', { waitUntil, isWhite, retry, duration: screenshotTime() })
-          } while (isWhite && timePdf() < timeout)
-
-          debug({ waitUntil, isWhite, timeout, duration: require('pretty-ms')(timePdf()) })
-        }
-        pdfBuffer = await generatePdf(page)
-      }
-
-      return pdfBuffer
+      debug({ waitUntil, isWhite, timeout, duration: require('pretty-ms')(timePdf()) })
     }
   }
+
+  const pdf =
+    page =>
+      async (url, opts = {}) => {
+        await prepare(page, url, opts)
+        return render(page, opts)
+      }
+
+  pdf.prepare = prepare
+  pdf.render = render
+  return pdf
 }
+
+module.exports.DEFAULT_OPTS = PDF_DEFAULT_OPTS

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -109,6 +109,14 @@ const waitForElement = async (page, element) => {
   return screenshotOpts
 }
 
+const SCREENSHOT_DEFAULT_OPTS = {
+  codeScheme: 'atom-dark',
+  overlay: {},
+  waitUntil: 'auto',
+  waitForDom: DEFAULT_WAIT_FOR_DOM,
+  isPageReady: defaultIsPageReady
+}
+
 module.exports = ({ goto, ...gotoOpts }) => {
   goto = goto || createGoto(gotoOpts)
 
@@ -116,11 +124,11 @@ module.exports = ({ goto, ...gotoOpts }) => {
     return async (
       url,
       {
-        codeScheme = 'atom-dark',
-        overlay: overlayOpts = {},
-        waitUntil = 'auto',
-        waitForDom = DEFAULT_WAIT_FOR_DOM,
-        isPageReady = defaultIsPageReady,
+        codeScheme = SCREENSHOT_DEFAULT_OPTS.codeScheme,
+        overlay: overlayOpts = SCREENSHOT_DEFAULT_OPTS.overlay,
+        waitUntil = SCREENSHOT_DEFAULT_OPTS.waitUntil,
+        waitForDom = SCREENSHOT_DEFAULT_OPTS.waitForDom,
+        isPageReady = SCREENSHOT_DEFAULT_OPTS.isPageReady,
         ...opts
       } = {}
     ) => {
@@ -269,4 +277,4 @@ module.exports.captureWithNavigationRetry = captureWithNavigationRetry
 module.exports.isWhiteScreenshot = isWhiteScreenshot
 module.exports.waitForDomStability = waitForDomStability
 module.exports.resolveWaitForDom = resolveWaitForDom
-module.exports.DEFAULT_WAIT_FOR_DOM = DEFAULT_WAIT_FOR_DOM
+module.exports.SCREENSHOT_DEFAULT_OPTS = SCREENSHOT_DEFAULT_OPTS


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core PDF/screenshot timing and default-option exports; callers depending on `DEFAULT_WAIT_FOR_DOM` or assuming a single opaque `pdf()` step need to adopt the new exports/API.
> 
> **Overview**
> **PDF generation** is refactored so navigation/readiness (`prepare`) and `page.pdf` capture (`render`) are separate steps on the returned `pdf` function (`pdf.prepare`, `pdf.render`), while the default `pdf(url)` path still runs prepare then render. Defaults are centralized in **`PDF_DEFAULT_OPTS`** (including `waitForDom` from screenshot defaults) and exported as **`module.exports.DEFAULT_OPTS`**.
> 
> **Screenshot** defaults are grouped into **`SCREENSHOT_DEFAULT_OPTS`** and used for destructuring defaults; the public export **`DEFAULT_WAIT_FOR_DOM`** is removed in favor of **`SCREENSHOT_DEFAULT_OPTS`** (which still carries `waitForDom`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b460b7bd6fde5bd555eccf7adc944d00416b31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized default settings across PDF generation and screenshot capture.
  * Centralized PDF option defaults and reused them during PDF creation.
  * Added reusable PDF workflow steps by exposing additional `prepare` and `render` entry points.
  * Updated screenshot option handling to use shared defaults, including readiness checks and timing behavior.
  * Exposed screenshot defaults as a public constant and removed the older default option export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->