### PR TITLE
fix(pdf): navigation-tolerant readiness gate; skip screenshot poll for painted pages

### DIFF
--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -26,11 +26,49 @@ const scriptEvaluate = (snapshot, onDomStability) => async (_fn, args) => {
   return snapshot
 }
 
-const IMAGELESS_READY = { height: 800, images: 0, decoded: 0, painted: 0, complete: true }
-const PAINTED_READY = { height: 2000, images: 3, decoded: 3, painted: 3, complete: true }
+const IMAGELESS_READY = {
+  height: 800,
+  images: 0,
+  decoded: 0,
+  painted: 0,
+  text: 0,
+  fonts: true,
+  complete: true
+}
+const PAINTED_READY = {
+  height: 2000,
+  images: 3,
+  decoded: 3,
+  painted: 3,
+  text: 0,
+  fonts: true,
+  complete: true
+}
 // A blank shell: an image decoded (e.g. a tracking pixel) but nothing visibly
 // painted, in a document taller than the viewport.
-const PIXEL_ONLY_READY = { height: 2000, images: 1, decoded: 1, painted: 0, complete: true }
+const PIXEL_ONLY_READY = {
+  height: 2000,
+  images: 1,
+  decoded: 1,
+  painted: 0,
+  text: 0,
+  fonts: true,
+  complete: true
+}
+// A text-only article: no images, but enough visible text in the viewport with
+// webfonts loaded — painted content without a single <img>.
+const TEXT_READY = {
+  height: 2000,
+  images: 0,
+  decoded: 0,
+  painted: 0,
+  text: 200,
+  fonts: true,
+  complete: true
+}
+// Same text, but a webfont still loading: during `font-display: block` the
+// text renders invisible, so it must not count as painted.
+const FONT_PENDING_READY = { ...TEXT_READY, fonts: false }
 const viewport = () => ({ width: 1280, height: 720 })
 
 // A `goto` stub that just runs the `waitUntilAuto` hook and reports an action
@@ -200,5 +238,59 @@ test('waitUntil auto: a timed-out gate does not take the painted fast path', asy
   await pdf('https://example.com', { waitUntil: 'auto', timeout: 300 })
 
   t.true(screenshotCalls >= 1)
+  t.is(pdfCalls, 1)
+})
+
+test('waitUntil auto skips the screenshot poll for visible text', async t => {
+  let screenshotCalls = 0
+  let pdfCalls = 0
+
+  const page = {
+    viewport,
+    screenshot: async () => {
+      screenshotCalls += 1
+      return whiteScreenshot
+    },
+    evaluate: scriptEvaluate(TEXT_READY, () => {}),
+    pdf: async () => {
+      pdfCalls += 1
+      return Buffer.from('pdf')
+    }
+  }
+
+  const goto = makeGoto()
+
+  const pdf = createPdf({ goto })(page)
+  await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
+
+  t.is(screenshotCalls, 0)
+  t.is(pdfCalls, 1)
+})
+
+test('waitUntil auto: text behind a loading webfont does not trip the fast path', async t => {
+  let screenshotCalls = 0
+  let pdfCalls = 0
+
+  const page = {
+    viewport,
+    screenshot: async () => {
+      screenshotCalls += 1
+      return noWhiteScreenshot
+    },
+    evaluate: scriptEvaluate(FONT_PENDING_READY, () => {}),
+    pdf: async () => {
+      pdfCalls += 1
+      return Buffer.from('pdf')
+    }
+  }
+
+  const goto = makeGoto()
+
+  const pdf = createPdf({ goto })(page)
+  await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
+
+  // The text is there but invisible while the font blocks: the white-screen
+  // check must still run.
+  t.is(screenshotCalls, 1)
   t.is(pdfCalls, 1)
 })

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { waitForDomStability } = require('@browserless/screenshot')
 const createPdf = require('@browserless/pdf')
 const path = require('path')
 const fs = require('fs')
@@ -13,13 +14,12 @@ const noWhiteScreenshot = fs.readFileSync(
   path.resolve(__dirname, '../../screenshot/test/fixtures/no-white-5k.png')
 )
 
-// `waitUntilAuto` runs two in-page evaluates: `waitForDomStability` (invoked
-// with an options arg) and the readiness `snapshot` (invoked with none). This
-// helper answers the first by recording its arg, and the second with a scripted
-// paint snapshot. `imageless` (no decoded images) keeps `waitForReady` off its
-// fast path so the white-screen poll still runs.
-const scriptEvaluate = (snapshot, onDomStability) => async (_fn, args) => {
-  if (args !== undefined) {
+// `waitUntilAuto` runs two in-page evaluates: `waitForDomStability` and the
+// readiness `snapshot`. Dispatch on function identity — the workspace resolves
+// both packages to the same module instance — so the stub keeps routing
+// correctly even if either evaluate's signature changes.
+const scriptEvaluate = (snapshot, onDomStability) => async (fn, args) => {
+  if (fn === waitForDomStability) {
     onDomStability(args)
     return { status: 'idle' }
   }
@@ -28,6 +28,7 @@ const scriptEvaluate = (snapshot, onDomStability) => async (_fn, args) => {
 
 const IMAGELESS_READY = {
   height: 800,
+  viewport: 720,
   images: 0,
   decoded: 0,
   painted: 0,
@@ -37,6 +38,7 @@ const IMAGELESS_READY = {
 }
 const PAINTED_READY = {
   height: 2000,
+  viewport: 720,
   images: 3,
   decoded: 3,
   painted: 3,
@@ -48,6 +50,7 @@ const PAINTED_READY = {
 // painted, in a document taller than the viewport.
 const PIXEL_ONLY_READY = {
   height: 2000,
+  viewport: 720,
   images: 1,
   decoded: 1,
   painted: 0,
@@ -59,6 +62,7 @@ const PIXEL_ONLY_READY = {
 // webfonts loaded — painted content without a single <img>.
 const TEXT_READY = {
   height: 2000,
+  viewport: 720,
   images: 0,
   decoded: 0,
   painted: 0,
@@ -69,7 +73,6 @@ const TEXT_READY = {
 // Same text, but a webfont still loading: during `font-display: block` the
 // text renders invisible, so it must not count as painted.
 const FONT_PENDING_READY = { ...TEXT_READY, fonts: false }
-const viewport = () => ({ width: 1280, height: 720 })
 
 // A `goto` stub that just runs the `waitUntilAuto` hook and reports an action
 // timeout. `onWaitUntilAuto` observes the blank-SPA re-wait `prepare` triggers.
@@ -90,7 +93,6 @@ test('waitUntil auto should generate final pdf once', async t => {
   let domStabilityArgs
 
   const page = {
-    viewport,
     screenshot: async () => (screenshotCalls++ === 0 ? whiteScreenshot : noWhiteScreenshot),
     evaluate: scriptEvaluate(IMAGELESS_READY, args => (domStabilityArgs = args)),
     pdf: async () => {
@@ -115,7 +117,6 @@ test('waitUntil auto should honor custom waitForDom', async t => {
   let domStabilityArgs
 
   const page = {
-    viewport,
     screenshot: async () => noWhiteScreenshot,
     evaluate: scriptEvaluate(IMAGELESS_READY, args => (domStabilityArgs = args)),
     pdf: async () => Buffer.from('pdf')
@@ -134,7 +135,6 @@ test('retries pdf generation when navigation destroys the execution context', as
   let waitUntilAutoCalls = 0
 
   const page = {
-    viewport,
     screenshot: async () => noWhiteScreenshot,
     evaluate: scriptEvaluate(IMAGELESS_READY, () => {}),
     pdf: async () => {
@@ -160,7 +160,6 @@ test('waitUntil auto skips the screenshot poll for painted content', async t => 
   let pdfCalls = 0
 
   const page = {
-    viewport,
     screenshot: async () => {
       screenshotCalls += 1
       return whiteScreenshot
@@ -186,7 +185,6 @@ test('waitUntil auto: a decoded tracking pixel does not trip the painted fast pa
   let pdfCalls = 0
 
   const page = {
-    viewport,
     screenshot: async () => {
       screenshotCalls += 1
       return noWhiteScreenshot
@@ -217,14 +215,20 @@ test('waitUntil auto: a timed-out gate does not take the painted fast path', asy
   // Never settles (height keeps growing), so the gate times out while still
   // reporting painted content. The fast path must be skipped and the poll run.
   const page = {
-    viewport,
     screenshot: async () => {
       screenshotCalls += 1
       return noWhiteScreenshot
     },
-    evaluate: async (_fn, args) => {
-      if (args !== undefined) return { status: 'idle' }
-      return { height: (height += 100), images: 3, decoded: 3, painted: 3, complete: true }
+    evaluate: async fn => {
+      if (fn === waitForDomStability) return { status: 'idle' }
+      return {
+        height: (height += 100),
+        viewport: 720,
+        images: 3,
+        decoded: 3,
+        painted: 3,
+        complete: true
+      }
     },
     pdf: async () => {
       pdfCalls += 1
@@ -246,7 +250,6 @@ test('waitUntil auto skips the screenshot poll for visible text', async t => {
   let pdfCalls = 0
 
   const page = {
-    viewport,
     screenshot: async () => {
       screenshotCalls += 1
       return whiteScreenshot
@@ -272,7 +275,6 @@ test('waitUntil auto: text behind a loading webfont does not trip the fast path'
   let pdfCalls = 0
 
   const page = {
-    viewport,
     screenshot: async () => {
       screenshotCalls += 1
       return noWhiteScreenshot

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -245,6 +245,45 @@ test('waitUntil auto: a timed-out gate does not take the painted fast path', asy
   t.is(pdfCalls, 1)
 })
 
+test('the capture retry budget is the remaining action budget, not a fresh one', async t => {
+  let height = 1000
+
+  // Worst case on both stages: the gate never settles (eats its half of the
+  // budget), then every capture races a navigation. The retry loop must give
+  // up when the SHARED budget is spent — handing it a fresh full timeout
+  // would let prepare run ~1.5x the action budget (gate half + full retry).
+  const page = {
+    screenshot: async () => {
+      throw new Error('Execution context was destroyed, most likely because of a navigation.')
+    },
+    evaluate: async fn => {
+      if (fn === waitForDomStability) return { status: 'idle' }
+      return {
+        height: (height += 100),
+        viewport: 720,
+        images: 0,
+        decoded: 0,
+        painted: 0,
+        text: 0,
+        fonts: true,
+        complete: true
+      }
+    },
+    pdf: async () => Buffer.from('pdf')
+  }
+
+  const goto = makeGoto({ action: 2000 })
+
+  const pdf = createPdf({ goto })(page)
+  const start = Date.now()
+  await t.throwsAsync(() => pdf('https://example.com', { waitUntil: 'auto', timeout: 2000 }), {
+    message: /Execution context was destroyed/
+  })
+  // gate ~1000ms + retries bounded by the remaining ~1000ms ≈ 2000ms total;
+  // a fresh per-capture budget would push this to ~3000ms.
+  t.true(Date.now() - start < 2600)
+})
+
 test('waitUntil auto skips the screenshot poll for visible text', async t => {
   let screenshotCalls = 0
   let pdfCalls = 0

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -161,3 +161,41 @@ test('waitUntil auto skips the screenshot poll for painted content', async t => 
   t.is(screenshotCalls, 0)
   t.is(pdfCalls, 1)
 })
+
+test('waitUntil auto: a timed-out gate does not take the painted fast path', async t => {
+  let screenshotCalls = 0
+  let pdfCalls = 0
+  let height = 1000
+
+  // Never settles (height keeps growing), so the gate times out while still
+  // reporting painted content. The fast path must be skipped and the poll run.
+  const page = {
+    viewport,
+    screenshot: async () => {
+      screenshotCalls += 1
+      return noWhiteScreenshot
+    },
+    evaluate: async (_fn, args) => {
+      if (args !== undefined) return { status: 'idle' }
+      return { height: (height += 100), images: 3, decoded: 3, complete: true }
+    },
+    pdf: async () => {
+      pdfCalls += 1
+      return Buffer.from('pdf')
+    }
+  }
+
+  const goto = async (page, opts = {}) => {
+    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
+    return { response: {} }
+  }
+
+  goto.timeouts = { action: () => 300 }
+  goto.waitUntilAuto = async () => {}
+
+  const pdf = createPdf({ goto })(page)
+  await pdf('https://example.com', { waitUntil: 'auto', timeout: 300 })
+
+  t.true(screenshotCalls >= 1)
+  t.is(pdfCalls, 1)
+})

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -13,6 +13,23 @@ const noWhiteScreenshot = fs.readFileSync(
   path.resolve(__dirname, '../../screenshot/test/fixtures/no-white-5k.png')
 )
 
+// `waitUntilAuto` runs two in-page evaluates: `waitForDomStability` (invoked
+// with an options arg) and the readiness `snapshot` (invoked with none). This
+// helper answers the first by recording its arg, and the second with a scripted
+// paint snapshot. `imageless` (no decoded images) keeps `waitForReady` off its
+// fast path so the white-screen poll still runs.
+const scriptEvaluate = (snapshot, onDomStability) => async (_fn, args) => {
+  if (args !== undefined) {
+    onDomStability(args)
+    return { status: 'idle' }
+  }
+  return snapshot
+}
+
+const IMAGELESS_READY = { height: 800, images: 0, decoded: 0, complete: true }
+const PAINTED_READY = { height: 2000, images: 3, decoded: 3, complete: true }
+const viewport = () => ({ width: 1280, height: 720 })
+
 test('waitUntil auto should generate final pdf once', async t => {
   let screenshotCalls = 0
   let pdfCalls = 0
@@ -20,11 +37,9 @@ test('waitUntil auto should generate final pdf once', async t => {
   let domStabilityArgs
 
   const page = {
+    viewport,
     screenshot: async () => (screenshotCalls++ === 0 ? whiteScreenshot : noWhiteScreenshot),
-    evaluate: async (_fn, args) => {
-      domStabilityArgs = args
-      return { status: 'idle' }
-    },
+    evaluate: scriptEvaluate(IMAGELESS_READY, args => (domStabilityArgs = args)),
     pdf: async () => {
       pdfCalls += 1
       return Buffer.from(`pdf-${pdfCalls}`)
@@ -58,11 +73,9 @@ test('waitUntil auto should honor custom waitForDom', async t => {
   let domStabilityArgs
 
   const page = {
+    viewport,
     screenshot: async () => noWhiteScreenshot,
-    evaluate: async (_fn, args) => {
-      domStabilityArgs = args
-      return { status: 'idle' }
-    },
+    evaluate: scriptEvaluate(IMAGELESS_READY, args => (domStabilityArgs = args)),
     pdf: async () => Buffer.from('pdf')
   }
 
@@ -88,8 +101,9 @@ test('retries pdf generation when navigation destroys the execution context', as
   let waitUntilAutoCalls = 0
 
   const page = {
+    viewport,
     screenshot: async () => noWhiteScreenshot,
-    evaluate: async () => ({ status: 'idle' }),
+    evaluate: scriptEvaluate(IMAGELESS_READY, () => {}),
     pdf: async () => {
       if (pdfCalls++ === 0) {
         throw new Error('Execution context was destroyed, most likely because of a navigation.')
@@ -114,4 +128,36 @@ test('retries pdf generation when navigation destroys the execution context', as
   t.deepEqual(buffer, Buffer.from('pdf-ok'))
   t.is(pdfCalls, 2)
   t.is(waitUntilAutoCalls, 1)
+})
+
+test('waitUntil auto skips the screenshot poll for painted content', async t => {
+  let screenshotCalls = 0
+  let pdfCalls = 0
+
+  const page = {
+    viewport,
+    screenshot: async () => {
+      screenshotCalls += 1
+      return whiteScreenshot
+    },
+    evaluate: scriptEvaluate(PAINTED_READY, () => {}),
+    pdf: async () => {
+      pdfCalls += 1
+      return Buffer.from('pdf')
+    }
+  }
+
+  const goto = async (page, opts = {}) => {
+    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
+    return { response: {} }
+  }
+
+  goto.timeouts = { action: () => 100000 }
+  goto.waitUntilAuto = async () => {}
+
+  const pdf = createPdf({ goto })(page)
+  await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
+
+  t.is(screenshotCalls, 0)
+  t.is(pdfCalls, 1)
 })

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -33,6 +33,18 @@ const PAINTED_READY = { height: 2000, images: 3, decoded: 3, painted: 3, complet
 const PIXEL_ONLY_READY = { height: 2000, images: 1, decoded: 1, painted: 0, complete: true }
 const viewport = () => ({ width: 1280, height: 720 })
 
+// A `goto` stub that just runs the `waitUntilAuto` hook and reports an action
+// timeout. `onWaitUntilAuto` observes the blank-SPA re-wait `prepare` triggers.
+const makeGoto = ({ action = 100000, onWaitUntilAuto } = {}) => {
+  const goto = async (page, opts = {}) => {
+    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
+    return { response: {} }
+  }
+  goto.timeouts = { action: () => action }
+  goto.waitUntilAuto = async () => onWaitUntilAuto && onWaitUntilAuto()
+  return goto
+}
+
 test('waitUntil auto should generate final pdf once', async t => {
   let screenshotCalls = 0
   let pdfCalls = 0
@@ -49,18 +61,7 @@ test('waitUntil auto should generate final pdf once', async t => {
     }
   }
 
-  const goto = async (page, opts = {}) => {
-    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
-    return { response: {} }
-  }
-
-  goto.timeouts = {
-    action: () => 100000
-  }
-
-  goto.waitUntilAuto = async () => {
-    waitUntilAutoCalls += 1
-  }
+  const goto = makeGoto({ onWaitUntilAuto: () => (waitUntilAutoCalls += 1) })
 
   const pdf = createPdf({ goto })(page)
   const buffer = await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
@@ -82,16 +83,7 @@ test('waitUntil auto should honor custom waitForDom', async t => {
     pdf: async () => Buffer.from('pdf')
   }
 
-  const goto = async (page, opts = {}) => {
-    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
-    return { response: {} }
-  }
-
-  goto.timeouts = {
-    action: () => 100000
-  }
-
-  goto.waitUntilAuto = async () => {}
+  const goto = makeGoto()
 
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', waitForDom: 2500, timeout: 500 })
@@ -115,15 +107,7 @@ test('retries pdf generation when navigation destroys the execution context', as
     }
   }
 
-  const goto = async (page, opts = {}) => {
-    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
-    return { response: {} }
-  }
-
-  goto.timeouts = { action: () => 100000 }
-  goto.waitUntilAuto = async () => {
-    waitUntilAutoCalls += 1
-  }
+  const goto = makeGoto({ onWaitUntilAuto: () => (waitUntilAutoCalls += 1) })
 
   const pdf = createPdf({ goto })(page)
   const buffer = await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
@@ -150,13 +134,7 @@ test('waitUntil auto skips the screenshot poll for painted content', async t => 
     }
   }
 
-  const goto = async (page, opts = {}) => {
-    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
-    return { response: {} }
-  }
-
-  goto.timeouts = { action: () => 100000 }
-  goto.waitUntilAuto = async () => {}
+  const goto = makeGoto()
 
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
@@ -182,13 +160,7 @@ test('waitUntil auto: a decoded tracking pixel does not trip the painted fast pa
     }
   }
 
-  const goto = async (page, opts = {}) => {
-    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
-    return { response: {} }
-  }
-
-  goto.timeouts = { action: () => 100000 }
-  goto.waitUntilAuto = async () => {}
+  const goto = makeGoto()
 
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
@@ -222,13 +194,7 @@ test('waitUntil auto: a timed-out gate does not take the painted fast path', asy
     }
   }
 
-  const goto = async (page, opts = {}) => {
-    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
-    return { response: {} }
-  }
-
-  goto.timeouts = { action: () => 300 }
-  goto.waitUntilAuto = async () => {}
+  const goto = makeGoto({ action: 300 })
 
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', timeout: 300 })

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -26,8 +26,11 @@ const scriptEvaluate = (snapshot, onDomStability) => async (_fn, args) => {
   return snapshot
 }
 
-const IMAGELESS_READY = { height: 800, images: 0, decoded: 0, complete: true }
-const PAINTED_READY = { height: 2000, images: 3, decoded: 3, complete: true }
+const IMAGELESS_READY = { height: 800, images: 0, decoded: 0, painted: 0, complete: true }
+const PAINTED_READY = { height: 2000, images: 3, decoded: 3, painted: 3, complete: true }
+// A blank shell: an image decoded (e.g. a tracking pixel) but nothing visibly
+// painted, in a document taller than the viewport.
+const PIXEL_ONLY_READY = { height: 2000, images: 1, decoded: 1, painted: 0, complete: true }
 const viewport = () => ({ width: 1280, height: 720 })
 
 test('waitUntil auto should generate final pdf once', async t => {
@@ -162,6 +165,40 @@ test('waitUntil auto skips the screenshot poll for painted content', async t => 
   t.is(pdfCalls, 1)
 })
 
+test('waitUntil auto: a decoded tracking pixel does not trip the painted fast path', async t => {
+  let screenshotCalls = 0
+  let pdfCalls = 0
+
+  const page = {
+    viewport,
+    screenshot: async () => {
+      screenshotCalls += 1
+      return noWhiteScreenshot
+    },
+    evaluate: scriptEvaluate(PIXEL_ONLY_READY, () => {}),
+    pdf: async () => {
+      pdfCalls += 1
+      return Buffer.from('pdf')
+    }
+  }
+
+  const goto = async (page, opts = {}) => {
+    if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
+    return { response: {} }
+  }
+
+  goto.timeouts = { action: () => 100000 }
+  goto.waitUntilAuto = async () => {}
+
+  const pdf = createPdf({ goto })(page)
+  await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
+
+  // Fast path skipped: the white-screen check still runs even though an image
+  // decoded, because nothing was visibly painted.
+  t.is(screenshotCalls, 1)
+  t.is(pdfCalls, 1)
+})
+
 test('waitUntil auto: a timed-out gate does not take the painted fast path', async t => {
   let screenshotCalls = 0
   let pdfCalls = 0
@@ -177,7 +214,7 @@ test('waitUntil auto: a timed-out gate does not take the painted fast path', asy
     },
     evaluate: async (_fn, args) => {
       if (args !== undefined) return { status: 'idle' }
-      return { height: (height += 100), images: 3, decoded: 3, complete: true }
+      return { height: (height += 100), images: 3, decoded: 3, painted: 3, complete: true }
     },
     pdf: async () => {
       pdfCalls += 1

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -27,6 +27,11 @@ const PDF_DEFAULT_OPTS = {
 // gate can't starve the fallback while total prepare stays within one `timeout`.
 const READY_BUDGET_RATIO = 0.5
 
+// Minimum visible characters for the text fast path. Matches the counting cap
+// in `waitForReady`'s snapshot, which stops walking text nodes once reached —
+// raising this above the cap would make the text fast path unreachable.
+const TEXT_PAINTED_MIN = 200
+
 const getMargin = unit => {
   if (!unit) return unit
   if (typeof unit === 'object') return unit
@@ -109,13 +114,16 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       const ready = await waitForReady(page, { timeout: Math.round(timeout * READY_BUDGET_RATIO) })
       debug('ready', { ...ready, duration: elapsed() })
 
-      // Fast path: the page settled with real painted content — a visibly
-      // rendered image (not a tracking pixel) in a document taller than the
-      // viewport can't be a blank shell, so skip the screenshot poll. A gate
-      // that timed out never settled, so don't trust its partial snapshot: fall
-      // through to the blank check.
+      // Fast path: the page settled with real painted content in a document
+      // taller than the viewport — a visibly rendered image (not a tracking
+      // pixel), or enough visible text with webfonts loaded (a pending
+      // `font-display: block` font renders text invisible, exactly when a
+      // capture would be white) — so it can't be a blank shell: skip the
+      // screenshot poll. A gate that timed out never settled, so don't trust
+      // its partial snapshot: fall through to the blank check.
       const viewportHeight = (page.viewport() || {}).height || 0
-      if (!ready.timedOut && ready.painted > 0 && ready.height > viewportHeight) return
+      const painted = ready.painted > 0 || (ready.text >= TEXT_PAINTED_MIN && ready.fonts)
+      if (!ready.timedOut && painted && ready.height > viewportHeight) return
 
       // Otherwise fall back to the screenshot poll — re-wait while the first
       // paint is still blank — to keep the blank-SPA protection. The page has

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -119,11 +119,13 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       // pixel), or enough visible text with webfonts loaded (a pending
       // `font-display: block` font renders text invisible, exactly when a
       // capture would be white) — so it can't be a blank shell: skip the
-      // screenshot poll. A gate that timed out never settled, so don't trust
-      // its partial snapshot: fall through to the blank check.
-      const viewportHeight = (page.viewport() || {}).height || 0
+      // screenshot poll. Height and viewport come from the same in-page
+      // snapshot (`page.viewport()` is null under `defaultViewport: null`),
+      // and an unknown viewport skips the fast path rather than dropping the
+      // taller-than-viewport guard. A gate that timed out never settled, so
+      // don't trust its partial snapshot: fall through to the blank check.
       const painted = ready.painted > 0 || (ready.text >= TEXT_PAINTED_MIN && ready.fonts)
-      if (!ready.timedOut && painted && ready.height > viewportHeight) return
+      if (!ready.timedOut && painted && ready.viewport > 0 && ready.height > ready.viewport) return
 
       // Otherwise fall back to the screenshot poll — re-wait while the first
       // paint is still blank — to keep the blank-SPA protection. The page has

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -144,7 +144,10 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
               type: 'jpeg',
               quality: 30
             }),
-          { page, goto, timeout }
+          // The retry loop keeps its own clock, so hand it only what is left
+          // of the shared budget — a fresh full `timeout` here would let one
+          // navigation-racing capture double the worst-case prepare time.
+          { page, goto, timeout: Math.max(0, timeout - elapsed()) }
         )
         isWhite = await isWhiteScreenshot(screenshot)
         if (isWhite) await goto.waitUntilAuto(page, { timeout: rest.timeout })

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -9,6 +9,7 @@ const {
   captureWithNavigationRetry,
   isWhiteScreenshot,
   waitForDomStability,
+  waitForReady,
   resolveWaitForDom,
   SCREENSHOT_DEFAULT_OPTS
 } = require('@browserless/screenshot')
@@ -54,8 +55,9 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
   }
 
   // Navigate `page` to `url` and wait until it is ready to print: DOM stability
-  // plus, in `auto` mode, a screenshot poll that re-waits while the first paint
-  // is still blank.
+  // plus, in `auto` mode, a navigation-tolerant readiness gate. Only a page that
+  // settles still-blank falls back to the (expensive, navigation-fragile)
+  // screenshot poll.
   const prepare = async (page, url, opts = {}) => {
     const {
       margin,
@@ -89,11 +91,34 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     async function waitUntilAuto (page) {
       await waitForDomStabilityResult(page)
       const timeout = goto.timeouts.action(rest.timeout)
-      let isWhite = false
+
+      // Cheap, navigation-tolerant readiness — no screenshots. Resolves once the
+      // page is visually quiet (height stable, images decoded, load complete),
+      // absorbing the client-side re-navigation that makes a screenshot poll
+      // throw `Execution context was destroyed`.
+      const readyTime = timeSpan()
+      const ready = await waitForReady(page, { timeout })
+      debug('ready', { ...ready, duration: readyTime() })
+
+      // Fast path: real painted content — decoded images in a document taller
+      // than the viewport can't be a blank shell, so skip the screenshot poll.
+      const viewportHeight = (page.viewport() || {}).height || 0
+      if (ready.decoded > 0 && ready.height > viewportHeight) return
+
+      // Otherwise a single white-screen check, now that the page has settled (so
+      // it won't race a navigation). A genuinely blank page falls back to the
+      // original screenshot poll to keep the blank-SPA protection.
+      const shot = await pReflect(
+        captureWithNavigationRetry(
+          () => page.screenshot({ ...rest, optimizeForSpeed: true, type: 'jpeg', quality: 30 }),
+          { page, goto, timeout }
+        )
+      )
+      if (shot.isFulfilled && !(await isWhiteScreenshot(shot.value))) return
+
+      let isWhite = true
       let retry = -1
-
       const timePdf = timeSpan()
-
       do {
         ++retry
         const screenshotTime = timeSpan()

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -91,14 +91,17 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     async function waitUntilAuto (page) {
       await waitForDomStabilityResult(page)
       const timeout = goto.timeouts.action(rest.timeout)
+      // One action budget shared by the readiness gate and the screenshot poll,
+      // so worst-case prepare stays within a single `timeout` instead of one
+      // per stage.
+      const elapsed = timeSpan()
 
       // Cheap, navigation-tolerant readiness — no screenshots. Resolves once the
       // page is visually quiet (height stable, images decoded, load complete),
       // absorbing the client-side re-navigation that makes a screenshot poll
       // throw `Execution context was destroyed`.
-      const readyTime = timeSpan()
       const ready = await waitForReady(page, { timeout })
-      debug('ready', { ...ready, duration: readyTime() })
+      debug('ready', { ...ready, duration: elapsed() })
 
       // Fast path: the page settled with real painted content — decoded images
       // in a document taller than the viewport can't be a blank shell, so skip
@@ -113,7 +116,6 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       // non-blank page exits after that single shot without an extra re-wait.
       let isWhite = false
       let retry = -1
-      const timePdf = timeSpan()
       do {
         ++retry
         const screenshotTime = timeSpan()
@@ -130,9 +132,9 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
         isWhite = await isWhiteScreenshot(screenshot)
         if (isWhite) await goto.waitUntilAuto(page, { timeout: rest.timeout })
         debug('retry', { waitUntil, isWhite, retry, duration: screenshotTime() })
-      } while (isWhite && timePdf() < timeout)
+      } while (isWhite && elapsed() < timeout)
 
-      debug({ waitUntil, isWhite, timeout, duration: require('pretty-ms')(timePdf()) })
+      debug({ waitUntil, isWhite, timeout, duration: require('pretty-ms')(elapsed()) })
     }
   }
 

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -100,23 +100,18 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       const ready = await waitForReady(page, { timeout })
       debug('ready', { ...ready, duration: readyTime() })
 
-      // Fast path: real painted content — decoded images in a document taller
-      // than the viewport can't be a blank shell, so skip the screenshot poll.
+      // Fast path: the page settled with real painted content — decoded images
+      // in a document taller than the viewport can't be a blank shell, so skip
+      // the screenshot poll. A gate that timed out never settled, so don't trust
+      // its partial snapshot: fall through to the blank check.
       const viewportHeight = (page.viewport() || {}).height || 0
-      if (ready.decoded > 0 && ready.height > viewportHeight) return
+      if (!ready.timedOut && ready.decoded > 0 && ready.height > viewportHeight) return
 
-      // Otherwise a single white-screen check, now that the page has settled (so
-      // it won't race a navigation). A genuinely blank page falls back to the
-      // original screenshot poll to keep the blank-SPA protection.
-      const shot = await pReflect(
-        captureWithNavigationRetry(
-          () => page.screenshot({ ...rest, optimizeForSpeed: true, type: 'jpeg', quality: 30 }),
-          { page, goto, timeout }
-        )
-      )
-      if (shot.isFulfilled && !(await isWhiteScreenshot(shot.value))) return
-
-      let isWhite = true
+      // Otherwise fall back to the screenshot poll — re-wait while the first
+      // paint is still blank — to keep the blank-SPA protection. The page has
+      // already settled, so the first capture won't race a navigation, and a
+      // non-blank page exits after that single shot without an extra re-wait.
+      let isWhite = false
       let retry = -1
       const timePdf = timeSpan()
       do {

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -22,6 +22,11 @@ const PDF_DEFAULT_OPTS = {
   waitUntil: 'auto'
 }
 
+// Share of the action budget the readiness gate may consume in `auto` mode. The
+// remainder is reserved for the blank-SPA screenshot poll to re-wait, so the
+// gate can't starve the fallback while total prepare stays within one `timeout`.
+const READY_BUDGET_RATIO = 0.5
+
 const getMargin = unit => {
   if (!unit) return unit
   if (typeof unit === 'object') return unit
@@ -99,8 +104,9 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       // Cheap, navigation-tolerant readiness — no screenshots. Resolves once the
       // page is visually quiet (height stable, images decoded, load complete),
       // absorbing the client-side re-navigation that makes a screenshot poll
-      // throw `Execution context was destroyed`.
-      const ready = await waitForReady(page, { timeout })
+      // throw `Execution context was destroyed`. Capped at a share of the budget
+      // so a slow gate still leaves the blank-SPA poll room to re-wait.
+      const ready = await waitForReady(page, { timeout: Math.round(timeout * READY_BUDGET_RATIO) })
       debug('ready', { ...ready, duration: elapsed() })
 
       // Fast path: the page settled with real painted content — decoded images

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -109,12 +109,13 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       const ready = await waitForReady(page, { timeout: Math.round(timeout * READY_BUDGET_RATIO) })
       debug('ready', { ...ready, duration: elapsed() })
 
-      // Fast path: the page settled with real painted content — decoded images
-      // in a document taller than the viewport can't be a blank shell, so skip
-      // the screenshot poll. A gate that timed out never settled, so don't trust
-      // its partial snapshot: fall through to the blank check.
+      // Fast path: the page settled with real painted content — a visibly
+      // rendered image (not a tracking pixel) in a document taller than the
+      // viewport can't be a blank shell, so skip the screenshot poll. A gate
+      // that timed out never settled, so don't trust its partial snapshot: fall
+      // through to the blank check.
       const viewportHeight = (page.viewport() || {}).height || 0
-      if (!ready.timedOut && ready.decoded > 0 && ready.height > viewportHeight) return
+      if (!ready.timedOut && ready.painted > 0 && ready.height > viewportHeight) return
 
       // Otherwise fall back to the screenshot poll — re-wait while the first
       // paint is still blank — to keep the blank-SPA protection. The page has

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -10,6 +10,7 @@ const waitForPrism = require('./pretty')
 const prettyTimeSpan = require('./time-span')
 const overlay = require('./overlay')
 const { waitForDomStability, resolveWaitForDom, DEFAULT_WAIT_FOR_DOM } = require('./wait-for-dom')
+const { waitForReady, DEFAULT_READY_OPTS } = require('./wait-for-ready')
 
 const timeSpan = require('@kikobeats/time-span')()
 
@@ -277,4 +278,6 @@ module.exports.captureWithNavigationRetry = captureWithNavigationRetry
 module.exports.isWhiteScreenshot = isWhiteScreenshot
 module.exports.waitForDomStability = waitForDomStability
 module.exports.resolveWaitForDom = resolveWaitForDom
+module.exports.waitForReady = waitForReady
+module.exports.DEFAULT_READY_OPTS = DEFAULT_READY_OPTS
 module.exports.SCREENSHOT_DEFAULT_OPTS = SCREENSHOT_DEFAULT_OPTS

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -10,7 +10,7 @@ const waitForPrism = require('./pretty')
 const prettyTimeSpan = require('./time-span')
 const overlay = require('./overlay')
 const { waitForDomStability, resolveWaitForDom, DEFAULT_WAIT_FOR_DOM } = require('./wait-for-dom')
-const { waitForReady, DEFAULT_READY_OPTS } = require('./wait-for-ready')
+const { waitForReady } = require('./wait-for-ready')
 
 const timeSpan = require('@kikobeats/time-span')()
 
@@ -279,5 +279,4 @@ module.exports.isWhiteScreenshot = isWhiteScreenshot
 module.exports.waitForDomStability = waitForDomStability
 module.exports.resolveWaitForDom = resolveWaitForDom
 module.exports.waitForReady = waitForReady
-module.exports.DEFAULT_READY_OPTS = DEFAULT_READY_OPTS
 module.exports.SCREENSHOT_DEFAULT_OPTS = SCREENSHOT_DEFAULT_OPTS

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -13,9 +13,12 @@ const { isContextDestroyed } = require('@browserless/errors')
 
 // Evaluated in-page: a cheap snapshot of the paint/settle signals. `decoded`
 // counts every loaded image (the load-settled signal); `painted` counts only
-// images rendered at a visible size — a 16×16 box or larger — so a lone
-// tracking pixel or 1×1 beacon can't pass for real content.
+// images a screenshot would actually see — decoded, rendered at a visible size
+// (a 16×16 box or larger, so a tracking pixel doesn't count), inside the
+// viewport, and not hidden via CSS — so a blank shell can't pass for content.
 const snapshot = () => {
+  const vw = window.innerWidth || document.documentElement.clientWidth
+  const vh = window.innerHeight || document.documentElement.clientHeight
   const images = document.images
   let decoded = 0
   let painted = 0
@@ -23,8 +26,16 @@ const snapshot = () => {
     const img = images[i]
     if (!img.complete || img.naturalWidth === 0) continue
     decoded++
-    const { width, height } = img.getBoundingClientRect()
-    if (width * height >= 256) painted++
+    const rect = img.getBoundingClientRect()
+    if (rect.width * rect.height < 256) continue
+    if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= vh || rect.left >= vw) continue
+    if (
+      typeof img.checkVisibility === 'function' &&
+      !img.checkVisibility({ visibilityProperty: true, opacityProperty: true })
+    ) {
+      continue
+    }
+    painted++
   }
   return {
     height: document.documentElement.scrollHeight,

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -24,7 +24,9 @@ const { isContextDestroyed } = require('@browserless/errors')
 // characters inside the viewport, counted up to 200 (the threshold consumers
 // rely on), and `fonts` reports whether webfonts finished loading — during a
 // `font-display: block` period text renders invisible, exactly when a capture
-// would be white.
+// would be white. `viewport` is the in-page viewport height, so consumers can
+// compare it against `height` without relying on `page.viewport()`, which is
+// null under `defaultViewport: null`.
 const snapshot = () => {
   const vw = window.innerWidth || document.documentElement.clientWidth
   const vh = window.innerHeight || document.documentElement.clientHeight
@@ -88,6 +90,7 @@ const snapshot = () => {
   }
   return {
     height: document.documentElement.scrollHeight,
+    viewport: vh,
     images,
     decoded,
     painted,
@@ -108,6 +111,7 @@ const waitForReady = async (page, { timeout, quietMs = 600, poll = 150 } = {}) =
   let resets = 0
   let last = {
     height: 0,
+    viewport: 0,
     images: 0,
     decoded: 0,
     painted: 0,

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -1,0 +1,73 @@
+'use strict'
+
+// Navigation-tolerant readiness gate. Resolves once the page has been visually
+// quiet — document height stable, every image decoded, `readyState` complete —
+// for `quietMs`, bounded by `timeout`. Unlike a screenshot poll it takes no
+// screenshots (which are expensive under software rendering, e.g. the GPU-less
+// fleet's llvmpipe) and it survives a client-side navigation: when the
+// execution context is destroyed mid-check the quiet window resets and polling
+// continues instead of throwing (SPAs re-commit their own URL after load).
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+// Evaluated in-page: a cheap snapshot of the paint/settle signals.
+const snapshot = () => {
+  const images = document.images
+  let decoded = 0
+  for (let i = 0; i < images.length; i++) {
+    const img = images[i]
+    if (img.complete && img.naturalWidth > 0) decoded++
+  }
+  return {
+    height: document.documentElement.scrollHeight,
+    images: images.length,
+    decoded,
+    complete: document.readyState === 'complete'
+  }
+}
+
+const DEFAULT_READY_OPTS = { quietMs: 600, poll: 150 }
+
+const waitForReady = async (
+  page,
+  { timeout, quietMs = DEFAULT_READY_OPTS.quietMs, poll = DEFAULT_READY_OPTS.poll } = {}
+) => {
+  const deadline = Date.now() + timeout
+  let lastHeight = -1
+  let quietSince = 0
+  let resets = 0
+  let last = { height: 0, images: 0, decoded: 0, complete: false }
+
+  while (Date.now() < deadline) {
+    let snap
+    try {
+      snap = await page.evaluate(snapshot)
+    } catch {
+      // Execution context destroyed by a client-side navigation: reset the
+      // quiet window and keep polling instead of failing the capture.
+      resets++
+      lastHeight = -1
+      quietSince = 0
+      await sleep(poll)
+      continue
+    }
+
+    last = snap
+    const imagesDecoded = snap.images === 0 || snap.decoded >= snap.images
+    const quiet = snap.complete && imagesDecoded && snap.height === lastHeight
+
+    if (quiet) {
+      if (quietSince === 0) quietSince = Date.now()
+      if (Date.now() - quietSince >= quietMs) return { ...snap, resets, timedOut: false }
+    } else {
+      quietSince = 0
+      lastHeight = snap.height
+    }
+
+    await sleep(poll)
+  }
+
+  return { ...last, resets, timedOut: true }
+}
+
+module.exports = { waitForReady, DEFAULT_READY_OPTS }

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -8,7 +8,7 @@
 // execution context is destroyed mid-check the quiet window resets and polling
 // continues instead of throwing (SPAs re-commit their own URL after load).
 
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+const { setTimeout: sleep } = require('node:timers/promises')
 
 // Evaluated in-page: a cheap snapshot of the paint/settle signals.
 const snapshot = () => {
@@ -26,12 +26,8 @@ const snapshot = () => {
   }
 }
 
-const DEFAULT_READY_OPTS = { quietMs: 600, poll: 150 }
-
-const waitForReady = async (
-  page,
-  { timeout, quietMs = DEFAULT_READY_OPTS.quietMs, poll = DEFAULT_READY_OPTS.poll } = {}
-) => {
+const waitForReady = async (page, { timeout, quietMs = 600, poll = 150 } = {}) => {
+  if (typeof timeout !== 'number') throw new TypeError('timeout must be a number')
   const deadline = Date.now() + timeout
   let lastHeight = -1
   let quietSince = 0
@@ -70,4 +66,4 @@ const waitForReady = async (
   return { ...last, resets, timedOut: true }
 }
 
-module.exports = { waitForReady, DEFAULT_READY_OPTS }
+module.exports = { waitForReady }

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -20,7 +20,11 @@ const { isContextDestroyed } = require('@browserless/errors')
 // images a screenshot would actually see: successfully decoded, rendered at a
 // visible size (a 16×16 box or larger, so a tracking pixel doesn't count),
 // inside the viewport, and not hidden via CSS — so a blank shell can't pass for
-// content.
+// content. `text` is the equivalent paint signal for imageless pages: visible
+// characters inside the viewport, counted up to 200 (the threshold consumers
+// rely on), and `fonts` reports whether webfonts finished loading — during a
+// `font-display: block` period text renders invisible, exactly when a capture
+// would be white.
 const snapshot = () => {
   const vw = window.innerWidth || document.documentElement.clientWidth
   const vh = window.innerHeight || document.documentElement.clientHeight
@@ -53,11 +57,42 @@ const snapshot = () => {
     }
     painted++
   }
+  // Counting stops at 200 chars, so a text-heavy page costs a handful of nodes,
+  // not a full DOM walk; only a near-blank shell walks every text node.
+  let text = 0
+  const walker = document.createTreeWalker(
+    document.body || document.documentElement,
+    window.NodeFilter.SHOW_TEXT
+  )
+  while (text < 200) {
+    const node = walker.nextNode()
+    if (!node) break
+    const value = node.nodeValue.trim()
+    if (!value) continue
+    const el = node.parentElement
+    if (!el) continue
+    const tag = el.tagName
+    if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT' || tag === 'TEMPLATE') continue
+    if (
+      typeof el.checkVisibility === 'function' &&
+      !el.checkVisibility({ visibilityProperty: true, opacityProperty: true })
+    ) {
+      continue
+    }
+    const range = document.createRange()
+    range.selectNodeContents(node)
+    const rect = range.getBoundingClientRect()
+    if (rect.width === 0 || rect.height === 0) continue
+    if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= vh || rect.left >= vw) continue
+    text += value.length
+  }
   return {
     height: document.documentElement.scrollHeight,
     images,
     decoded,
     painted,
+    text,
+    fonts: !document.fonts || document.fonts.status === 'loaded',
     complete: document.readyState === 'complete'
   }
 }
@@ -71,7 +106,15 @@ const waitForReady = async (page, { timeout, quietMs = 600, poll = 150 } = {}) =
   let lastHeight = -1
   let quietSince = 0
   let resets = 0
-  let last = { height: 0, images: 0, decoded: 0, painted: 0, complete: false }
+  let last = {
+    height: 0,
+    images: 0,
+    decoded: 0,
+    painted: 0,
+    text: 0,
+    fonts: false,
+    complete: false
+  }
 
   while (Date.now() < deadline) {
     let snap

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -9,6 +9,7 @@
 // continues instead of throwing (SPAs re-commit their own URL after load).
 
 const { setTimeout: sleep } = require('node:timers/promises')
+const { isContextDestroyed } = require('@browserless/errors')
 
 // Evaluated in-page: a cheap snapshot of the paint/settle signals.
 const snapshot = () => {
@@ -27,7 +28,7 @@ const snapshot = () => {
 }
 
 const waitForReady = async (page, { timeout, quietMs = 600, poll = 150 } = {}) => {
-  if (typeof timeout !== 'number') throw new TypeError('timeout must be a number')
+  if (!Number.isFinite(timeout)) throw new TypeError('timeout must be a finite number')
   const deadline = Date.now() + timeout
   let lastHeight = -1
   let quietSince = 0
@@ -38,9 +39,12 @@ const waitForReady = async (page, { timeout, quietMs = 600, poll = 150 } = {}) =
     let snap
     try {
       snap = await page.evaluate(snapshot)
-    } catch {
-      // Execution context destroyed by a client-side navigation: reset the
-      // quiet window and keep polling instead of failing the capture.
+    } catch (error) {
+      // Only a client-side navigation tearing down the execution context is
+      // absorbed: reset the quiet window and keep polling. Any other evaluate
+      // failure is a real error and surfaces instead of masquerading as a
+      // timeout.
+      if (!isContextDestroyed(error)) throw error
       resets++
       lastHeight = -1
       quietSince = 0

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -111,6 +111,10 @@ const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) =
   // gate could never satisfy its own requirement and would always time out.
   quietMs = Math.min(quietMs, Math.floor(timeout / 2))
   const deadline = Date.now() + timeout
+  // Never sleep past the deadline: with a poll larger than the remaining
+  // budget, a full-length sleep would overshoot the timeout and steal time
+  // from whatever shares the caller's budget (the blank-SPA screenshot poll).
+  const nextPoll = () => sleep(Math.min(poll, Math.max(0, deadline - Date.now())))
   let lastHeight = -1
   let quietSince = 0
   let resets = 0
@@ -138,7 +142,7 @@ const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) =
       resets++
       lastHeight = -1
       quietSince = 0
-      await sleep(poll)
+      await nextPoll()
       continue
     }
 
@@ -154,7 +158,7 @@ const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) =
       lastHeight = snap.height
     }
 
-    await sleep(poll)
+    await nextPoll()
   }
 
   return { ...last, resets, timedOut: true }

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -12,10 +12,11 @@ const { setTimeout: sleep } = require('node:timers/promises')
 const { isContextDestroyed } = require('@browserless/errors')
 
 // Evaluated in-page: a cheap snapshot of the paint/settle signals. `decoded`
-// counts every loaded image (the load-settled signal); `painted` counts only
-// images a screenshot would actually see — decoded, rendered at a visible size
-// (a 16×16 box or larger, so a tracking pixel doesn't count), inside the
-// viewport, and not hidden via CSS — so a blank shell can't pass for content.
+// counts every image that finished loading — a broken `<img>` counts too, so it
+// can't stall the settle gate — while `painted` counts only images a screenshot
+// would actually see: successfully decoded, rendered at a visible size (a 16×16
+// box or larger, so a tracking pixel doesn't count), inside the viewport, and
+// not hidden via CSS — so a blank shell can't pass for content.
 const snapshot = () => {
   const vw = window.innerWidth || document.documentElement.clientWidth
   const vh = window.innerHeight || document.documentElement.clientHeight
@@ -24,8 +25,9 @@ const snapshot = () => {
   let painted = 0
   for (let i = 0; i < images.length; i++) {
     const img = images[i]
-    if (!img.complete || img.naturalWidth === 0) continue
+    if (!img.complete) continue
     decoded++
+    if (img.naturalWidth === 0) continue
     const rect = img.getBoundingClientRect()
     if (rect.width * rect.height < 256) continue
     if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= vh || rect.left >= vw) continue

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -29,6 +29,9 @@ const snapshot = () => {
 
 const waitForReady = async (page, { timeout, quietMs = 600, poll = 150 } = {}) => {
   if (!Number.isFinite(timeout)) throw new TypeError('timeout must be a finite number')
+  // The quiet window must fit within the budget with room to observe it, or the
+  // gate could never satisfy its own requirement and would always time out.
+  quietMs = Math.min(quietMs, Math.floor(timeout / 2))
   const deadline = Date.now() + timeout
   let lastHeight = -1
   let quietSince = 0

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -11,18 +11,26 @@
 const { setTimeout: sleep } = require('node:timers/promises')
 const { isContextDestroyed } = require('@browserless/errors')
 
-// Evaluated in-page: a cheap snapshot of the paint/settle signals.
+// Evaluated in-page: a cheap snapshot of the paint/settle signals. `decoded`
+// counts every loaded image (the load-settled signal); `painted` counts only
+// images rendered at a visible size — a 16×16 box or larger — so a lone
+// tracking pixel or 1×1 beacon can't pass for real content.
 const snapshot = () => {
   const images = document.images
   let decoded = 0
+  let painted = 0
   for (let i = 0; i < images.length; i++) {
     const img = images[i]
-    if (img.complete && img.naturalWidth > 0) decoded++
+    if (!img.complete || img.naturalWidth === 0) continue
+    decoded++
+    const { width, height } = img.getBoundingClientRect()
+    if (width * height >= 256) painted++
   }
   return {
     height: document.documentElement.scrollHeight,
     images: images.length,
     decoded,
+    painted,
     complete: document.readyState === 'complete'
   }
 }
@@ -36,7 +44,7 @@ const waitForReady = async (page, { timeout, quietMs = 600, poll = 150 } = {}) =
   let lastHeight = -1
   let quietSince = 0
   let resets = 0
-  let last = { height: 0, images: 0, decoded: 0, complete: false }
+  let last = { height: 0, images: 0, decoded: 0, painted: 0, complete: false }
 
   while (Date.now() < deadline) {
     let snap

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -11,21 +11,35 @@
 const { setTimeout: sleep } = require('node:timers/promises')
 const { isContextDestroyed } = require('@browserless/errors')
 
-// Evaluated in-page: a cheap snapshot of the paint/settle signals. `decoded`
-// counts every image that finished loading — a broken `<img>` counts too, so it
-// can't stall the settle gate — while `painted` counts only images a screenshot
-// would actually see: successfully decoded, rendered at a visible size (a 16×16
-// box or larger, so a tracking pixel doesn't count), inside the viewport, and
-// not hidden via CSS — so a blank shell can't pass for content.
+// Evaluated in-page: a cheap snapshot of the paint/settle signals. `images`
+// counts only images expected to settle: a lazy image well below the viewport
+// sits outside Chromium's lazy-load fetch threshold and never starts loading
+// without a scroll, so counting it could only stall the gate into its timeout.
+// `decoded` counts every counted image that finished loading — a broken `<img>`
+// counts too, so it can't stall the settle gate — while `painted` counts only
+// images a screenshot would actually see: successfully decoded, rendered at a
+// visible size (a 16×16 box or larger, so a tracking pixel doesn't count),
+// inside the viewport, and not hidden via CSS — so a blank shell can't pass for
+// content.
 const snapshot = () => {
   const vw = window.innerWidth || document.documentElement.clientWidth
   const vh = window.innerHeight || document.documentElement.clientHeight
-  const images = document.images
+  const imgs = document.images
+  let images = 0
   let decoded = 0
   let painted = 0
-  for (let i = 0; i < images.length; i++) {
-    const img = images[i]
-    if (!img.complete) continue
+  for (let i = 0; i < imgs.length; i++) {
+    const img = imgs[i]
+    if (!img.complete) {
+      // Two viewports of headroom stays inside the smallest fetch threshold
+      // Chromium uses for lazy images (~1250px on fast connections), so an
+      // undecoded lazy image within it is loading and worth waiting for;
+      // beyond it, the fetch never starts.
+      if (img.loading === 'lazy' && img.getBoundingClientRect().top > vh * 2) continue
+      images++
+      continue
+    }
+    images++
     decoded++
     if (img.naturalWidth === 0) continue
     const rect = img.getBoundingClientRect()
@@ -41,7 +55,7 @@ const snapshot = () => {
   }
   return {
     height: document.documentElement.scrollHeight,
-    images: images.length,
+    images,
     decoded,
     painted,
     complete: document.readyState === 'complete'

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -100,7 +100,12 @@ const snapshot = () => {
   }
 }
 
-const waitForReady = async (page, { timeout, quietMs = 600, poll = 150 } = {}) => {
+// 300ms of held quiet plus one 150ms poll to prove height stability puts the
+// gate's floor at ~450ms. The hold guards against lulls (a page momentarily
+// stable between async chunks); height stability + all images decoded +
+// `readyState === 'complete'` carry most of the settle signal, so a longer
+// hold buys little — below ~300ms it would start trusting coincidences.
+const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) => {
   if (!Number.isFinite(timeout)) throw new TypeError('timeout must be a finite number')
   // The quiet window must fit within the budget with room to observe it, or the
   // gate could never satisfy its own requirement and would always time out.

--- a/packages/screenshot/test/wait-for-ready-live.js
+++ b/packages/screenshot/test/wait-for-ready-live.js
@@ -11,6 +11,9 @@ const { waitForReady } = require('..')
 // what distinguishes "painted" is the rendered box, viewport, and visibility.
 const PIXEL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC'
+// Valid data-URI syntax, but the payload ("hello") isn't a decodable image, so
+// the <img> finishes loading with an error: complete, naturalWidth 0.
+const BROKEN = 'data:image/png;base64,aGVsbG8='
 
 const html = body =>
   `<!doctype html><html><body style="margin:0;height:3000px">${body}</body></html>`
@@ -66,5 +69,13 @@ test('imageless page: no images, nothing painted', async t => {
   const r = await ready(browserless, '<h1>ok</h1>')(t)
   t.false(r.timedOut)
   t.is(r.images, 0)
+  t.is(r.painted, 0)
+})
+
+test('broken image: counts as settled (decoded) so it never stalls the gate', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(browserless, `<img src="${BROKEN}" width="300" height="300">`)(t)
+  t.false(r.timedOut)
+  t.is(r.decoded, 1)
   t.is(r.painted, 0)
 })

--- a/packages/screenshot/test/wait-for-ready-live.js
+++ b/packages/screenshot/test/wait-for-ready-live.js
@@ -80,6 +80,34 @@ test('broken image: counts as settled (decoded) so it never stalls the gate', as
   t.is(r.painted, 0)
 })
 
+test('text: 200+ visible characters in the viewport count as painted text', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(browserless, `<p>${'lorem ipsum '.repeat(20)}</p>`)(t)
+  t.false(r.timedOut)
+  t.true(r.text >= 200)
+  t.true(r.fonts)
+})
+
+test('hidden text does not count toward the text signal', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(
+    browserless,
+    `<p style="visibility:hidden">${'lorem ipsum '.repeat(20)}</p>`
+  )(t)
+  t.false(r.timedOut)
+  t.is(r.text, 0)
+})
+
+test('below-viewport text does not count toward the text signal', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(
+    browserless,
+    `<p style="position:absolute;top:5000px">${'lorem ipsum '.repeat(20)}</p>`
+  )(t)
+  t.false(r.timedOut)
+  t.is(r.text, 0)
+})
+
 test('below-fold lazy image: excluded from the settle gate so it cannot stall it', async t => {
   const browserless = await getBrowserContext(t)
   // 20000px down is beyond every lazy-load fetch threshold Chromium uses, so

--- a/packages/screenshot/test/wait-for-ready-live.js
+++ b/packages/screenshot/test/wait-for-ready-live.js
@@ -79,3 +79,20 @@ test('broken image: counts as settled (decoded) so it never stalls the gate', as
   t.is(r.decoded, 1)
   t.is(r.painted, 0)
 })
+
+test('below-fold lazy image: excluded from the settle gate so it cannot stall it', async t => {
+  const browserless = await getBrowserContext(t)
+  // 20000px down is beyond every lazy-load fetch threshold Chromium uses, so
+  // the image never starts loading (`complete` stays false forever). The src
+  // is a real HTTP URL: had the exclusion failed and the fetch happened, the
+  // server's HTML reply would error the <img> into `complete`, showing up as
+  // `images: 2, decoded: 2` instead of a timeout.
+  const r = await ready(
+    browserless,
+    `<img src="${PIXEL}" width="300" height="300">` +
+      '<img src="lazy.png" loading="lazy" width="300" height="300" style="position:absolute;top:20000px">'
+  )(t)
+  t.false(r.timedOut)
+  t.is(r.images, 1)
+  t.is(r.decoded, 1)
+})

--- a/packages/screenshot/test/wait-for-ready-live.js
+++ b/packages/screenshot/test/wait-for-ready-live.js
@@ -29,9 +29,8 @@ const ready = (browserless, body) => {
     return browserless.withPage((page, goto) => async () => {
       await goto(page, { url, waitUntil: 'load', adblock: false, timeout: 5000 })
       const result = await waitForReady(page, { timeout: 5000, quietMs: 100, poll: 50 })
-      const viewportHeight = await page.evaluate(() => window.innerHeight)
       await page.close()
-      return { ...result, viewportHeight }
+      return result
     })()
   }
 }
@@ -42,7 +41,8 @@ test('painted: a visibly rendered image in a tall document', async t => {
   t.false(r.timedOut)
   t.is(r.decoded, 1)
   t.true(r.painted >= 1)
-  t.true(r.height > r.viewportHeight)
+  t.true(r.viewport > 0)
+  t.true(r.height > r.viewport)
 })
 
 test('tracking pixel: decoded but not painted', async t => {

--- a/packages/screenshot/test/wait-for-ready-live.js
+++ b/packages/screenshot/test/wait-for-ready-live.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const { getBrowserContext, runServer } = require('@browserless/test')
+const test = require('ava')
+
+const { waitForReady } = require('..')
+
+// Exercises the real in-page `snapshot()` against a live DOM — the part the
+// unit tests can't reach, since `getBoundingClientRect`/`checkVisibility` only
+// mean anything in a browser. A 1×1 transparent PNG stands in for real imagery;
+// what distinguishes "painted" is the rendered box, viewport, and visibility.
+const PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC'
+
+const html = body =>
+  `<!doctype html><html><body style="margin:0;height:3000px">${body}</body></html>`
+
+const ready = (browserless, body) => {
+  const serve = t =>
+    runServer(t, ({ res }) => {
+      res.setHeader('content-type', 'text/html')
+      res.end(html(body))
+    })
+  return async t => {
+    const url = await serve(t)
+    return browserless.withPage((page, goto) => async () => {
+      await goto(page, { url, waitUntil: 'load', adblock: false, timeout: 5000 })
+      const result = await waitForReady(page, { timeout: 5000, quietMs: 100, poll: 50 })
+      const viewportHeight = await page.evaluate(() => window.innerHeight)
+      await page.close()
+      return { ...result, viewportHeight }
+    })()
+  }
+}
+
+test('painted: a visibly rendered image in a tall document', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(browserless, `<img src="${PIXEL}" width="300" height="300">`)(t)
+  t.false(r.timedOut)
+  t.is(r.decoded, 1)
+  t.true(r.painted >= 1)
+  t.true(r.height > r.viewportHeight)
+})
+
+test('tracking pixel: decoded but not painted', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(browserless, `<img src="${PIXEL}" width="1" height="1">`)(t)
+  t.false(r.timedOut)
+  t.is(r.decoded, 1)
+  t.is(r.painted, 0)
+})
+
+test('hidden image: decoded but not painted', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(
+    browserless,
+    `<img src="${PIXEL}" width="300" height="300" style="visibility:hidden">`
+  )(t)
+  t.false(r.timedOut)
+  t.is(r.decoded, 1)
+  t.is(r.painted, 0)
+})
+
+test('imageless page: no images, nothing painted', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(browserless, '<h1>ok</h1>')(t)
+  t.false(r.timedOut)
+  t.is(r.images, 0)
+  t.is(r.painted, 0)
+})

--- a/packages/screenshot/test/wait-for-ready.js
+++ b/packages/screenshot/test/wait-for-ready.js
@@ -46,6 +46,14 @@ test('navigation-tolerant: a destroyed context resets the quiet window, then res
   t.is(r.height, 1000)
 })
 
+test('clamps the quiet window to the budget so a tiny timeout still resolves', async t => {
+  const page = scriptedPage([READY, READY, READY, READY, READY, READY])
+  // quietMs (5000) far exceeds timeout (300): without clamping, the gate could
+  // never observe 5s of quiet within a 300ms budget and would always time out.
+  const r = await waitForReady(page, { timeout: 300, quietMs: 5000, poll: 10 })
+  t.false(r.timedOut)
+})
+
 test('a non-navigation evaluate error surfaces instead of spinning to a timeout', async t => {
   const boom = new Error('Evaluation failed: ReferenceError: snapshot is not defined')
   const page = scriptedPage([READY, boom])

--- a/packages/screenshot/test/wait-for-ready.js
+++ b/packages/screenshot/test/wait-for-ready.js
@@ -55,6 +55,13 @@ test('times out when the page never settles (height keeps growing)', async t => 
   t.true(r.timedOut)
 })
 
+test('fails fast when `timeout` is missing instead of returning a NaN deadline', async t => {
+  const page = scriptedPage([READY])
+  await t.throwsAsync(() => waitForReady(page, { quietMs: 40, poll: 10 }), {
+    instanceOf: TypeError
+  })
+})
+
 test('an imageless page is ready on height/readyState quiet alone', async t => {
   const s = { height: 800, images: 0, decoded: 0, complete: true }
   const page = scriptedPage([s, s, s, s, s])

--- a/packages/screenshot/test/wait-for-ready.js
+++ b/packages/screenshot/test/wait-for-ready.js
@@ -46,6 +46,14 @@ test('navigation-tolerant: a destroyed context resets the quiet window, then res
   t.is(r.height, 1000)
 })
 
+test('a non-navigation evaluate error surfaces instead of spinning to a timeout', async t => {
+  const boom = new Error('Evaluation failed: ReferenceError: snapshot is not defined')
+  const page = scriptedPage([READY, boom])
+  await t.throwsAsync(() => waitForReady(page, { timeout: 2000, quietMs: 40, poll: 10 }), {
+    message: /Evaluation failed/
+  })
+})
+
 test('times out when the page never settles (height keeps growing)', async t => {
   let h = 0
   const page = {

--- a/packages/screenshot/test/wait-for-ready.js
+++ b/packages/screenshot/test/wait-for-ready.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const test = require('ava')
+
+const { waitForReady } = require('..')
+
+// A fake page whose `evaluate` yields scripted snapshots (or throws to simulate
+// a client-side navigation destroying the execution context). No browser: this
+// exercises the gate's decision logic deterministically and fast.
+const scriptedPage = frames => {
+  let i = 0
+  return {
+    evaluate: async () => {
+      const frame = frames[Math.min(i, frames.length - 1)]
+      i++
+      if (frame instanceof Error) throw frame
+      return frame
+    }
+  }
+}
+
+const READY = { height: 1000, images: 3, decoded: 3, complete: true }
+
+test('resolves once the page is quiet: height stable, images decoded, load complete', async t => {
+  const page = scriptedPage([
+    { height: 500, images: 3, decoded: 1, complete: false }, // still loading
+    { height: 900, images: 3, decoded: 2, complete: true }, // images not all decoded
+    READY,
+    READY,
+    READY,
+    READY,
+    READY // stable
+  ])
+  const r = await waitForReady(page, { timeout: 2000, quietMs: 40, poll: 10 })
+  t.false(r.timedOut)
+  t.is(r.height, 1000)
+  t.is(r.resets, 0)
+})
+
+test('navigation-tolerant: a destroyed context resets the quiet window, then resolves', async t => {
+  const boom = new Error('Execution context was destroyed, most likely because of a navigation.')
+  const page = scriptedPage([READY, READY, boom, boom, READY, READY, READY, READY])
+  const r = await waitForReady(page, { timeout: 2000, quietMs: 40, poll: 10 })
+  t.false(r.timedOut)
+  t.true(r.resets >= 1, 'counted the navigation resets')
+  t.is(r.height, 1000)
+})
+
+test('times out when the page never settles (height keeps growing)', async t => {
+  let h = 0
+  const page = {
+    evaluate: async () => ({ height: (h += 100), images: 2, decoded: 2, complete: true })
+  }
+  const r = await waitForReady(page, { timeout: 200, quietMs: 60, poll: 10 })
+  t.true(r.timedOut)
+})
+
+test('an imageless page is ready on height/readyState quiet alone', async t => {
+  const s = { height: 800, images: 0, decoded: 0, complete: true }
+  const page = scriptedPage([s, s, s, s, s])
+  const r = await waitForReady(page, { timeout: 1000, quietMs: 40, poll: 10 })
+  t.false(r.timedOut)
+  t.is(r.images, 0)
+})

--- a/packages/screenshot/test/wait-for-ready.js
+++ b/packages/screenshot/test/wait-for-ready.js
@@ -71,6 +71,19 @@ test('times out when the page never settles (height keeps growing)', async t => 
   t.true(r.timedOut)
 })
 
+test('the poll sleep is clamped to the deadline so a huge poll cannot overshoot', async t => {
+  let h = 0
+  const page = {
+    evaluate: async () => ({ height: (h += 100), images: 0, decoded: 0, complete: true })
+  }
+  const start = Date.now()
+  // poll (10s) dwarfs the budget (120ms): an unclamped sleep would hold the
+  // gate ~10s past its deadline, stealing that time from the caller's budget.
+  const r = await waitForReady(page, { timeout: 120, quietMs: 40, poll: 10000 })
+  t.true(r.timedOut)
+  t.true(Date.now() - start < 1000)
+})
+
 test('fails fast when `timeout` is missing instead of returning a NaN deadline', async t => {
   const page = scriptedPage([READY])
   await t.throwsAsync(() => waitForReady(page, { quietMs: 40, poll: 10 }), {


### PR DESCRIPTION
## Problem

`prepare()`'s `auto` readiness gates on a **screenshot poll** (`waitUntilAuto`): screenshot → `isWhite?` → repeat. In the GPU-less fleet (llvmpipe) this has two failure modes:

- **Slow.** Screenshots are software-rasterized (seconds each), so readiness alone burns 7–14s even for tiny documents.
- **Fragile.** The poll throws `Execution context was destroyed, most likely because of a navigation` / `Page.captureScreenshot: Target closed` when a page client-navigates under it. Many pages (webtoon readers, scribd) re-commit their own URL right after `load`, so the capture races the re-nav and the whole render fails.

Downstream (microlink-api) this surfaces as PDF requests silently falling back to a full single-shot render and timing out at 28s.

## Change

Add `waitForReady` to `@browserless/screenshot`: a **navigation-tolerant** gate that resolves once the page is visually quiet — document height stable, every image decoded, `readyState === 'complete'` — held for `quietMs`, taking **no screenshots**. When `page.evaluate` throws on a destroyed context it resets the quiet window and keeps polling instead of failing.

`prepare()` now runs `waitForReady` first. Real painted content (decoded images in a document taller than the viewport) returns immediately; only a page that settles *still-blank* falls back to the original screenshot poll, so the blank-SPA protection is preserved.

## Validation

- 4 deterministic unit tests for the gate (quiet→resolve, nav-reset→resolve, never-settles→timeout, imageless page).
- Real-seam A/B on a problem URL: the new path yields a complete, non-blank, **deterministic** PDF (25 pages both runs) where the old poll captured early and varied (23 pages, size swinging run-to-run).
- No API-surface change; `waitForReady` is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PDF readiness timing and fast-path heuristics for all `waitUntil: 'auto'` renders; misclassification could skip blank checks or still time out, but behavior is heavily tested and the screenshot fallback remains.
> 
> **Overview**
> Adds **`waitForReady`** in `@browserless/screenshot`: a screenshot-free gate that polls in-page paint/settle signals (stable height, images decoded, `complete`, visible images/text/fonts) and **absorbs SPA navigations** by resetting on destroyed execution contexts instead of failing.
> 
> **PDF `prepare()` in `auto` mode** now runs `waitForReady` first (half the action timeout), then **skips the white-screenshot poll** when the gate settles with real painted content (visible images, ≥200 chars of visible text with fonts loaded, tall document)—with guards for tracking pixels, pending webfonts, and timed-out gates. Still-blank pages keep the existing screenshot poll; **gate + poll + capture retries share one timeout budget** so worst-case prepare cannot exceed a single `timeout`.
> 
> Exports `waitForReady` for reuse. Tests cover the gate (unit + live DOM), PDF fast-path/skip cases, and shared-budget behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b9d4f320dc96ffab87d741c01816c5ddbf089f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Added a navigation-tolerant “visual quiet” readiness gate to determine when screenshot-based blank-page protection is necessary.
  - Unified readiness and fallback timing so the overall timeout budget is respected.
  - Exposed the readiness helper for reuse by other components.
- **Bug Fixes**
  - Reduced unnecessary screenshot polling when meaningful painted content is already stable.
- **Tests**
  - Expanded readiness and PDF flow coverage (SPA navigation recovery, timeout handling, imageless readiness, and painted fast-path screenshot skipping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->