### PR TITLE
fix(errors): treat detached-frame and early-main-frame as retryable

### DIFF
--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -51,10 +51,10 @@ const getErrorMessage = rawError => {
   return isObject(error) && typeof error.message === 'string' ? error.message : ''
 }
 
-// Whether the error means the page navigated away (the execution context /
-// browser context was torn down mid-operation). These are transient on SPAs
-// that navigate client-side: waiting for navigation to settle and retrying the
-// operation in-place typically succeeds.
+// Whether the error means the page's frame was not in a usable state for the
+// operation — torn down mid-flight (a client-side navigation), or not yet
+// attached. Both are transient on SPAs that navigate after load: waiting for
+// navigation to settle and retrying the operation in-place typically succeeds.
 const isContextDestroyed = rawError => {
   const errorMessage = getErrorMessage(rawError)
   return (
@@ -65,7 +65,14 @@ const isContextDestroyed = rawError => {
     ].some(message => errorMessage.startsWith(message)) ||
     errorMessage.includes('Session closed') ||
     errorMessage.includes('Attempted to use detached Frame') ||
-    errorMessage.includes('Execution context was destroyed')
+    // Chrome's other phrasing of a frame detaching mid-operation (a navigation
+    // committed while an evaluate/print targeting the old frame was in flight).
+    errorMessage.includes('Execution context is not available in detached frame') ||
+    errorMessage.includes('Execution context was destroyed') ||
+    // The inverse race: an operation ran before the page's main frame attached.
+    // The frame arrives once navigation commits, so a settle-and-retry resolves
+    // it; a page that never navigates falls through when the retry budget ends.
+    errorMessage.includes('Requesting main frame too early')
   )
 }
 

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -143,6 +143,16 @@ test('isContextDestroyed', t => {
     )
   )
   t.true(errors.isContextDestroyed({ error: { message: 'Execution context was destroyed' } }))
+  // Chrome's other phrasing of a detached frame, carrying the frame URL — seen
+  // in production on SPAs (app.oviond.com) that navigate to a sub-route mid-print.
+  t.true(
+    errors.isContextDestroyed({
+      message:
+        'Execution context is not available in detached frame or worker "https://app.oviond.com/pdf/x"'
+    })
+  )
+  // The inverse race: an operation ran before the main frame attached.
+  t.true(errors.isContextDestroyed({ message: 'Requesting main frame too early!' }))
 
   t.false(errors.isContextDestroyed({ message: 'Evaluation failed: boom' }))
   t.false(errors.isContextDestroyed({ message: 'Navigation timeout of 30000 ms exceeded' }))


### PR DESCRIPTION
## Problem

`captureWithNavigationRetry` (which wraps `page.pdf()` / `page.screenshot()`) and `waitForReady` only wait-for-navigation-and-retry when `isContextDestroyed` returns true. Two frame-lifecycle races on production **3.42.8** are not recognized, so they fail the capture immediately:

```
Execution context is not available in detached frame or worker "<url>"   6 requests / 24h
Requesting main frame too early!                                          2 requests / 24h
```

Sample (`d53acca8`, app.oviond.com — a SPA that navigates to a sub-route mid-print):

```
pdf chunk pages=4 ... duration=19.6s
pdf render n=1 pages=4 duration=8.1s
chunk:failed message="Execution context is not available in detached frame or worker \"https://app.oviond.com/pdf/.../project/...\""
parallel:fallback message="Execution context is not available in detached frame ..."
```

## Fix

Add both strings to `isContextDestroyed`:

- **`Execution context is not available in detached frame`** — Chrome's other phrasing of a frame detaching mid-operation. Semantically identical to the already-matched `Attempted to use detached Frame`; the retry (wait for navigation to settle, re-run on the new frame) is exactly right.
- **`Requesting main frame too early`** — the inverse race: the operation ran before the page's main frame attached. The frame arrives once navigation commits, so a settle-and-retry resolves it.

The retry is bounded by `timeouts.action`, so a genuinely broken page that never navigates falls through the same as today — just after a short wait instead of instantly.

## Confidence

Not equal between the two, stated plainly:

- **detached-frame**: high. 6 occurrences, real SaaS pages, same class as an existing matched pattern.
- **main-frame-too-early**: lower. 2 occurrences, both on pages that also logged `empty response` / `prerender:error` (may never navigate). Included because it is a genuine transient lifecycle race and the retry cost is bounded, but it may just convert a fast fail into a short-delayed fail on broken pages rather than rescue them.

Tests: 9 pass, `isContextDestroyed` extended with both production strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to error-string classification in the errors package; bounded retry behavior already exists for similar patterns.
> 
> **Overview**
> Extends **`isContextDestroyed`** so two production Chrome frame-lifecycle errors are treated like existing navigation/context teardown races and flow through **`ensureError`** as **`contextDisconnected`** (enabling settle-and-retry in PDF/screenshot paths instead of immediate failure).
> 
> New matches: **`Execution context is not available in detached frame`** (detached frame mid-operation) and **`Requesting main frame too early`** (main frame not attached yet). Comments on the helper are updated to describe both “torn down mid-flight” and “not yet attached” cases.
> 
> Tests add positive cases for both production message strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723593711d3489f1504c81f17b4949fcd4173469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of browser errors caused by detached frames, unavailable execution contexts, and early main-frame requests.
  * These conditions are now more reliably identified as temporary context disconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->