### PR TITLE
fix(pdf): walk the page to load deferred content before printing

### DIFF
--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -11,6 +11,7 @@ const {
   waitForDomStability,
   waitForReady,
   resolveWaitForDom,
+  scrollToLoadContent,
   SCREENSHOT_DEFAULT_OPTS
 } = require('@browserless/screenshot')
 
@@ -29,6 +30,12 @@ const PDF_DEFAULT_OPTS = {
 // share. The gate returns as soon as the page is quiet, so this bounds only a
 // page that never settles.
 const READY_BUDGET_RATIO = 0.25
+
+// Share of the request budget the lazy-content walk may consume. It is a
+// backstop, not a cost: the walk returns as soon as every scroller is exhausted,
+// which is a few hundred milliseconds on an ordinary page. Only a document that
+// keeps growing as it is walked spends the whole allowance.
+const SCROLL_BUDGET_RATIO = 0.25
 
 // Minimum visible characters for the text fast path. Matches the counting cap
 // in `waitForReady`'s snapshot, which stops walking text nodes once reached —
@@ -94,9 +101,23 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       )
     }
 
+    // A PDF is always a full-page capture, so anything the page defers until it
+    // scrolls into view prints as an empty placeholder — a report of skeleton
+    // boxes. Screenshots already walk the page for this reason, but only when
+    // `fullPage`; printing has no such switch, so it always applies.
+    const loadLazyContent = async page => {
+      const scrollTime = timeSpan()
+      await scrollToLoadContent(
+        page,
+        Math.round((rest.timeout ?? goto.timeouts.action()) * SCROLL_BUDGET_RATIO)
+      )
+      debug('scroll', { duration: scrollTime() })
+    }
+
     if (waitUntil !== 'auto') {
       await goto(page, { ...rest, url, waitUntil })
       await waitForDomStabilityResult(page)
+      await loadLazyContent(page)
       return
     }
 
@@ -106,6 +127,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     let readiness
 
     await goto(page, { ...rest, url, waitUntil, waitUntilAuto })
+    await loadLazyContent(page)
     return readiness
 
     async function waitUntilAuto (page, { timeout: autoTimeout } = {}) {

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -64,6 +64,84 @@ const waitForImagesOnViewport = page =>
     )
   )
 
+// A pane counts as its own scroller once it overflows by more than this. Small
+// overflows are scrollbar-rounding noise, not content worth walking.
+const MIN_SCROLLER_OVERFLOW = 50
+
+// Longest single wait after the walk. The walk only fires the intersections;
+// what they request lands during this settle, and the requests resolve in
+// parallel with each other, so one wait covers all of them.
+const SCROLL_SETTLE_MAX = 1000
+
+// Reveal content the page defers until it is scrolled into view, then wait once
+// while what that triggered loads.
+//
+// Two things this does that walking `window` alone does not:
+//
+// Inner panes. Not every app scrolls the document. A full-height `overflow:auto`
+// pane — dashboards, report viewers — leaves `document.body.scrollHeight` at the
+// viewport forever, so scrolling the window is a no-op and nothing is ever
+// revealed. Measured on a report whose scroller was an inner div: 120 skeleton
+// placeholders before, 0 after. Scrollers are walked together rather than one
+// after another, so a page with several panes costs the same as its deepest.
+//
+// No pause between steps. Pausing serialized work the browser already does
+// concurrently: the requests one step fires resolve while the next steps run.
+// Touching each position as fast as the clock allows and settling once produced
+// identical output far quicker — a report walked in 770ms instead of 6.1s, and
+// 40 native lazy images decoded in 1.2s instead of 6.0s, both complete either
+// way. `timeout` is now a backstop for a page that never finishes, not the pace.
+const scrollToLoadContent = async (page, timeout) =>
+  page.evaluate(
+    async ({ timeout, settleMax, minOverflow }) => {
+      const tick = () => new Promise(resolve => setTimeout(resolve, 16))
+
+      const scrollers = [
+        {
+          extent: () => document.body.scrollHeight,
+          step: () => window.innerHeight,
+          to: y => window.scrollTo(0, y)
+        },
+        ...[...document.querySelectorAll('*')]
+          .filter(element => {
+            const { overflowY } = window.getComputedStyle(element)
+            return (
+              /auto|scroll/.test(overflowY) &&
+              element.scrollHeight > element.clientHeight + minOverflow
+            )
+          })
+          .map(element => ({
+            extent: () => element.scrollHeight,
+            step: () => element.clientHeight,
+            to: y => {
+              element.scrollTop = y
+            }
+          }))
+      ]
+
+      const deadline = Date.now() + timeout
+
+      await Promise.all(
+        scrollers.map(async scroller => {
+          const step = Math.max(1, scroller.step())
+          // `extent` is re-read every turn: revealing content can lengthen the
+          // very thing being walked, and a length captured up front would stop
+          // short of whatever the walk itself added.
+          for (let y = 0; y < scroller.extent() && Date.now() < deadline; y += step) {
+            scroller.to(y)
+            await tick()
+          }
+          scroller.to(0)
+        })
+      )
+
+      await new Promise(resolve =>
+        setTimeout(resolve, Math.max(0, Math.min(settleMax, deadline - Date.now())))
+      )
+    },
+    { timeout, settleMax: SCROLL_SETTLE_MAX, minOverflow: MIN_SCROLLER_OVERFLOW }
+  )
+
 const scrollFullPageToLoadContent = async (page, timeout) => {
   const debug = require('debug-logfmt')('browserless:goto')
 
@@ -75,28 +153,7 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
 
   duration('waitForDomStability', result)
 
-  await page.evaluate(
-    timeout =>
-      new Promise(resolve => {
-        let currentScrollPosition = 0
-        const scrollStep = Math.floor(window.innerHeight)
-        const pageHeight = document.body.scrollHeight
-        const totalSteps = Math.ceil(pageHeight / scrollStep)
-        const stepDelay = timeout / 2 / totalSteps
-        const scrollNext = async () => {
-          if (currentScrollPosition >= pageHeight) {
-            resolve()
-            return
-          }
-          window.scrollBy(0, scrollStep)
-          currentScrollPosition += scrollStep
-          setTimeout(scrollNext, stepDelay)
-        }
-        scrollNext()
-      }),
-    timeout
-  )
-  await page.evaluate(() => window.scrollTo(0, 0))
+  await scrollToLoadContent(page, timeout)
 }
 
 const waitForElement = async (page, element) => {
@@ -279,4 +336,6 @@ module.exports.isWhiteScreenshot = isWhiteScreenshot
 module.exports.waitForDomStability = waitForDomStability
 module.exports.resolveWaitForDom = resolveWaitForDom
 module.exports.waitForReady = waitForReady
+module.exports.scrollFullPageToLoadContent = scrollFullPageToLoadContent
+module.exports.scrollToLoadContent = scrollToLoadContent
 module.exports.SCREENSHOT_DEFAULT_OPTS = SCREENSHOT_DEFAULT_OPTS

--- a/packages/screenshot/test/scroll-to-load-content.js
+++ b/packages/screenshot/test/scroll-to-load-content.js
@@ -1,0 +1,132 @@
+'use strict'
+
+const { getBrowserContext, runServer } = require('@browserless/test')
+const test = require('ava')
+
+const { scrollToLoadContent } = require('..')
+
+// A page whose scroller is an inner `overflow:auto` pane, not the document:
+// `document.body.scrollHeight` stays at the viewport no matter how long the
+// content is, which is the layout that made `window.scrollBy` a no-op. Each
+// block swaps its placeholder for real content the first time it intersects.
+const innerPaneHtml =
+  blocks => `<!doctype html><html><body style="margin:0;height:100vh;overflow:hidden">
+<div id="pane" style="position:absolute;inset:0;overflow:auto">
+  ${Array.from(
+    { length: blocks },
+    (_, i) => `<div class="block" data-i="${i}" style="height:900px">placeholder</div>`
+  ).join('')}
+</div>
+<script>
+  const io = new IntersectionObserver(entries => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue
+      entry.target.textContent = 'loaded-' + entry.target.dataset.i
+      entry.target.dataset.loaded = '1'
+      io.unobserve(entry.target)
+    }
+  }, { root: document.getElementById('pane') })
+  document.querySelectorAll('.block').forEach(el => io.observe(el))
+</script></body></html>`
+
+const loadedCount = page =>
+  page.evaluate(() => ({
+    total: document.querySelectorAll('.block').length,
+    loaded: document.querySelectorAll('.block[data-loaded="1"]').length,
+    documentHeight: document.body.scrollHeight
+  }))
+
+test('reveals content gated behind an inner scroll pane', async t => {
+  const BLOCKS = 12
+  const browserless = await getBrowserContext(t)
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(innerPaneHtml(BLOCKS))
+  })
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url, waitUntil: 'load' })
+    const before = await loadedCount(page)
+    await scrollToLoadContent(page, 10000)
+    const after = await loadedCount(page)
+    await page.close()
+    return { before, after }
+  })
+
+  const { before, after } = await run()
+
+  t.true(
+    before.documentHeight < 1500,
+    'the document itself never grows, so walking `window` alone reveals nothing'
+  )
+  t.true(before.loaded < BLOCKS, 'content below the fold starts unrevealed')
+  t.is(after.loaded, BLOCKS, 'every block is revealed after the walk')
+})
+
+// Native lazy images are the pattern screenshots already relied on, so the walk
+// must keep serving them: every image is requested and decoded, not merely
+// scrolled past.
+test('loads native lazy images down the document', async t => {
+  const IMAGES = 20
+  const PNG = Buffer.from(
+    '89504e470d0a1a0a0000000d4948445200000001000000010806000000' +
+      '1f15c4890000000d4944415478da6364f8cf000000030101007ca1d027' +
+      '0000000049454e44ae426082',
+    'hex'
+  )
+  const browserless = await getBrowserContext(t)
+  const url = await runServer(t, ({ req, res }) => {
+    if (req.url.startsWith('/img/')) {
+      return setTimeout(() => {
+        res.setHeader('content-type', 'image/png')
+        res.end(PNG)
+      }, 50)
+    }
+    res.setHeader('content-type', 'text/html')
+    res.end(
+      `<!doctype html><html><body style="margin:0">${Array.from(
+        { length: IMAGES },
+        (_, i) =>
+          `<div style="height:900px"><img loading="lazy" src="/img/${i}.png" width="300" height="300"></div>`
+      ).join('')}</body></html>`
+    )
+  })
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url, waitUntil: 'load' })
+    await scrollToLoadContent(page, 10000)
+    const result = await page.evaluate(() => ({
+      total: document.images.length,
+      decoded: [...document.images].filter(img => img.complete && img.naturalWidth > 0).length
+    }))
+    await page.close()
+    return result
+  })
+
+  const { total, decoded } = await run()
+  t.is(total, IMAGES)
+  t.is(decoded, IMAGES, 'every lazy image is requested and decoded')
+})
+
+// The timeout is a backstop for a document that keeps growing, not the pace. A
+// page with nothing to scroll must not be charged for it — pausing between steps
+// used to spend the whole allowance on a one-screen document.
+test('returns promptly when there is nothing to scroll', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end('<!doctype html><html><body style="margin:0"><p>short</p></body></html>')
+  })
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url, waitUntil: 'load' })
+    const startedAt = Date.now()
+    await scrollToLoadContent(page, 10000)
+    const elapsed = Date.now() - startedAt
+    await page.close()
+    return elapsed
+  })
+
+  const elapsed = await run()
+  t.true(elapsed < 5000, `expected well under the 10s backstop, took ${elapsed}ms`)
+})


### PR DESCRIPTION
A PDF is always a full-page capture, so anything the page defers until it is scrolled into view prints as an empty placeholder. Screenshots already walk the page for this reason, but only when `fullPage`; printing has no such switch. `prepare` now walks before it returns.

## Walking `window` alone was not enough

Not every app scrolls the document. A full-height `overflow:auto` pane — dashboards, report viewers — leaves `document.body.scrollHeight` at the viewport however long the content is, so `window.scrollBy` moves nothing.

Measured on a customer report whose scroller was an inner div:

```
document.body.scrollHeight       633    (never changes, even fully loaded)
.report-canvas-scroll         12,479    the actual scroller

skeleton placeholders:  120 before walk  ->  120 after   (window only)
                        120 before walk  ->    0 after   (with panes)
```

So the walk now collects the document *and* every inner scroller, and walks them together rather than one after another — a page with several panes costs the same as its deepest.

## Pacing was the wrong lever

The old loop paused between steps, which serialized work the browser already does concurrently: the requests one step fires resolve while later steps run. It also slept once more *after* reaching the bottom, so pages with nothing to scroll paid the full allowance — a one-screen document spent 3.3s scrolling nothing.

Touching each position as fast as the clock allows and settling once gives identical output:

| page | before | after | result |
|---|---|---|---|
| inner-pane report | 6.1s | 770ms | identical (0 skeletons, 97 svg, 11,479 chars) |
| 40 native lazy images | 6.0s | 1.2s | identical (40/40 decoded) |
| one-screen document | 3.3s | ~0.3s | nothing to do either way |

`timeout` is now a backstop for a document that keeps growing, not the pace.

## Shape

`scrollFullPageToLoadContent` keeps its shape — DOM-stability wait, then the walk — so the screenshot path is unchanged apart from the pacing it now shares. The walk is split out as `scrollToLoadContent` for callers that already waited for stability, which `prepare` does; going through the full helper would pay a second `idle` period on every render.

## Tests

New `packages/screenshot/test/scroll-to-load-content.js`:

- **reveals content gated behind an inner scroll pane** — 12 blocks behind an `IntersectionObserver` rooted on an `overflow:auto` pane. Asserts the document never grows (so `window` walking is provably a no-op here), then that all 12 are revealed. Disabling pane detection turns this red at `1` of `12`.
- **loads native lazy images down the document** — 20 `loading="lazy"` images off a delayed server, all requested and decoded. This is the pattern screenshots already relied on.
- **returns promptly when there is nothing to scroll** — a one-screen page must not be charged the backstop.

Full screenshot suite: 47 passing. Lint clean.

## Does not fix, on its own

The report this came from still prints skeletons after this change, because its shell passes the readiness gate empty:

```
ready height=800 viewport=800 images=0 decoded=0 painted=0 text=0 complete=true timedOut=false duration=458
```

`complete=true` plus a quiet DOM is enough today, but a page waiting on network is quiet without being loaded, so the walk runs against a shell with nothing to reveal. Isolated, both halves are required:

```
neither          0 skeletons,  0 svg,      0 chars   (blank page)
scroll only     38 skeletons,  0 svg,      0 chars
wait only      120 skeletons, 22 svg,  2,091 chars   (what ships today)
wait + scroll    0 skeletons, 97 svg, 11,479 chars   (correct)
```

The gate is a separate change and a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdKhHYtYcxYyxaGnZnuJxU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core page-load behavior for all PDFs and full-page screenshots (timing and scroll side effects in-page), though behavior is covered by new integration tests and bounded timeouts.
> 
> **Overview**
> PDF **prepare** now always runs a lazy-content scroll walk before render (unlike screenshots, which only do this for `fullPage`), using ~25% of the request action timeout as a backstop.
> 
> The shared walk is refactored into **`scrollToLoadContent`**: it scrolls the **window and every inner `overflow:auto|scroll` pane in parallel**, advances quickly (~16ms ticks) instead of pacing the whole timeout between steps, re-reads scroll extent each step for growing content, then settles once (up to 1s). **`scrollFullPageToLoadContent`** keeps DOM-stability-then-walk for full-page screenshots but delegates to the new helper.
> 
> New tests cover inner-pane IntersectionObserver content, lazy images, and fast return on short pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c631e554e45afc9dd607b36dd9fd32df131908bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved lazy-content loading for PDF generation and screenshots.
  * Screenshot capture now handles nested scrollable areas and content revealed during scrolling.
  * Full-page captures more reliably include deferred images and dynamically loaded content.

* **Bug Fixes**
  * Improved handling of short or non-scrollable pages without unnecessary delays.

* **Tests**
  * Added coverage for dynamically revealed content, lazy-loaded images, and short pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->