### PR TITLE
test: remove unavailable areyouheadless e2e test

### DIFF
--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -43,8 +43,7 @@
   },
   "devDependencies": {
     "@browserless/test": "workspace:*",
-    "ava": "5",
-    "p-wait-for": "3"
+    "ava": "5"
   },
   "engines": {
     "node": ">= 24"

--- a/packages/goto/test/e2e/evasions.js
+++ b/packages/goto/test/e2e/evasions.js
@@ -1,22 +1,7 @@
 'use strict'
 
 const { getBrowserContext } = require('@browserless/test')
-const pWaitFor = require('p-wait-for')
 const test = require('ava')
-
-test('arh.antoinevastel.com/bots/areyouheadless', async t => {
-  let assertion = false
-
-  const fn = async () => {
-    const browserless = await getBrowserContext(t)
-    const content = await browserless.text('https://arh.antoinevastel.com/bots/areyouheadless')
-    await browserless.destroyContext()
-    return (assertion = content.includes('You are not Chrome headless'))
-  }
-
-  await pWaitFor(fn)
-  t.true(assertion)
-})
 
 test('creepjs', async t => {
   const browserless = await getBrowserContext(t)


### PR DESCRIPTION
The `arh.antoinevastel.com/bots/areyouheadless` endpoint is no longer available, so the e2e test can never pass.

## Changes
- Remove the `areyouheadless` test from `packages/goto/test/e2e/evasions.js`
- Drop the now-unused `p-wait-for` import (it was only used by that test)
- Remove `p-wait-for` from `packages/goto` devDependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only cleanup with no production code or runtime behavior changes.
> 
> **Overview**
> Removes the **areyouheadless** evasion e2e that polled `arh.antoinevastel.com/bots/areyouheadless`, because that endpoint is gone and the test could never pass.
> 
> Also drops the **`p-wait-for`** devDependency and its import from `evasions.js`, since it was only used by that test. Other evasion tests (`creepjs`, `fingerprintjs`, `amiunique`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8987a65cc085d4b502ca65711c29bd47929b8cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed the headless-browser detection test for `arh.antoinevastel.com`.
  * Retained coverage for other fingerprinting and browser-evasion scenarios.

* **Chores**
  * Removed an unused development dependency from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->