### PR TITLE
fix(pdf): wait for the document to render before printing it

### DIFF
--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -44,7 +44,11 @@
     "src"
   ],
   "scripts": {
-    "test": "exit 0"
+    "test": "ava"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "@browserless/test": "workspace:*",
+    "ava": "5"
+  }
 }

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -3,6 +3,7 @@
 const timeSpan = require('@kikobeats/time-span')({ format: n => Math.round(n) })
 const debug = require('debug-logfmt')('browserless:pdf')
 const createGoto = require('@browserless/goto')
+const { setTimeout: sleep } = require('node:timers/promises')
 const pReflect = require('p-reflect')
 
 const {
@@ -30,10 +31,40 @@ const PDF_DEFAULT_OPTS = {
 // page that never settles.
 const READY_BUDGET_RATIO = 0.25
 
+// Share of the same allowance spent confirming the document carries anything at
+// all before the readiness gate is asked whether it has settled.
+const CONTENT_BUDGET_RATIO = 0.25
+
+// How often to re-ask while the document is still empty.
+const CONTENT_POLL = 150
+
 // Minimum visible characters for the text fast path. Matches the counting cap
 // in `waitForReady`'s snapshot, which stops walking text nodes once reached —
 // raising this above the cap would make the text fast path unreachable.
 const TEXT_PAINTED_MIN = 200
+
+// Does the document carry anything at all, anywhere in it?
+//
+// The readiness gate is viewport-scoped by design: content below the fold is
+// legitimately invisible, so `painted` and `text` reading zero is normal for a
+// page whose content simply starts lower. That makes the gate unable to tell
+// such a page apart from a shell that has rendered nothing yet — and a shell
+// passes every other settle signal it has. Its HTML arrived, so `readyState` is
+// `complete`; it has no images, so there is nothing to decode; and its height
+// cannot move when the app scrolls an inner pane rather than the document, so
+// height stability holds from the first poll. Observed on a report that rendered
+// nothing for ~1.5s: the gate called it ready at 458ms with `painted=0 text=0`,
+// and the PDF printed its skeleton placeholders.
+//
+// So ask a different question, document-wide rather than viewport-scoped, and
+// ask it first. The element probe runs before `innerText` because it is the
+// cheaper of the two and the one a rendered app trips immediately.
+const hasDocumentContent = () => {
+  const body = document.body
+  if (!body) return false
+  if (body.querySelector('img,svg,canvas,video,table,input,button,picture')) return true
+  return (body.innerText || '').trim().length > 0
+}
 
 const getMargin = unit => {
   if (!unit) return unit
@@ -65,6 +96,22 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       () => page.pdf({ ...rest, margin: getMargin(margin), printBackground, scale }),
       { page, goto, timeout: goto.timeouts.action(rest.timeout) }
     )
+  }
+
+  // Poll until the document carries something, or the budget runs out. A page
+  // that already has content answers on the first evaluate, so an ordinary
+  // render pays one round trip for this.
+  const waitForDocumentContent = async (page, timeout) => {
+    const deadline = Date.now() + timeout
+    while (true) {
+      const result = await pReflect(page.evaluate(hasDocumentContent))
+      // A navigation tearing down the context is not evidence either way; treat
+      // it like an empty poll and try again while the budget lasts.
+      if (!result.isRejected && result.value) return true
+      const remaining = deadline - Date.now()
+      if (remaining <= 0) return false
+      await sleep(Math.min(CONTENT_POLL, remaining))
+    }
   }
 
   // Navigate `page` to `url` and wait until it is ready to print: DOM stability
@@ -111,6 +158,13 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     async function waitUntilAuto (page, { timeout: autoTimeout } = {}) {
       await waitForDomStabilityResult(page)
       const timeout = goto.timeouts.action(rest.timeout)
+
+      const contentTime = timeSpan()
+      const hasContent = await waitForDocumentContent(
+        page,
+        Math.round((autoTimeout ?? timeout) * CONTENT_BUDGET_RATIO)
+      )
+      debug('content', { hasContent, duration: contentTime() })
 
       // The readiness gate waits for a page to settle — page-load work, not a
       // small action. Budgeting it from `timeouts.action` (timeout/11) gave it

--- a/packages/pdf/test/empty-shell.js
+++ b/packages/pdf/test/empty-shell.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const { getBrowserContext, runServer } = require('@browserless/test')
+const test = require('ava')
+
+const createPdf = require('..')
+
+// A shell that renders nothing until its data arrives, laid out the way that
+// defeats every settle signal the readiness gate has: the HTML is complete, it
+// ships no images, and it scrolls an inner pane so the document height is fixed
+// at the viewport and can never change. Before the content wait, `prepare`
+// returned in ~450ms and printed the placeholders.
+const shellHtml =
+  delay => `<!doctype html><html><body style="margin:0;height:100vh;overflow:hidden">
+<div id="pane" style="position:absolute;inset:0;overflow:auto">
+  <div id="skeleton" style="height:900px;background:#e5e7eb"></div>
+</div>
+<script>
+  setTimeout(() => {
+    document.getElementById('pane').innerHTML =
+      '<table><tr><td>real content that only exists after the data lands</td></tr></table>'
+  }, ${delay})
+</script></body></html>`
+
+const prepared = (browserless, body) => async timeout => {
+  const url = await runServer({ teardown: () => {} }, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(body)
+  })
+  return browserless.withPage((page, goto) => async () => {
+    const { prepare } = createPdf({ goto })
+    await prepare(page, url, { timeout })
+    const content = await page.evaluate(() => ({
+      hasTable: !!document.querySelector('table'),
+      text: (document.body.innerText || '').trim().length,
+      documentHeight: document.body.scrollHeight
+    }))
+    await page.close()
+    return content
+  })()
+}
+
+test('waits for a shell to render before printing it', async t => {
+  const browserless = await getBrowserContext(t)
+  const content = await prepared(browserless, shellHtml(1200))(30000)
+
+  t.true(
+    content.documentHeight < 1500,
+    'the document height never moves, so it cannot signal that content arrived'
+  )
+  t.true(content.hasTable, 'prepare returned only once the real content existed')
+  t.true(content.text > 0)
+})
+
+// The wait is bounded: a document that never renders anything must not hold the
+// render open, it just prints whatever is there once the budget is spent.
+test('gives up on a shell that never renders, rather than hanging', async t => {
+  const browserless = await getBrowserContext(t)
+  const startedAt = Date.now()
+  const content = await prepared(browserless, shellHtml(600000))(4000)
+  const elapsed = Date.now() - startedAt
+
+  t.false(content.hasTable, 'nothing ever rendered')
+  t.true(elapsed < 20000, `bounded by the budget, took ${elapsed}ms`)
+})
+
+// An ordinary page already carries content on the first check, so it must not
+// pay anything for the wait.
+test('does not delay a page that already has content', async t => {
+  const browserless = await getBrowserContext(t)
+  const startedAt = Date.now()
+  const content = await prepared(
+    browserless,
+    '<!doctype html><html><body><h1>ready immediately</h1><p>with text</p></body></html>'
+  )(30000)
+  const elapsed = Date.now() - startedAt
+
+  t.true(content.text > 0)
+  t.true(elapsed < 10000, `no meaningful wait, took ${elapsed}ms`)
+})


### PR DESCRIPTION
An app shell that has not rendered anything yet satisfies every settle signal the readiness gate has, so `prepare` returns and prints the placeholders.

On a report that renders nothing for ~1.5s, the gate resolved at **458ms**:

```
ready height=800 viewport=800 images=0 decoded=0 painted=0 text=0
      covered=false fonts=true complete=true resets=0 timedOut=false
```

## Why every signal says "ready"

`packages/screenshot/src/wait-for-ready.js`:

```js
const quiet = snap.complete && imagesDecoded && snap.height === lastHeight
```

| signal | value | why |
|---|---|---|
| `complete` | `true` | the shell's HTML arrived; the data is still in flight |
| `imagesDecoded` | `true` | zero images, so vacuously true |
| `height === lastHeight` | `true` | **pinned at 633 forever** |

The third one is the trap. This app scrolls an inner `overflow:auto` pane rather than the document, so the document height never moves — not while loading, not after. Height stability, the strongest settle signal, holds from the first poll and never stops holding.

The blank-page fallback does not catch it either: it asks only `isWhiteScreenshot`, and grey skeletons on white are not white.

## Why `painted` / `text` cannot be the fix

They *did* report zero, and my first attempt added them to the gate's quiet condition. That is wrong: both are viewport-scoped by design, so a page whose content merely starts below the fold reads zero for the same reason while being perfectly ready. The existing suite says so directly, and turned red in five places:

```
✘ below-viewport text does not count toward the text signal
✘ white-on-white text does not count toward the text signal
✘ hidden text does not count toward the text signal
✘ an imageless page is ready on height/readyState quiet alone
✘ no document root: the snapshot degrades to zeros
```

Requiring viewport-scoped content in the shared gate makes every such page burn its budget. Reverted.

## What this does instead

Ask a different question — document-wide rather than viewport-scoped — and ask it *before* the gate: does the document carry anything at all, anywhere?

```js
const hasDocumentContent = () => {
  const body = document.body
  if (!body) return false
  if (body.querySelector('img,svg,canvas,video,table,input,button,picture')) return true
  return (body.innerText || '').trim().length > 0
}
```

Poll until it does or the budget runs out. Cheap element probe first, `innerText` only if that misses.

| page | content wait |
|---|---|
| ordinary page | **1ms** (answers on the first evaluate) |
| the report | **1565ms**, then prints what it actually renders |

## Tests

The pdf package had `test: exit 0` and no test directory, so it gains one here. `packages/pdf/test/empty-shell.js`:

- **waits for a shell to render before printing it** — a shell laid out to defeat every settle signal (complete HTML, no images, inner-pane scroll so height is fixed). Asserts the document height provably cannot signal arrival, then that `prepare` returned only once real content existed. Disabling the wait turns this red.
- **gives up on a shell that never renders** — bounded by the budget, does not hang.
- **does not delay a page that already has content** — no tax on ordinary renders.

Screenshot suite unchanged: 44 passing. Lint clean.

## Half of a fix

This is one of the two things that report needs. The other is #850, walking it to load what it defers until scrolled into view. Measured in isolation:

```
neither          0 skeletons,  0 svg,      0 chars   (blank page)
scroll only     38 skeletons,  0 svg,      0 chars
this PR only   120 skeletons, 22 svg,  2,091 chars
both             0 skeletons, 97 svg, 11,479 chars   (correct)
```

Verified together on the real report: 8 pages, 729 kB, no placeholders, in 4.3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdKhHYtYcxYyxaGnZnuJxU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PDF prepare timing for all `waitUntil: 'auto'` renders; bounded budget limits hang risk but could still affect slow or minimal-DOM pages.
> 
> **Overview**
> Fixes PDFs printing **empty app shells** when `waitUntil: 'auto'` treats the page as settled before real UI appears (e.g. complete HTML, no images, fixed document height with inner scroll).
> 
> **`prepare` / `waitUntilAuto`** now runs a **document-wide content poll** (`hasDocumentContent` + `waitForDocumentContent`) **before** `waitForReady`, using ~25% of the load budget and 150ms polls. It looks for substantive elements or any trimmed `innerText` anywhere in the body—not viewport-scoped painted/text signals—so below-the-fold-ready pages are not broken.
> 
> The **`@browserless/pdf` package** switches from a no-op test script to **AVA** with **`empty-shell.js`**: wait for delayed shell content, bounded timeout when content never arrives, and no extra delay when content is already present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d077661330e97c08aca9b2acd1f9c1226897373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF generation for pages that load content dynamically, helping ensure rendered documents include the finished content rather than placeholders or blank sections.
  * Added safeguards so PDF creation continues within a reasonable time when page content never becomes available.
  * Pages that already contain content continue without unnecessary waiting.

* **Tests**
  * Added coverage for delayed content, incomplete pages, and immediately available content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->