### PR TITLE
fix(pdf): detect covered content in readiness gate, keep zero-screenshot fast path

### DIFF
--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -162,7 +162,7 @@ test('waitUntil auto skips the screenshot poll for painted content', async t => 
   const page = {
     screenshot: async () => {
       screenshotCalls += 1
-      return whiteScreenshot
+      return noWhiteScreenshot
     },
     evaluate: scriptEvaluate(PAINTED_READY, () => {}),
     pdf: async () => {
@@ -176,7 +176,8 @@ test('waitUntil auto skips the screenshot poll for painted content', async t => 
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
 
-  t.is(screenshotCalls, 0)
+  // One probe capture confirms the paint signal; the poll loop never runs.
+  t.is(screenshotCalls, 1)
   t.is(pdfCalls, 1)
 })
 
@@ -291,7 +292,7 @@ test('waitUntil auto skips the screenshot poll for visible text', async t => {
   const page = {
     screenshot: async () => {
       screenshotCalls += 1
-      return whiteScreenshot
+      return noWhiteScreenshot
     },
     evaluate: scriptEvaluate(TEXT_READY, () => {}),
     pdf: async () => {
@@ -305,8 +306,34 @@ test('waitUntil auto skips the screenshot poll for visible text', async t => {
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
 
-  t.is(screenshotCalls, 0)
+  t.is(screenshotCalls, 1)
   t.is(pdfCalls, 1)
+})
+
+test('waitUntil auto: DOM text under a white overlay does not skip the blank check', async t => {
+  let screenshotCalls = 0
+  let waitUntilAutoCalls = 0
+
+  const page = {
+    screenshot: async () => {
+      screenshotCalls += 1
+      // Probe and first poll capture are white (overlay); then content shows.
+      if (screenshotCalls <= 2) return whiteScreenshot
+      return noWhiteScreenshot
+    },
+    evaluate: scriptEvaluate(TEXT_READY, () => {}),
+    pdf: async () => Buffer.from('pdf')
+  }
+
+  const goto = makeGoto({ onWaitUntilAuto: () => (waitUntilAutoCalls += 1) })
+
+  const pdf = createPdf({ goto })(page)
+  await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
+
+  // The gate sees 200+ chars of text, but the probe is white (overlay): the
+  // fast path must fall through to the poll and re-wait.
+  t.is(screenshotCalls, 3)
+  t.is(waitUntilAutoCalls, 1)
 })
 
 test('waitUntil auto: text behind a loading webfont does not trip the fast path', async t => {

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -33,6 +33,7 @@ const IMAGELESS_READY = {
   decoded: 0,
   painted: 0,
   text: 0,
+  covered: false,
   fonts: true,
   complete: true
 }
@@ -43,6 +44,7 @@ const PAINTED_READY = {
   decoded: 3,
   painted: 3,
   text: 0,
+  covered: false,
   fonts: true,
   complete: true
 }
@@ -55,6 +57,7 @@ const PIXEL_ONLY_READY = {
   decoded: 1,
   painted: 0,
   text: 0,
+  covered: false,
   fonts: true,
   complete: true
 }
@@ -67,12 +70,17 @@ const TEXT_READY = {
   decoded: 0,
   painted: 0,
   text: 200,
+  covered: false,
   fonts: true,
   complete: true
 }
 // Same text, but a webfont still loading: during `font-display: block` the
 // text renders invisible, so it must not count as painted.
 const FONT_PENDING_READY = { ...TEXT_READY, fonts: false }
+// Same painted signals, but the content hides behind an opaque fixed overlay
+// (a loading screen): a capture would be white despite the DOM signals.
+const COVERED_TEXT_READY = { ...TEXT_READY, covered: true }
+const COVERED_PAINTED_READY = { ...PAINTED_READY, covered: true }
 
 // A `goto` stub that just runs the `waitUntilAuto` hook and reports an action
 // timeout. `onWaitUntilAuto` observes the blank-SPA re-wait `prepare` triggers.
@@ -162,7 +170,7 @@ test('waitUntil auto skips the screenshot poll for painted content', async t => 
   const page = {
     screenshot: async () => {
       screenshotCalls += 1
-      return noWhiteScreenshot
+      return whiteScreenshot
     },
     evaluate: scriptEvaluate(PAINTED_READY, () => {}),
     pdf: async () => {
@@ -176,8 +184,8 @@ test('waitUntil auto skips the screenshot poll for painted content', async t => 
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
 
-  // One probe capture confirms the paint signal; the poll loop never runs.
-  t.is(screenshotCalls, 1)
+  // Painted, uncovered content: the poll never runs, zero captures.
+  t.is(screenshotCalls, 0)
   t.is(pdfCalls, 1)
 })
 
@@ -292,7 +300,7 @@ test('waitUntil auto skips the screenshot poll for visible text', async t => {
   const page = {
     screenshot: async () => {
       screenshotCalls += 1
-      return noWhiteScreenshot
+      return whiteScreenshot
     },
     evaluate: scriptEvaluate(TEXT_READY, () => {}),
     pdf: async () => {
@@ -306,22 +314,22 @@ test('waitUntil auto skips the screenshot poll for visible text', async t => {
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
 
-  t.is(screenshotCalls, 1)
+  t.is(screenshotCalls, 0)
   t.is(pdfCalls, 1)
 })
 
-test('waitUntil auto: DOM text under a white overlay does not skip the blank check', async t => {
+test('waitUntil auto: text under an opaque overlay does not skip the blank check', async t => {
   let screenshotCalls = 0
   let waitUntilAutoCalls = 0
 
   const page = {
     screenshot: async () => {
       screenshotCalls += 1
-      // Probe and first poll capture are white (overlay); then content shows.
-      if (screenshotCalls <= 2) return whiteScreenshot
+      // The overlay keeps the first poll capture white; then content shows.
+      if (screenshotCalls === 1) return whiteScreenshot
       return noWhiteScreenshot
     },
-    evaluate: scriptEvaluate(TEXT_READY, () => {}),
+    evaluate: scriptEvaluate(COVERED_TEXT_READY, () => {}),
     pdf: async () => Buffer.from('pdf')
   }
 
@@ -330,10 +338,37 @@ test('waitUntil auto: DOM text under a white overlay does not skip the blank che
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
 
-  // The gate sees 200+ chars of text, but the probe is white (overlay): the
-  // fast path must fall through to the poll and re-wait.
-  t.is(screenshotCalls, 3)
+  // The gate sees 200+ chars of text, but it is covered: the fast path must
+  // fall through to the poll and re-wait until the capture is non-white.
+  t.is(screenshotCalls, 2)
   t.is(waitUntilAutoCalls, 1)
+})
+
+test('waitUntil auto: painted images under an opaque overlay do not skip the blank check', async t => {
+  let screenshotCalls = 0
+  let pdfCalls = 0
+
+  const page = {
+    screenshot: async () => {
+      screenshotCalls += 1
+      return noWhiteScreenshot
+    },
+    evaluate: scriptEvaluate(COVERED_PAINTED_READY, () => {}),
+    pdf: async () => {
+      pdfCalls += 1
+      return Buffer.from('pdf')
+    }
+  }
+
+  const goto = makeGoto()
+
+  const pdf = createPdf({ goto })(page)
+  await pdf('https://example.com', { waitUntil: 'auto', timeout: 500 })
+
+  // Covered content skips the fast path; the poll runs and exits on the first
+  // non-white capture (the overlay may legitimately be an interstitial).
+  t.is(screenshotCalls, 1)
+  t.is(pdfCalls, 1)
 })
 
 test('waitUntil auto: text behind a loading webfont does not trip the fast path', async t => {

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -114,34 +114,27 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       const ready = await waitForReady(page, { timeout: Math.round(timeout * READY_BUDGET_RATIO) })
       debug('ready', { ...ready, duration: elapsed() })
 
-      const probeScreenshot = () =>
-        captureWithNavigationRetry(
-          () =>
-            page.screenshot({
-              ...rest,
-              optimizeForSpeed: true,
-              type: 'jpeg',
-              quality: 30
-            }),
-          { page, goto, timeout: Math.max(0, timeout - elapsed()) }
-        )
-
       // Fast path: the page settled with real painted content in a document
       // taller than the viewport — a visibly rendered image (not a tracking
       // pixel), or enough visible text with webfonts loaded (a pending
       // `font-display: block` font renders text invisible, exactly when a
-      // capture would be white). Height and viewport come from the same in-page
+      // capture would be white) — and that content is not `covered` by an
+      // opaque viewport-filling layer (a fixed white loading overlay passes
+      // every other DOM signal while a capture stays white): skip the
+      // screenshot poll. Height and viewport come from the same in-page
       // snapshot (`page.viewport()` is null under `defaultViewport: null`),
       // and an unknown viewport skips the fast path rather than dropping the
       // taller-than-viewport guard. A gate that timed out never settled, so
       // don't trust its partial snapshot: fall through to the blank check.
-      // DOM signals alone can't prove a screenshot would be non-white — a fixed
-      // loading overlay or white-on-white text can pass the gate — so take one
-      // cheap probe capture before skipping the poll loop.
       const painted = ready.painted > 0 || (ready.text >= TEXT_PAINTED_MIN && ready.fonts)
-      if (!ready.timedOut && painted && ready.viewport > 0 && ready.height > ready.viewport) {
-        const probe = await probeScreenshot()
-        if (!(await isWhiteScreenshot(probe))) return
+      if (
+        !ready.timedOut &&
+        painted &&
+        !ready.covered &&
+        ready.viewport > 0 &&
+        ready.height > ready.viewport
+      ) {
+        return
       }
 
       // Otherwise fall back to the screenshot poll — re-wait while the first
@@ -153,7 +146,19 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       do {
         ++retry
         const screenshotTime = timeSpan()
-        const screenshot = await probeScreenshot()
+        const screenshot = await captureWithNavigationRetry(
+          () =>
+            page.screenshot({
+              ...rest,
+              optimizeForSpeed: true,
+              type: 'jpeg',
+              quality: 30
+            }),
+          // The retry loop keeps its own clock, so hand it only what is left
+          // of the shared budget — a fresh full `timeout` here would let one
+          // navigation-racing capture double the worst-case prepare time.
+          { page, goto, timeout: Math.max(0, timeout - elapsed()) }
+        )
         isWhite = await isWhiteScreenshot(screenshot)
         if (isWhite) await goto.waitUntilAuto(page, { timeout: rest.timeout })
         debug('retry', { waitUntil, isWhite, retry, duration: screenshotTime() })

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -114,18 +114,35 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       const ready = await waitForReady(page, { timeout: Math.round(timeout * READY_BUDGET_RATIO) })
       debug('ready', { ...ready, duration: elapsed() })
 
+      const probeScreenshot = () =>
+        captureWithNavigationRetry(
+          () =>
+            page.screenshot({
+              ...rest,
+              optimizeForSpeed: true,
+              type: 'jpeg',
+              quality: 30
+            }),
+          { page, goto, timeout: Math.max(0, timeout - elapsed()) }
+        )
+
       // Fast path: the page settled with real painted content in a document
       // taller than the viewport — a visibly rendered image (not a tracking
       // pixel), or enough visible text with webfonts loaded (a pending
       // `font-display: block` font renders text invisible, exactly when a
-      // capture would be white) — so it can't be a blank shell: skip the
-      // screenshot poll. Height and viewport come from the same in-page
+      // capture would be white). Height and viewport come from the same in-page
       // snapshot (`page.viewport()` is null under `defaultViewport: null`),
       // and an unknown viewport skips the fast path rather than dropping the
       // taller-than-viewport guard. A gate that timed out never settled, so
       // don't trust its partial snapshot: fall through to the blank check.
+      // DOM signals alone can't prove a screenshot would be non-white — a fixed
+      // loading overlay or white-on-white text can pass the gate — so take one
+      // cheap probe capture before skipping the poll loop.
       const painted = ready.painted > 0 || (ready.text >= TEXT_PAINTED_MIN && ready.fonts)
-      if (!ready.timedOut && painted && ready.viewport > 0 && ready.height > ready.viewport) return
+      if (!ready.timedOut && painted && ready.viewport > 0 && ready.height > ready.viewport) {
+        const probe = await probeScreenshot()
+        if (!(await isWhiteScreenshot(probe))) return
+      }
 
       // Otherwise fall back to the screenshot poll — re-wait while the first
       // paint is still blank — to keep the blank-SPA protection. The page has
@@ -136,19 +153,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       do {
         ++retry
         const screenshotTime = timeSpan()
-        const screenshot = await captureWithNavigationRetry(
-          () =>
-            page.screenshot({
-              ...rest,
-              optimizeForSpeed: true,
-              type: 'jpeg',
-              quality: 30
-            }),
-          // The retry loop keeps its own clock, so hand it only what is left
-          // of the shared budget — a fresh full `timeout` here would let one
-          // navigation-racing capture double the worst-case prepare time.
-          { page, goto, timeout: Math.max(0, timeout - elapsed()) }
-        )
+        const screenshot = await probeScreenshot()
         isWhite = await isWhiteScreenshot(screenshot)
         if (isWhite) await goto.waitUntilAuto(page, { timeout: rest.timeout })
         debug('retry', { waitUntil, isWhite, retry, duration: screenshotTime() })

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -22,14 +22,72 @@ const { isContextDestroyed } = require('@browserless/errors')
 // inside the viewport, and not hidden via CSS — so a blank shell can't pass for
 // content. `text` is the equivalent paint signal for imageless pages: visible
 // characters inside the viewport, counted up to 200 (the threshold consumers
-// rely on), and `fonts` reports whether webfonts finished loading — during a
-// `font-display: block` period text renders invisible, exactly when a capture
-// would be white. `viewport` is the in-page viewport height, so consumers can
-// compare it against `height` without relying on `page.viewport()`, which is
-// null under `defaultViewport: null`.
+// rely on) and skipping text whose color matches its effective background
+// (invisible on capture), and `fonts` reports whether webfonts finished
+// loading — during a `font-display: block` period text renders invisible,
+// exactly when a capture would be white. `covered` reports whether the counted
+// content hides behind an opaque viewport-covering layer (a fixed white
+// loading overlay passes every DOM signal while a capture stays white):
+// hit-testing catches interactive overlays, and a root-level scan catches
+// `pointer-events: none` layers hit-testing can't see. `viewport` is the
+// in-page viewport height, so consumers can compare it against `height`
+// without relying on `page.viewport()`, which is null under
+// `defaultViewport: null`.
 const snapshot = () => {
   const vw = window.innerWidth || document.documentElement.clientWidth
   const vh = window.innerHeight || document.documentElement.clientHeight
+
+  // Computed colors resolve to `rgb()`/`rgba()`; anything else is unknown.
+  const parseColor = value => {
+    const match = /rgba?\(([^)]+)\)/.exec(value || '')
+    if (!match) return null
+    const parts = match[1].split(',').map(parseFloat)
+    return { r: parts[0], g: parts[1], b: parts[2], a: parts.length === 4 ? parts[3] : 1 }
+  }
+
+  // First opaque background up the ancestor chain; the canvas default (white)
+  // when every ancestor is transparent.
+  const effectiveBackground = el => {
+    for (let node = el; node; node = node.parentElement) {
+      const color = parseColor(window.getComputedStyle(node).backgroundColor)
+      if (color && color.a >= 0.99) return color
+    }
+    return { r: 255, g: 255, b: 255, a: 1 }
+  }
+
+  const sameColor = (a, b) =>
+    Math.abs(a.r - b.r) < 10 && Math.abs(a.g - b.g) < 10 && Math.abs(a.b - b.b) < 10
+
+  // A layer only blanks a capture when it is itself painted solid: visible,
+  // full opacity, and an opaque background color or a background image.
+  const isOpaqueLayer = el => {
+    const style = window.getComputedStyle(el)
+    if (style.visibility === 'hidden' || parseFloat(style.opacity) < 0.99) return false
+    const background = parseColor(style.backgroundColor)
+    return (background && background.a >= 0.99) || style.backgroundImage !== 'none'
+  }
+
+  const coversViewport = el => {
+    const rect = el.getBoundingClientRect()
+    const width = Math.min(rect.right, vw) - Math.max(rect.left, 0)
+    const height = Math.min(rect.bottom, vh) - Math.max(rect.top, 0)
+    return width > 0 && height > 0 && width * height >= vw * vh * 0.9
+  }
+
+  // Up to a handful of counted content samples — enough to hit-test without
+  // turning the snapshot into a layout storm. The clamp keeps each probe point
+  // inside the viewport; the rect checks below guarantee it stays inside the
+  // sampled content's own box.
+  const contentPoints = []
+  const samplePoint = (el, rect) => {
+    if (contentPoints.length >= 4) return
+    contentPoints.push({
+      el,
+      x: Math.max(0, Math.min(vw - 1, rect.left + rect.width / 2)),
+      y: Math.max(0, Math.min(vh - 1, rect.top + rect.height / 2))
+    })
+  }
+
   const imgs = document.images
   let images = 0
   let decoded = 0
@@ -58,6 +116,7 @@ const snapshot = () => {
       continue
     }
     painted++
+    samplePoint(img, rect)
   }
   // Counting stops at 200 chars, so a text-heavy page costs a handful of nodes,
   // not a full DOM walk; only a near-blank shell walks every text node.
@@ -86,8 +145,56 @@ const snapshot = () => {
     const rect = range.getBoundingClientRect()
     if (rect.width === 0 || rect.height === 0) continue
     if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= vh || rect.left >= vw) continue
+    // White-on-white (or any color-on-same-color) text passes every geometry
+    // check while a capture shows nothing: don't count it as painted text.
+    const color = parseColor(window.getComputedStyle(el).color)
+    if (color && (color.a < 0.05 || sameColor(color, effectiveBackground(el)))) continue
     text += value.length
+    samplePoint(el, rect)
   }
+
+  // Is this content sample's paint hidden behind an unrelated opaque,
+  // viewport-covering layer? Walk up from the hit-tested element: anything
+  // related to the sample (itself, an ancestor, a descendant) paints with it,
+  // and the walk stops at the first common ancestor — an ancestor's background
+  // always paints below its own descendants.
+  const coveredAt = ({ el, x, y }) => {
+    const top = document.elementFromPoint(x, y)
+    if (!top) return false
+    for (let node = top; node && node !== document.documentElement; node = node.parentElement) {
+      if (node === el || node.contains(el) || el.contains(node)) return false
+      if (coversViewport(node) && isOpaqueLayer(node)) return true
+    }
+    return false
+  }
+
+  // Only pages the fast path could trust get the (layout-forcing) cover check.
+  let covered = false
+  if (painted > 0 || text >= 200) {
+    covered = contentPoints.some(coveredAt)
+    // `elementFromPoint` skips `pointer-events: none` elements, exactly how
+    // fading loading overlays are styled — scan root-level layers for one.
+    // Overlays mount as direct children of <body>; a deeper scan would cost a
+    // full styled DOM walk on every poll for a marginal case.
+    if (!covered && document.body) {
+      const layers = document.body.children
+      for (let i = 0; i < layers.length && !covered; i++) {
+        const layer = layers[i]
+        const style = window.getComputedStyle(layer)
+        if (style.pointerEvents !== 'none') continue
+        if (
+          style.position !== 'fixed' &&
+          style.position !== 'absolute' &&
+          style.position !== 'sticky'
+        ) {
+          continue
+        }
+        if (contentPoints.some(point => layer.contains(point.el))) continue
+        if (coversViewport(layer) && isOpaqueLayer(layer)) covered = true
+      }
+    }
+  }
+
   return {
     height: document.documentElement.scrollHeight,
     viewport: vh,
@@ -95,6 +202,7 @@ const snapshot = () => {
     decoded,
     painted,
     text,
+    covered,
     fonts: !document.fonts || document.fonts.status === 'loaded',
     complete: document.readyState === 'complete'
   }
@@ -125,6 +233,7 @@ const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) =
     decoded: 0,
     painted: 0,
     text: 0,
+    covered: false,
     fonts: false,
     complete: false
   }

--- a/packages/screenshot/test/wait-for-ready-live.js
+++ b/packages/screenshot/test/wait-for-ready-live.js
@@ -86,6 +86,76 @@ test('text: 200+ visible characters in the viewport count as painted text', asyn
   t.false(r.timedOut)
   t.true(r.text >= 200)
   t.true(r.fonts)
+  t.false(r.covered)
+})
+
+test('covered: an opaque fixed overlay hides painted text', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(
+    browserless,
+    `<p>${'lorem ipsum '.repeat(20)}</p>` +
+      '<div style="position:fixed;inset:0;background:#fff;z-index:9999"></div>'
+  )(t)
+  t.false(r.timedOut)
+  t.true(r.text >= 200)
+  t.true(r.covered)
+})
+
+test('covered: an opaque fixed overlay hides a painted image', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(
+    browserless,
+    `<img src="${PIXEL}" width="300" height="300">` +
+      '<div style="position:fixed;inset:0;background:#fff;z-index:9999"></div>'
+  )(t)
+  t.false(r.timedOut)
+  t.true(r.painted >= 1)
+  t.true(r.covered)
+})
+
+test('covered: a pointer-events:none overlay is caught by the root-level scan', async t => {
+  const browserless = await getBrowserContext(t)
+  // `elementFromPoint` skips `pointer-events: none` elements, so only the
+  // root-level layer scan can see this one (how fading loaders are styled).
+  const r = await ready(
+    browserless,
+    `<p>${'lorem ipsum '.repeat(20)}</p>` +
+      '<div style="position:fixed;inset:0;background:#fff;z-index:9999;pointer-events:none"></div>'
+  )(t)
+  t.false(r.timedOut)
+  t.true(r.text >= 200)
+  t.true(r.covered)
+})
+
+test('not covered: a transparent full-viewport click-catcher', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(
+    browserless,
+    `<p>${'lorem ipsum '.repeat(20)}</p>` +
+      '<div style="position:fixed;inset:0;z-index:9999"></div>'
+  )(t)
+  t.false(r.timedOut)
+  t.true(r.text >= 200)
+  t.false(r.covered)
+})
+
+test('not covered: a fixed opaque app shell that contains the content', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(
+    browserless,
+    '<div style="position:fixed;inset:0;background:#fff;overflow:auto">' +
+      `<p>${'lorem ipsum '.repeat(20)}</p></div>`
+  )(t)
+  t.false(r.timedOut)
+  t.true(r.text >= 200)
+  t.false(r.covered)
+})
+
+test('white-on-white text does not count toward the text signal', async t => {
+  const browserless = await getBrowserContext(t)
+  const r = await ready(browserless, `<p style="color:#fff">${'lorem ipsum '.repeat(20)}</p>`)(t)
+  t.false(r.timedOut)
+  t.is(r.text, 0)
 })
 
 test('hidden text does not count toward the text signal', async t => {


### PR DESCRIPTION
Supersedes #838.

## Bug

PR #837's fast path trusts DOM paint signals (visible images, 200+ chars of text) to skip the blank-SPA screenshot poll. A fixed opaque overlay (loading screen) or white-on-white text passes every DOM signal while a capture stays white: blank PDF.

## Why not #838

#838 fixes it with a probe screenshot on every painted page. That makes the fast path behaviorally identical to the poll loop's first iteration: painted pages pay one capture, the whole point of #837 (zero screenshots for painted content) is gone, and the fall-through case captures twice back-to-back.

## Fix

Detect the cover inside the in-page readiness snapshot instead, keeping the fast path screenshot-free:

- `covered` signal in `waitForReady`'s snapshot: hit-test up to 4 counted content samples via `elementFromPoint`, walking up from the hit for an unrelated opaque viewport-covering layer (the walk stops at the first common ancestor, whose background always paints below its own descendants). A root-level scan of `<body>` children catches `pointer-events: none` overlays hit-testing can't see (how fading loaders are styled).
- Text whose color matches its effective background (white-on-white) no longer counts toward the `text` paint signal.
- The pdf fast path requires `!ready.covered`; #838's probe is removed and the poll loop restored. A clean painted page takes zero captures again.
- The cover check only runs when the fast path could trigger (`painted > 0 || text >= 200`), so blank pages pay nothing extra per poll.

Covered or suspicious pages fall through to the existing screenshot poll, where a capture verifies ground truth.

## Cost

| Page | #837 | #838 | this PR |
|------|------|------|---------|
| clean painted page | 0 captures (but blank-PDF bug) | 1 capture | 0 captures |
| overlay page | 0 captures, blank PDF | probe + duplicate capture + poll | poll from first capture |
| blank SPA | poll (unchanged) | poll (unchanged) | poll (unchanged) |

## Known limits

Deep-nested `pointer-events: none` overlays (not direct `<body>` children) and exotic paint (white canvas, blend modes) escape DOM detection; documented in code. Those pages keep #837's residual risk instead of paying a capture on every request.

## Validation

- 7 new live-browser snapshot tests: overlay over text, overlay over image, `pointer-events: none` overlay, transparent click-catcher, opaque app shell containing the content, white-on-white text
- 2 new pdf unit tests for covered fixtures; fast-path tests back to asserting **zero** captures with white-screenshot mocks, so any regression to capturing fails loud
- 15/15 wait-for-ready live tests, 43/43 screenshot package tests, 11/11 pdf tests, `standard` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when PDF auto-wait skips vs runs the screenshot poll, which directly affects blank vs correct output; scope is limited to readiness heuristics with broad new test coverage.
> 
> **Overview**
> Fixes **blank PDFs** when DOM paint signals look ready but a full-viewport loading overlay (or similar) still blocks what a capture would show.
> 
> **`waitForReady` snapshot** now exposes **`covered`** and tightens the **`text`** signal: text that matches its effective background (e.g. white-on-white) no longer counts as painted. Coverage is detected in-page by hit-testing up to four content sample points (`elementFromPoint` + walk for unrelated opaque layers) and by scanning direct **`body`** children for **`pointer-events: none`** fixed/absolute overlays that hit-testing misses. The cover check runs only when the page could qualify for the painted fast path.
> 
> **PDF `waitUntil: auto`** only skips the screenshot poll when **`!ready.covered`** in addition to the existing painted / height / font checks, so overlay pages fall through to the existing white-screenshot poll without adding a probe capture on every painted page.
> 
> New live-browser tests cover overlays, click-catchers, app shells, and white-on-white text; PDF unit tests assert covered fixtures still poll screenshots while clean painted pages stay at **zero** captures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a682660510061c4a0e1178b4317d84ed503c78c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness detection when page content is hidden beneath opaque overlays.
  * Prevented automatic screenshot checks from being skipped when visible text or images are covered.
  * Excluded white-on-white text from readiness signals to avoid false positives.
  * Improved handling of transparent overlays and overlays that do not intercept pointer events.
  * Added coverage validation for common app-shell layouts and painted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->