### PR TITLE
fix(pdf): budget readiness from the load allowance, return it to the caller

### DIFF
--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -120,7 +120,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       // returns as soon as the page is quiet, so this is a cap, not a cost.
       const readyTime = timeSpan()
       const ready = await waitForReady(page, {
-        timeout: Math.round((autoTimeout || timeout) * READY_BUDGET_RATIO)
+        timeout: Math.round((autoTimeout ?? timeout) * READY_BUDGET_RATIO)
       })
       readiness = ready
       debug('ready', { ...ready, duration: readyTime() })

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -22,10 +22,13 @@ const PDF_DEFAULT_OPTS = {
   waitUntil: 'auto'
 }
 
-// Share of the action budget the readiness gate may consume in `auto` mode. The
-// remainder is reserved for the blank-SPA screenshot poll to re-wait, so the
-// gate can't starve the fallback while total prepare stays within one `timeout`.
-const READY_BUDGET_RATIO = 0.5
+// Share of the phase's load allowance the readiness gate may consume in `auto`
+// mode. Pages observed settling in 0.6-3.3s (a hydrating document is the slow
+// end), so a quarter of the allowance — ~3.9s at the default request budget —
+// covers them with margin while keeping the cap well short of the render's
+// share. The gate returns as soon as the page is quiet, so this bounds only a
+// page that never settles.
+const READY_BUDGET_RATIO = 0.25
 
 // Minimum visible characters for the text fast path. Matches the counting cap
 // in `waitForReady`'s snapshot, which stops walking text nodes once reached —
@@ -97,22 +100,34 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       return
     }
 
+    // Surfaced to the caller: a page whose readiness could not be confirmed
+    // (`timedOut`) is a poor one to keep rendering on, so a caller reusing this
+    // load across page-ranges can choose a fresh context instead.
+    let readiness
+
     await goto(page, { ...rest, url, waitUntil, waitUntilAuto })
-    async function waitUntilAuto (page) {
+    return readiness
+
+    async function waitUntilAuto (page, { timeout: autoTimeout } = {}) {
       await waitForDomStabilityResult(page)
       const timeout = goto.timeouts.action(rest.timeout)
-      // One action budget shared by the readiness gate and the screenshot poll,
-      // so worst-case prepare stays within a single `timeout` instead of one
-      // per stage.
-      const elapsed = timeSpan()
 
-      // Cheap, navigation-tolerant readiness — no screenshots. Resolves once the
-      // page is visually quiet (height stable, images decoded, load complete),
-      // absorbing the client-side re-navigation that makes a screenshot poll
-      // throw `Execution context was destroyed`. Capped at a share of the budget
-      // so a slow gate still leaves the blank-SPA poll room to re-wait.
-      const ready = await waitForReady(page, { timeout: Math.round(timeout * READY_BUDGET_RATIO) })
-      debug('ready', { ...ready, duration: elapsed() })
+      // The readiness gate waits for a page to settle — page-load work, not a
+      // small action. Budgeting it from `timeouts.action` (timeout/11) gave it
+      // ~1.2s while a hydrating document needs 2-3s, so it timed out on every
+      // tall page and the zero-capture fast path never fired. Budget it from
+      // the load allowance goto actually assigned to this phase; the gate
+      // returns as soon as the page is quiet, so this is a cap, not a cost.
+      const readyTime = timeSpan()
+      const ready = await waitForReady(page, {
+        timeout: Math.round((autoTimeout || timeout) * READY_BUDGET_RATIO)
+      })
+      readiness = ready
+      debug('ready', { ...ready, duration: readyTime() })
+
+      // The blank-page poll keeps its own action budget, measured from here so
+      // a slow gate cannot starve it.
+      const elapsed = timeSpan()
 
       // Fast path: the page settled with real painted content in a document
       // taller than the viewport — a visibly rendered image (not a tracking


### PR DESCRIPTION
## Problem

The readiness gate waits for a page to **settle** — page-load work — but was budgeted from `timeouts.action` (`timeout/11`), then halved by `READY_BUDGET_RATIO`: **~1.2s**. A hydrating document needs 2-3s, so the gate timed out on every tall page and the zero-capture fast path added in #837/#839 **has never fired in production**.

Every production split trace for a 46-page document shows it:

```
ready height=76210 images=29 painted=2 resets=0 timedOut=true  duration=1207   <- probe
ready height=71325 images=4  painted=2 resets=0 timedOut=false duration=844    <- sibling
```

`duration=1207` is exactly the cap, every time.

Two consequences:

- **The fast path is dead code in practice.** `timedOut=true` fails its guard, so every render falls through to the screenshot poll — the cost #837 existed to remove.
- **The document is under-measured.** A starved gate sampled `36149` where a settled context reports `38034`. Callers that derive a page count from that (microlink-api's parallel renderer) mis-size their split.

## Change

Budget the gate from the load allowance `goto` assigns to this phase, at a quarter share (~3.9s at the default request budget). Observed settle times are 0.6-3.3s, and the gate returns as soon as the page is quiet — so this caps only a page that *never* settles, it is not a cost added to healthy pages.

The blank-page screenshot poll keeps its own action budget, now measured from **after** the gate, so a slow gate cannot starve it.

Also **return the readiness result from `prepare`**. A caller reusing one load across page-ranges can then skip that reuse when readiness could not be confirmed, instead of printing a page it never verified had settled. `prepare` previously returned `undefined`; the non-`auto` branch still does.

## Verification

Against the local checkout, both previously `timedOut=true` in production:

```
ch-806 prepare=2595ms timedOut=false height=38034 painted=2 | render OK
ch-804 prepare=1400ms timedOut=false height=71325 painted=2 | render OK
```

chapter-806's height now matches the settled-context value (38034, not 36149).

Caveat: on native GL the old budget may not have timed out either, so this run is consistent with the fix rather than isolating it. The `timedOut=true` evidence is from the GPU-less fleet, and that is where it needs confirming after release.

`waitForReady` itself is unchanged; its 8 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PDF auto-wait timing and prepare’s return value for `waitUntil: 'auto'`, which can affect production render speed, fast-path behavior, and downstream split sizing for callers that consume readiness.
> 
> **Overview**
> Fixes **`waitUntil: 'auto'`** PDF prep so the readiness gate gets enough time to finish on slow/hydrating pages instead of almost always hitting **`timedOut=true`**.
> 
> The gate’s cap is now **25% of the phase load timeout** `goto` passes into **`waitUntilAuto`** (not the tiny **`timeouts.action`** slice that capped it around ~1.2s). That should let the zero-screenshot fast path run when the page actually settles, and yield more accurate height for split/page-count logic. The blank-page screenshot poll still uses the action budget, but its clock **starts after** the gate so a long settle doesn’t eat that budget.
> 
> **`prepare`** in auto mode now **returns the readiness result** (including **`timedOut`**) so callers reusing one load across page ranges can bail out and reload when readiness wasn’t confirmed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0db59df54fb053ce6631965e0875ede56868a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic page-readiness handling during PDF generation.
  * Reduced the time allocated to readiness checks, helping the process move more efficiently to subsequent rendering steps.
  * Improved timing separation and diagnostics for readiness checks and blank-page detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->