### PR TITLE
fix(screenshot): never let the text walk fail a capture

### DIFF
--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -121,36 +121,46 @@ const snapshot = () => {
   // Counting stops at 200 chars, so a text-heavy page costs a handful of nodes,
   // not a full DOM walk; only a near-blank shell walks every text node.
   let text = 0
-  const walker = document.createTreeWalker(
-    document.body || document.documentElement,
-    window.NodeFilter.SHOW_TEXT
-  )
-  while (text < 200) {
-    const node = walker.nextNode()
-    if (!node) break
-    const value = node.nodeValue.trim()
-    if (!value) continue
-    const el = node.parentElement
-    if (!el) continue
-    const tag = el.tagName
-    if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT' || tag === 'TEMPLATE') continue
-    if (
-      typeof el.checkVisibility === 'function' &&
-      !el.checkVisibility({ visibilityProperty: true, opacityProperty: true })
-    ) {
-      continue
+  // A document that is mid-parse or detached can have neither `body` nor
+  // `documentElement`, and `createTreeWalker` throws on a null root. Text is only
+  // a paint signal, so a count that cannot be taken means "no text seen yet": the
+  // gate stays conservative and re-polls, rather than failing a render that would
+  // otherwise succeed. The same holds mid-walk — a DOM mutating under the walker
+  // must not take the capture down with it.
+  const textRoot = document.body || document.documentElement
+  const walker = textRoot
+    ? document.createTreeWalker(textRoot, window.NodeFilter.SHOW_TEXT)
+    : { nextNode: () => null }
+  try {
+    while (text < 200) {
+      const node = walker.nextNode()
+      if (!node) break
+      const value = node.nodeValue.trim()
+      if (!value) continue
+      const el = node.parentElement
+      if (!el) continue
+      const tag = el.tagName
+      if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT' || tag === 'TEMPLATE') continue
+      if (
+        typeof el.checkVisibility === 'function' &&
+        !el.checkVisibility({ visibilityProperty: true, opacityProperty: true })
+      ) {
+        continue
+      }
+      const range = document.createRange()
+      range.selectNodeContents(node)
+      const rect = range.getBoundingClientRect()
+      if (rect.width === 0 || rect.height === 0) continue
+      if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= vh || rect.left >= vw) continue
+      // White-on-white (or any color-on-same-color) text passes every geometry
+      // check while a capture shows nothing: don't count it as painted text.
+      const color = parseColor(window.getComputedStyle(el).color)
+      if (color && (color.a < 0.05 || sameColor(color, effectiveBackground(el)))) continue
+      text += value.length
+      samplePoint(el, rect)
     }
-    const range = document.createRange()
-    range.selectNodeContents(node)
-    const rect = range.getBoundingClientRect()
-    if (rect.width === 0 || rect.height === 0) continue
-    if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= vh || rect.left >= vw) continue
-    // White-on-white (or any color-on-same-color) text passes every geometry
-    // check while a capture shows nothing: don't count it as painted text.
-    const color = parseColor(window.getComputedStyle(el).color)
-    if (color && (color.a < 0.05 || sameColor(color, effectiveBackground(el)))) continue
-    text += value.length
-    samplePoint(el, rect)
+  } catch {
+    // Keep whatever was counted before the DOM shifted underneath the walk.
   }
 
   // Is this content sample's paint hidden behind an unrelated opaque,

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -34,8 +34,12 @@ const { isContextDestroyed } = require('@browserless/errors')
 // without relying on `page.viewport()`, which is null under
 // `defaultViewport: null`.
 const snapshot = () => {
-  const vw = window.innerWidth || document.documentElement.clientWidth
-  const vh = window.innerHeight || document.documentElement.clientHeight
+  // A document that is mid-parse or detached can have a null `documentElement`
+  // (the same state the text walk below guards against), so every dereference
+  // of it in this snapshot goes through `root`.
+  const root = document.documentElement
+  const vw = window.innerWidth || (root ? root.clientWidth : 0)
+  const vh = window.innerHeight || (root ? root.clientHeight : 0)
 
   // Computed colors resolve to `rgb()`/`rgba()`; anything else is unknown.
   const parseColor = value => {
@@ -127,7 +131,7 @@ const snapshot = () => {
   // gate stays conservative and re-polls, rather than failing a render that would
   // otherwise succeed. The same holds mid-walk — a DOM mutating under the walker
   // must not take the capture down with it.
-  const textRoot = document.body || document.documentElement
+  const textRoot = document.body || root
   const walker = textRoot
     ? document.createTreeWalker(textRoot, window.NodeFilter.SHOW_TEXT)
     : { nextNode: () => null }
@@ -206,7 +210,7 @@ const snapshot = () => {
   }
 
   return {
-    height: document.documentElement.scrollHeight,
+    height: root ? root.scrollHeight : 0,
     viewport: vh,
     images,
     decoded,

--- a/packages/screenshot/test/wait-for-ready-live.js
+++ b/packages/screenshot/test/wait-for-ready-live.js
@@ -178,6 +178,30 @@ test('below-viewport text does not count toward the text signal', async t => {
   t.is(r.text, 0)
 })
 
+test('no document root: the snapshot degrades to zeros instead of failing the capture', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(html('<h1>ok</h1>'))
+  })
+  const r = await browserless.withPage((page, goto) => async () => {
+    await goto(page, { url, waitUntil: 'load', adblock: false, timeout: 5000 })
+    // The production failure state behind #845: a mid-parse or detached
+    // document exposes neither `body` nor `documentElement`. Every snapshot
+    // dereference of the root must survive it — `createTreeWalker` threw on
+    // the null walker root, and `scrollHeight`/`clientWidth` sit one null
+    // dereference away from the same capture-killing rethrow.
+    await page.evaluate(() => document.removeChild(document.documentElement))
+    const result = await waitForReady(page, { timeout: 5000, quietMs: 100, poll: 50 })
+    await page.close()
+    return result
+  })()
+  t.false(r.timedOut)
+  t.is(r.height, 0)
+  t.is(r.text, 0)
+  t.is(r.painted, 0)
+})
+
 test('below-fold lazy image: excluded from the settle gate so it cannot stall it', async t => {
   const browserless = await getBrowserContext(t)
   // 20000px down is beyond every lazy-load fetch threshold Chromium uses, so


### PR DESCRIPTION
## Bug

`waitForReady`'s snapshot builds a TreeWalker over `document.body || document.documentElement`. A document that is mid-parse or detached has **neither**, and `createTreeWalker` throws on a null root.

That throw is not a context-destroyed error, so the gate rethrows it by design (added in #841 so genuine evaluation bugs would not masquerade as timeouts). The effect is that a survivable, transient DOM state fails the entire capture.

Observed on production **3.42.8**, three times in six hours, across very different documents:

```
pages   n  message
    6   1  Failed to execute 'createTreeWalker' on 'Document'
   25   3  Failed to execute 'createTreeWalker' on 'Document'
  426   6  Failed to execute 'createTreeWalker' on 'Document'
```

## Fix

Guard the root, and wrap the walk so a DOM mutating underneath it keeps whatever was counted:

```js
const textRoot = document.body || document.documentElement
const walker = textRoot
  ? document.createTreeWalker(textRoot, window.NodeFilter.SHOW_TEXT)
  : { nextNode: () => null }
try {
  while (text < 200) { ... }
} catch {
  // keep whatever was counted before the DOM shifted
}
```

`text` is only a **paint signal**. Failing to read it means "no text seen yet", which leaves the gate *more* conservative, not less: it re-polls, or falls through to the blank-page screenshot check. It can never make a blank page look painted.

The rethrow for genuine evaluation errors is untouched, and its test still passes.

Tests: 8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized defensive changes to screenshot readiness heuristics; behavior when the DOM is normal is unchanged, and the failure mode becomes more conservative polling rather than looser capture.
> 
> **Overview**
> Fixes production capture failures where `waitForReady`'s in-page `snapshot()` threw on transient DOM states (mid-parse or detached documents with no `body`/`documentElement`), which bubbled out of `page.evaluate` and aborted the screenshot because only context-destroyed errors are retried.
> 
> **`snapshot()`** now routes layout reads through a guarded `root` (`scrollHeight`, viewport fallbacks), only creates a `TreeWalker` when `document.body || root` exists (otherwise a no-op walker), and wraps the text walk in `try/catch` so DOM changes mid-scan keep partial counts instead of killing the poll. Missing text is treated as "not painted yet," so the gate stays conservative and re-polls rather than falsely declaring readiness.
> 
> Adds a live browser test that removes `documentElement` and asserts the gate returns zeroed signals without timing out as a hard failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f70e7d242d23507df6e836426bb7a8cfa74bf7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot readiness checks to handle pages that are still parsing or have an incomplete document structure.
  * Made text-paint sampling more resilient to DOM mutations during traversal.
  * Updated height and metrics handling so captures degrade gracefully when the document root is missing, avoiding failures/timeouts.
* **Tests**
  * Added an end-to-end test covering the “missing document root” scenario to verify the operation settles and returns zeroed metrics without timing out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->