### PR TITLE
fix(pdf): wait for SPA content before printing

### DIFF
--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -14,17 +14,17 @@ const noWhiteScreenshot = fs.readFileSync(
   path.resolve(__dirname, '../../screenshot/test/fixtures/no-white-5k.png')
 )
 
-// `waitUntilAuto` runs two in-page evaluates: `waitForDomStability` and
-// `paintSignals`. Dispatch on function identity — the workspace resolves both
-// packages to the same module instance — so the stub keeps routing correctly
-// even if either evaluate's signature changes.
-const scriptEvaluate = (signals, onDomStability) => async (fn, args) => {
-  if (fn === waitForDomStability) {
-    onDomStability(args)
-    return { status: 'idle' }
-  }
-  return signals
-}
+// Dispatch on function identity so prepareFullDocument's scroll quiet
+// (`waitForDomStability`) and readiness (`paintSignals`) stay stubbed correctly.
+const scriptEvaluate =
+  (signals, onDomStability = () => {}) =>
+    async (fn, args) => {
+      if (fn === waitForDomStability) {
+        onDomStability(args)
+        return { status: 'idle' }
+      }
+      return signals
+    }
 
 const IMAGELESS_READY = {
   height: 800,
@@ -101,11 +101,10 @@ test('waitUntil auto should generate final pdf once', async t => {
   let screenshotCalls = 0
   let pdfCalls = 0
   let waitUntilAutoCalls = 0
-  const domStabilityCalls = []
 
   const page = {
     screenshot: async () => (screenshotCalls++ === 0 ? whiteScreenshot : noWhiteScreenshot),
-    evaluate: scriptEvaluate(IMAGELESS_READY, args => domStabilityCalls.push(args)),
+    evaluate: scriptEvaluate(IMAGELESS_READY),
     pdf: async () => {
       pdfCalls += 1
       return Buffer.from(`pdf-${pdfCalls}`)
@@ -121,25 +120,6 @@ test('waitUntil auto should generate final pdf once', async t => {
   t.is(pdfCalls, 1)
   t.true(screenshotCalls >= 2)
   t.is(waitUntilAutoCalls, 1)
-  // Default waitForDom is off; only prepareFullDocument's scroll quiet may call it.
-  t.false(domStabilityCalls.some(args => args && args.timeout === 2500))
-})
-
-test('waitUntil auto should honor custom waitForDom', async t => {
-  const domStabilityCalls = []
-
-  const page = {
-    screenshot: async () => noWhiteScreenshot,
-    evaluate: scriptEvaluate(IMAGELESS_READY, args => domStabilityCalls.push(args)),
-    pdf: async () => Buffer.from('pdf')
-  }
-
-  const goto = makeGoto()
-
-  const pdf = createPdf({ goto })(page)
-  await pdf('https://example.com', { waitUntil: 'auto', waitForDom: 2500, timeout: 500 })
-
-  t.true(domStabilityCalls.some(args => args && args.timeout === 2500 && args.idle === 250))
 })
 
 test('retries pdf generation when navigation destroys the execution context', async t => {

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -14,16 +14,16 @@ const noWhiteScreenshot = fs.readFileSync(
   path.resolve(__dirname, '../../screenshot/test/fixtures/no-white-5k.png')
 )
 
-// `waitUntilAuto` runs two in-page evaluates: `waitForDomStability` and the
-// readiness `snapshot`. Dispatch on function identity — the workspace resolves
-// both packages to the same module instance — so the stub keeps routing
-// correctly even if either evaluate's signature changes.
-const scriptEvaluate = (snapshot, onDomStability) => async (fn, args) => {
+// `waitUntilAuto` runs two in-page evaluates: `waitForDomStability` and
+// `paintSignals`. Dispatch on function identity — the workspace resolves both
+// packages to the same module instance — so the stub keeps routing correctly
+// even if either evaluate's signature changes.
+const scriptEvaluate = (signals, onDomStability) => async (fn, args) => {
   if (fn === waitForDomStability) {
     onDomStability(args)
     return { status: 'idle' }
   }
-  return snapshot
+  return signals
 }
 
 const IMAGELESS_READY = {

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -89,7 +89,10 @@ const makeGoto = ({ action = 100000, onWaitUntilAuto } = {}) => {
     if (opts.waitUntilAuto) await opts.waitUntilAuto(page)
     return { response: {} }
   }
-  goto.timeouts = { action: () => action }
+  goto.timeouts = {
+    action: () => action,
+    goto: (ms = action) => Math.round(ms * (7 / 8))
+  }
   goto.waitUntilAuto = async () => onWaitUntilAuto && onWaitUntilAuto()
   return goto
 }
@@ -98,11 +101,11 @@ test('waitUntil auto should generate final pdf once', async t => {
   let screenshotCalls = 0
   let pdfCalls = 0
   let waitUntilAutoCalls = 0
-  let domStabilityArgs
+  const domStabilityCalls = []
 
   const page = {
     screenshot: async () => (screenshotCalls++ === 0 ? whiteScreenshot : noWhiteScreenshot),
-    evaluate: scriptEvaluate(IMAGELESS_READY, args => (domStabilityArgs = args)),
+    evaluate: scriptEvaluate(IMAGELESS_READY, args => domStabilityCalls.push(args)),
     pdf: async () => {
       pdfCalls += 1
       return Buffer.from(`pdf-${pdfCalls}`)
@@ -118,15 +121,16 @@ test('waitUntil auto should generate final pdf once', async t => {
   t.is(pdfCalls, 1)
   t.true(screenshotCalls >= 2)
   t.is(waitUntilAutoCalls, 1)
-  t.is(domStabilityArgs, undefined)
+  // Default waitForDom is off; only prepareFullDocument's scroll quiet may call it.
+  t.false(domStabilityCalls.some(args => args && args.timeout === 2500))
 })
 
 test('waitUntil auto should honor custom waitForDom', async t => {
-  let domStabilityArgs
+  const domStabilityCalls = []
 
   const page = {
     screenshot: async () => noWhiteScreenshot,
-    evaluate: scriptEvaluate(IMAGELESS_READY, args => (domStabilityArgs = args)),
+    evaluate: scriptEvaluate(IMAGELESS_READY, args => domStabilityCalls.push(args)),
     pdf: async () => Buffer.from('pdf')
   }
 
@@ -135,7 +139,7 @@ test('waitUntil auto should honor custom waitForDom', async t => {
   const pdf = createPdf({ goto })(page)
   await pdf('https://example.com', { waitUntil: 'auto', waitForDom: 2500, timeout: 500 })
 
-  t.deepEqual(domStabilityArgs, { timeout: 2500, idle: 250 })
+  t.true(domStabilityCalls.some(args => args && args.timeout === 2500 && args.idle === 250))
 })
 
 test('retries pdf generation when navigation destroys the execution context', async t => {

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -381,3 +381,21 @@ test('waitUntil auto: text behind a loading webfont does not trip the fast path'
   t.is(screenshotCalls, 1)
   t.is(pdfCalls, 1)
 })
+
+// Regression: @browserless/pdf destructures helpers from @browserless/screenshot,
+// so every one of those names must be re-exported by the screenshot entry point.
+// A missing re-export (e.g. tryHydrateScroll) only throws once the matching code
+// path fires on a real page, so guard the contract directly. Derived from pdf's
+// source so it tracks the imports automatically.
+test('screenshot re-exports every helper pdf imports from it', t => {
+  const screenshot = require('@browserless/screenshot')
+  const source = fs.readFileSync(require.resolve('@browserless/pdf'), 'utf8')
+  const block = source.match(/const\s*\{([^}]*)\}\s*=\s*require\('@browserless\/screenshot'\)/)
+  t.truthy(block, 'pdf must import from @browserless/screenshot')
+  const names = block[1]
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean)
+  const missing = names.filter(name => screenshot[name] === undefined)
+  t.deepEqual(missing, [], `missing screenshot re-exports: ${missing.join(', ')}`)
+})

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -1,3 +1,6 @@
 'use strict'
 
-module.exports = async ({ url, browserless, opts }) => [await browserless.pdf(url, opts)]
+module.exports = async ({ url, browserless, opts, isPageReady }) => {
+  if (typeof isPageReady === 'function') opts.isPageReady = isPageReady
+  return [await browserless.pdf(url, opts)]
+}

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -78,10 +78,16 @@ const run = async () => {
     launchOpts.ignoreDefaultArgs = ['--disable-extensions']
   }
 
+  const parsedOpts = nestie(opts)
+  if (parsedOpts.timeout != null) {
+    launchOpts.timeout = Number(parsedOpts.timeout)
+  }
   const browser = createBrowser(launchOpts)
   onExit(browser.close)
-  const browserless = await browser.createContext()
-  return fn({ url, browserless, opts: nestie(opts), isPageReady })
+  const browserless = await browser.createContext(
+    launchOpts.timeout != null ? { timeout: launchOpts.timeout } : undefined
+  )
+  return fn({ url, browserless, opts: parsedOpts, isPageReady })
 }
 
 run()

--- a/packages/pdf/README.md
+++ b/packages/pdf/README.md
@@ -73,7 +73,6 @@ The package applies these optimized defaults:
 | `scale` | `number` | `0.65` | Scale of the webpage rendering (0.1 - 2) |
 | `printBackground` | `boolean` | `true` | Print background graphics |
 | `waitUntil` | `string` | `'auto'` | When to consider navigation done |
-| `waitForDom` | `number` | `0` | DOM stability window in ms (idle is `waitForDom / 10`, `0` disables DOM wait) |
 | `format` | `string` | `'Letter'` | Paper format (A4, Letter, etc.) |
 | `landscape` | `boolean` | `false` | Paper orientation |
 | `width` | `string \| number` | — | Paper width (overrides format) |
@@ -112,10 +111,9 @@ Supported units: `px`, `in`, `cm`, `mm`
 When `waitUntil: 'auto'` (the default), the package:
 
 1. Navigates to the page
-2. Optionally waits for DOM stability (`waitForDom`, default `0` = disabled)
-3. Takes a low-quality screenshot to check for white/blank content
-4. If the page appears blank, retries until content is detected
-5. Generates the PDF once content is confirmed
+2. Waits for paint/readiness signals (`waitForReady` + `isPageReady`)
+3. Hydrates overflow content when ready (`prepareFullDocument`)
+4. Generates the PDF
 
 This ensures dynamic content (JavaScript-rendered pages) is fully loaded before PDF generation.
 

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -115,6 +115,11 @@ const resolveScrollTimeout = (goto, timeout) =>
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
 
+  // Set by `prepare` when the page cleared readiness (or used a non-auto wait).
+  // `render` only unwraps overflow for prepared pages so bot-check shells that
+  // never pass `isPageReady` are not expanded at print time.
+  let documentPrepared = false
+
   // Render an already-prepared page to a PDF buffer. Split out from the load so
   // a single load can be reused across page-range chunks (microlink-api's
   // parallel renderer) without re-navigating.
@@ -126,7 +131,9 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       printBackground: opts.printBackground ?? PDF_DEFAULT_OPTS.printBackground
     })
 
-    await pReflect(page.evaluate(expandOverflow))
+    if (documentPrepared) {
+      await pReflect(page.evaluate(expandOverflow))
+    }
 
     return captureWithNavigationRetry(() => page.pdf(pdfOpts), {
       page,
@@ -154,6 +161,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     } = opts
     const waitForDomOpts = resolveWaitForDom(waitForDom)
     const gotoOpts = { ...rest, mediaType }
+    documentPrepared = false
 
     const waitForDomStabilityResult = async page => {
       if (!waitForDomOpts) return
@@ -186,6 +194,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     if (waitUntil !== 'auto') {
       await goto(page, { ...gotoOpts, url, waitUntil })
       await waitForDomStabilityResult(page)
+      documentPrepared = true
       return
     }
 
@@ -204,6 +213,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
         timeout: resolveScrollTimeout(goto, rest.timeout)
       })
       readiness = { ...readiness, ...prep }
+      documentPrepared = true
     }
 
     return readiness

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -65,38 +65,6 @@ const isPaintedContent = ({ painted = 0, text = 0, fonts = true } = {}) =>
 const isBlankShell = ({ painted = 0, text = 0, covered = false } = {}) =>
   covered || (painted === 0 && text === 0)
 
-// App shells often keep content in an overflow scroller (`doc` ≈ viewport).
-// `page.pdf()` only paginates the document flow, so unwrap the tallest
-// overflow root when it is taller than the viewport.
-const expandOverflowForPdf = () => {
-  const scroll = [...document.querySelectorAll('*')]
-    .filter(el => {
-      const s = window.getComputedStyle(el)
-      return (
-        (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
-        el.scrollHeight > el.clientHeight + 200
-      )
-    })
-    .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
-
-  if (!scroll) return false
-
-  let el = scroll
-  while (el) {
-    const pos = window.getComputedStyle(el).position
-    el.style.setProperty('overflow', 'visible', 'important')
-    el.style.setProperty('height', 'auto', 'important')
-    el.style.setProperty('max-height', 'none', 'important')
-    if (pos === 'absolute' || pos === 'fixed') {
-      el.style.setProperty('position', 'relative', 'important')
-      el.style.setProperty('inset', 'auto', 'important')
-    }
-    if (el === document.documentElement) break
-    el = el.parentElement
-  }
-  return true
-}
-
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
 
@@ -116,24 +84,17 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     } = opts
 
     if (mediaType) await pReflect(page.emulateMediaType(mediaType))
-    const expanded = await pReflect(page.evaluate(expandOverflowForPdf))
-    debug('expandOverflowForPdf', {
-      mediaType,
-      expanded: !expanded.isRejected && expanded.value
-    })
 
-    const pdfOpts = {
-      ...rest,
-      margin: getMargin(margin),
-      printBackground,
-      scale
-    }
-
-    return captureWithNavigationRetry(() => page.pdf(pdfOpts), {
-      page,
-      goto,
-      timeout: goto.timeouts.action(rest.timeout)
-    })
+    return captureWithNavigationRetry(
+      () =>
+        page.pdf({
+          ...rest,
+          margin: getMargin(margin),
+          printBackground,
+          scale
+        }),
+      { page, goto, timeout: goto.timeouts.action(rest.timeout) }
+    )
   }
 
   // Navigate `page` to `url` and wait until it is ready to print: DOM stability

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -111,13 +111,16 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
 
     let readiness
     let isReady = false
+    let didHydrateScroll = false
+    let didHydrateAttempt = false
 
     await goto(page, { ...rest, url, waitUntil, waitUntilAuto })
 
     if (isReady) {
       const prep = await prepareFullDocument(page, {
         goto,
-        timeout: resolveScrollTimeout(goto, rest.timeout)
+        timeout: resolveScrollTimeout(goto, rest.timeout),
+        scrolled: didHydrateScroll
       })
       readiness = { ...readiness, ...prep }
     }
@@ -136,7 +139,6 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
 
       const elapsed = timeSpan()
       const pollTimeout = Math.max(0, timeout - readyTime())
-      let didHydrateScroll = false
 
       isReady =
         !ready.timedOut &&
@@ -168,10 +170,17 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
           isReady = await checkPageReady(page, { response, screenshot, isWhite })
 
           const remaining = pollTimeout - elapsed()
-          if (!isReady && !didHydrateScroll && !isWhite && remaining > 1000) {
-            didHydrateScroll = true
-            await pReflect(scrollFullPageToLoadContent(page, Math.min(remaining / 2, 8000)))
-            debug('ready:hydrateScroll', { remaining })
+          if (!isReady && !didHydrateAttempt && !isWhite && remaining > 1000) {
+            didHydrateAttempt = true
+            const hydrate = await pReflect(
+              scrollFullPageToLoadContent(page, Math.min(remaining / 2, 5000))
+            )
+            didHydrateScroll = !hydrate.isRejected && !!hydrate.value?.hydrated
+            debug('ready:hydrateScroll', {
+              remaining,
+              hydrated: didHydrateScroll,
+              ...(hydrate.isRejected ? {} : hydrate.value)
+            })
           }
 
           if (!isReady) await goto.waitUntilAuto(page, { timeout: rest.timeout })

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -10,7 +10,8 @@ const {
   isWhiteScreenshot,
   waitForDomStability,
   waitForReady,
-  scrollFullPageToLoadContent,
+  prepareFullDocument,
+  expandOverflow,
   resolveWaitForDom,
   SCREENSHOT_DEFAULT_OPTS
 } = require('@browserless/screenshot')
@@ -69,12 +70,10 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       margin = PDF_DEFAULT_OPTS.margin,
       scale = PDF_DEFAULT_OPTS.scale,
       printBackground = PDF_DEFAULT_OPTS.printBackground,
-      mediaType,
-      waitUntil,
-      waitForDom,
-      isPageReady,
       ...rest
     } = opts
+
+    await pReflect(page.evaluate(expandOverflow))
 
     return captureWithNavigationRetry(
       () =>
@@ -128,22 +127,24 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     // (`timedOut`) is a poor one to keep rendering on, so a caller reusing this
     // load across page-ranges can choose a fresh context instead.
     let readiness
+    let isReady = false
 
     await goto(page, { ...gotoOpts, url, waitUntil, waitUntilAuto })
+
+    // Same full-document prep as fullPage screenshot (scroll + unwrap overflow).
+    if (isReady) {
+      readiness = await prepareFullDocument(page, {
+        goto,
+        timeout: goto.timeouts.goto(rest.timeout)
+      })
+    }
+
     return readiness
 
     async function waitUntilAuto (page, { timeout: autoTimeout } = {}) {
       await waitForDomStabilityResult(page)
-      // Checkpoint + SPA hydrate needs more than `timeouts.action` (~2.7s): budget
-      // the blank poll from the same load allowance as the readiness gate.
       const timeout = autoTimeout ?? goto.timeouts.action(rest.timeout)
 
-      // The readiness gate waits for a page to settle — page-load work, not a
-      // small action. Budgeting it from `timeouts.action` (timeout/11) gave it
-      // ~1.2s while a hydrating document needs 2-3s, so it timed out on every
-      // tall page and the zero-capture fast path never fired. Budget it from
-      // the load allowance goto actually assigned to this phase; the gate
-      // returns as soon as the page is quiet, so this is a cap, not a cost.
       const readyTime = timeSpan()
       const ready = await waitForReady(page, {
         timeout: Math.round(timeout * READY_BUDGET_RATIO)
@@ -151,32 +152,16 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       readiness = ready
       debug('ready', { ...ready, duration: readyTime() })
 
-      // The blank-page poll keeps its own clock, measured from here so a slow
-      // gate cannot starve it. Remaining load allowance is the cap.
       const elapsed = timeSpan()
       const pollTimeout = Math.max(0, timeout - readyTime())
 
-      // Fast path: the page settled with real painted content in a document
-      // taller than the viewport — a visibly rendered image (not a tracking
-      // pixel), or enough visible text with webfonts loaded (a pending
-      // `font-display: block` font renders text invisible, exactly when a
-      // capture would be white) — and that content is not `covered` by an
-      // opaque viewport-filling layer (a fixed white loading overlay passes
-      // every other DOM signal while a capture stays white): skip the
-      // screenshot poll. Height and viewport come from the same in-page
-      // paintSignals (`page.viewport()` is null under `defaultViewport: null`),
-      // and an unknown viewport skips the fast path rather than dropping the
-      // taller-than-viewport guard. A gate that timed out never settled, so
-      // don't trust its partial signals: fall through to the blank check.
-      let isReady =
+      isReady =
         !ready.timedOut &&
         isPaintedContent(ready) &&
         !ready.covered &&
         ready.viewport > 0 &&
         ready.height > ready.viewport
 
-      // Otherwise fall back to the screenshot poll — same ready check as
-      // fullPage screenshot: white frame + `isPageReady` (bot-check / title).
       if (!isReady) {
         let retry = -1
         do {
@@ -185,14 +170,10 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
           const screenshot = await captureWithNavigationRetry(
             () =>
               page.screenshot({
-                ...rest,
                 optimizeForSpeed: true,
                 type: 'jpeg',
                 quality: 30
               }),
-            // The retry loop keeps its own clock, so hand it only what is left
-            // of the shared budget — a fresh full `timeout` here would let one
-            // navigation-racing capture double the worst-case prepare time.
             { page, goto, timeout: Math.max(0, pollTimeout - elapsed()) }
           )
           const isWhite = await isWhiteScreenshot(screenshot)
@@ -218,26 +199,6 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
             duration: screenshotTime()
           })
         } while (!isReady && elapsed() < pollTimeout)
-      }
-
-      // PDF is inherently full-page: scroll the document (or its tallest
-      // overflow scroller) so lazy sections hydrate before print, then wait
-      // for the fetches that scroll triggered to go idle and the DOM to settle.
-      if (isReady && elapsed() < pollTimeout) {
-        const scrollTimeout = Math.max(0, pollTimeout - elapsed())
-        await goto.run({
-          fn: scrollFullPageToLoadContent(page, scrollTimeout),
-          timeout: Math.max(scrollTimeout * 2, scrollTimeout + 1000),
-          debug: 'scrollFullPageToLoadContent'
-        })
-        await goto.waitUntilAuto(page, {
-          timeout: Math.max(0, pollTimeout - elapsed())
-        })
-        const settle = await waitForReady(page, {
-          timeout: Math.max(0, pollTimeout - elapsed())
-        })
-        readiness = settle
-        debug('settle', { ...settle, duration: elapsed() })
       }
 
       debug({ waitUntil, isReady, timeout: pollTimeout, duration: require('pretty-ms')(elapsed()) })

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -10,7 +10,6 @@ const {
   isWhiteScreenshot,
   waitForDomStability,
   waitForReady,
-  paintSignals,
   scrollFullPageToLoadContent,
   resolveWaitForDom,
   SCREENSHOT_DEFAULT_OPTS
@@ -58,12 +57,6 @@ const getPageSnapshot = page =>
 
 const isPaintedContent = ({ painted = 0, text = 0, fonts = true } = {}) =>
   painted > 0 || (text >= TEXT_PAINTED_MIN && fonts)
-
-// A quiet document with nothing visible yet — black SPA shell after a bot
-// checkpoint, empty root before hydrate. `isWhiteScreenshot` only catches
-// near-white frames, so these must be rejected on paint signals.
-const isBlankShell = ({ painted = 0, text = 0, covered = false } = {}) =>
-  covered || (painted === 0 && text === 0)
 
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
@@ -184,10 +177,8 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
         ready.viewport > 0 &&
         ready.height > ready.viewport
 
-      // Otherwise fall back to the screenshot poll — re-wait while the first
-      // paint is still blank — to keep the blank-SPA protection. Also reject
-      // black/empty shells and (via `isPageReady`) bot-check interstitial
-      // pages: those fail the white-pixel check while still being unprintable.
+      // Otherwise fall back to the screenshot poll — same ready check as
+      // fullPage screenshot: white frame + `isPageReady` (bot-check / title).
       if (!isReady) {
         let retry = -1
         do {
@@ -207,30 +198,24 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
             { page, goto, timeout: Math.max(0, pollTimeout - elapsed()) }
           )
           const isWhite = await isWhiteScreenshot(screenshot)
-          const [pageSnapshot, paintResult] = await Promise.all([
-            pReflect(getPageSnapshot(page)),
-            pReflect(page.evaluate(paintSignals))
-          ])
+          const pageSnapshot = await pReflect(getPageSnapshot(page))
           const pageMeta = pageSnapshot.isRejected ? {} : pageSnapshot.value
-          const signals = paintResult.isRejected ? {} : paintResult.value
           const pageReadyResult = await pReflect(
             isPageReady({
               page,
               screenshot,
               isWhite,
               isWhiteScreenshot,
-              ...pageMeta,
-              ...signals
+              ...pageMeta
             })
           )
-          isReady = !pageReadyResult.isRejected && !!pageReadyResult.value && !isBlankShell(signals)
+          isReady = !pageReadyResult.isRejected && !!pageReadyResult.value
 
           if (!isReady) await goto.waitUntilAuto(page, { timeout: rest.timeout })
           debug('retry', {
             waitUntil,
             isReady,
             isWhite,
-            blank: isBlankShell(signals),
             retry,
             duration: screenshotTime()
           })

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -69,14 +69,12 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       margin = PDF_DEFAULT_OPTS.margin,
       scale = PDF_DEFAULT_OPTS.scale,
       printBackground = PDF_DEFAULT_OPTS.printBackground,
-      mediaType = PDF_DEFAULT_OPTS.mediaType,
+      mediaType,
       waitUntil,
       waitForDom,
       isPageReady,
       ...rest
     } = opts
-
-    if (mediaType) await pReflect(page.emulateMediaType(mediaType))
 
     return captureWithNavigationRetry(
       () =>

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -10,7 +10,7 @@ const {
   isWhiteScreenshot,
   waitForDomStability,
   waitForReady,
-  snapshot,
+  paintSignals,
   scrollFullPageToLoadContent,
   resolveWaitForDom,
   SCREENSHOT_DEFAULT_OPTS
@@ -34,7 +34,7 @@ const PDF_DEFAULT_OPTS = {
 const READY_BUDGET_RATIO = 0.25
 
 // Minimum visible characters for the text fast path. Matches the counting cap
-// in `waitForReady`'s snapshot, which stops walking text nodes once reached —
+// in `waitForReady`'s paintSignals, which stops walking text nodes once reached —
 // raising this above the cap would make the text fast path unreachable.
 const TEXT_PAINTED_MIN = 200
 
@@ -173,10 +173,10 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       // opaque viewport-filling layer (a fixed white loading overlay passes
       // every other DOM signal while a capture stays white): skip the
       // screenshot poll. Height and viewport come from the same in-page
-      // snapshot (`page.viewport()` is null under `defaultViewport: null`),
+      // paintSignals (`page.viewport()` is null under `defaultViewport: null`),
       // and an unknown viewport skips the fast path rather than dropping the
       // taller-than-viewport guard. A gate that timed out never settled, so
-      // don't trust its partial snapshot: fall through to the blank check.
+      // don't trust its partial signals: fall through to the blank check.
       let isReady =
         !ready.timedOut &&
         isPaintedContent(ready) &&
@@ -207,12 +207,12 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
             { page, goto, timeout: Math.max(0, pollTimeout - elapsed()) }
           )
           const isWhite = await isWhiteScreenshot(screenshot)
-          const [pageSnapshot, paintSnapshot] = await Promise.all([
+          const [pageSnapshot, paintResult] = await Promise.all([
             pReflect(getPageSnapshot(page)),
-            pReflect(page.evaluate(snapshot))
+            pReflect(page.evaluate(paintSignals))
           ])
           const pageMeta = pageSnapshot.isRejected ? {} : pageSnapshot.value
-          const paint = paintSnapshot.isRejected ? {} : paintSnapshot.value
+          const signals = paintResult.isRejected ? {} : paintResult.value
           const pageReadyResult = await pReflect(
             isPageReady({
               page,
@@ -220,17 +220,17 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
               isWhite,
               isWhiteScreenshot,
               ...pageMeta,
-              ...paint
+              ...signals
             })
           )
-          isReady = !pageReadyResult.isRejected && !!pageReadyResult.value && !isBlankShell(paint)
+          isReady = !pageReadyResult.isRejected && !!pageReadyResult.value && !isBlankShell(signals)
 
           if (!isReady) await goto.waitUntilAuto(page, { timeout: rest.timeout })
           debug('retry', {
             waitUntil,
             isReady,
             isWhite,
-            blank: isBlankShell(paint),
+            blank: isBlankShell(signals),
             retry,
             duration: screenshotTime()
           })

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -8,17 +8,14 @@ const pReflect = require('p-reflect')
 const {
   captureWithNavigationRetry,
   isWhiteScreenshot,
-  waitForDomStability,
   waitForReady,
   prepareFullDocument,
   expandOverflow,
   scrollFullPageToLoadContent,
-  resolveWaitForDom,
   SCREENSHOT_DEFAULT_OPTS
 } = require('@browserless/screenshot')
 
 const PDF_DEFAULT_OPTS = {
-  waitForDom: SCREENSHOT_DEFAULT_OPTS.waitForDom,
   margin: '0.35cm',
   scale: 0.65,
   printBackground: true,
@@ -83,23 +80,9 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
   const prepare = async (page, url, opts = {}) => {
     const {
       waitUntil = PDF_DEFAULT_OPTS.waitUntil,
-      waitForDom = PDF_DEFAULT_OPTS.waitForDom,
       isPageReady = PDF_DEFAULT_OPTS.isPageReady,
       ...rest
     } = opts
-    const waitForDomOpts = resolveWaitForDom(waitForDom)
-
-    const waitForDomStabilityResult = async page => {
-      if (!waitForDomOpts) return
-
-      const result = await pReflect(page.evaluate(waitForDomStability, waitForDomOpts))
-      debug(
-        'waitForDomStability',
-        result.isRejected
-          ? { ...waitForDomOpts, error: result.reason.message || result.reason }
-          : { ...waitForDomOpts, ...result.value }
-      )
-    }
 
     const checkPageReady = async (page, { response, screenshot, isWhite } = {}) => {
       const pageMetaResult = await pReflect(getPageMeta(page))
@@ -119,7 +102,6 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
 
     if (waitUntil !== 'auto') {
       await goto(page, { ...rest, url, waitUntil })
-      await waitForDomStabilityResult(page)
       await prepareFullDocument(page, {
         goto,
         timeout: resolveScrollTimeout(goto, rest.timeout)
@@ -143,7 +125,6 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     return readiness
 
     async function waitUntilAuto (page, { response, timeout: autoTimeout } = {}) {
-      await waitForDomStabilityResult(page)
       const timeout = autoTimeout ?? goto.timeouts.action(rest.timeout)
 
       const readyTime = timeSpan()

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -133,10 +133,11 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
 
     // Same full-document prep as fullPage screenshot (scroll + unwrap overflow).
     if (isReady) {
-      readiness = await prepareFullDocument(page, {
-        goto,
-        timeout: goto.timeouts.goto(rest.timeout)
-      })
+      const scrollTimeout =
+        typeof goto.timeouts.goto === 'function'
+          ? goto.timeouts.goto(rest.timeout)
+          : goto.timeouts.action(rest.timeout)
+      readiness = await prepareFullDocument(page, { goto, timeout: scrollTimeout })
     }
 
     return readiness

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -12,6 +12,7 @@ const {
   waitForReady,
   prepareFullDocument,
   expandOverflow,
+  scrollFullPageToLoadContent,
   resolveWaitForDom,
   SCREENSHOT_DEFAULT_OPTS
 } = require('@browserless/screenshot')
@@ -23,6 +24,8 @@ const PDF_DEFAULT_OPTS = {
   printBackground: true,
   waitUntil: 'auto',
   isPageReady: SCREENSHOT_DEFAULT_OPTS.isPageReady
+  // mediaType intentionally unset: `page.pdf()` already uses Chromium print
+  // CSS. Pass `mediaType: 'screen' | 'print'` to call emulateMediaType.
 }
 
 // Share of the phase's load allowance the readiness gate may consume in `auto`
@@ -37,6 +40,51 @@ const READY_BUDGET_RATIO = 0.25
 // in `waitForReady`'s paintSignals, which stops walking text nodes once reached —
 // raising this above the cap would make the text fast path unreachable.
 const TEXT_PAINTED_MIN = 200
+
+// Puppeteer `page.pdf()` options only — keep navigation/readiness keys out of
+// the CDP payload even though unknown keys are usually ignored.
+const toPdfOpts = ({
+  path,
+  scale,
+  displayHeaderFooter,
+  headerTemplate,
+  footerTemplate,
+  printBackground,
+  landscape,
+  pageRanges,
+  format,
+  width,
+  height,
+  preferCSSPageSize,
+  margin,
+  omitBackground,
+  tagged,
+  outline,
+  waitForFonts,
+  timeout
+}) =>
+  Object.fromEntries(
+    Object.entries({
+      path,
+      scale,
+      displayHeaderFooter,
+      headerTemplate,
+      footerTemplate,
+      printBackground,
+      landscape,
+      pageRanges,
+      format,
+      width,
+      height,
+      preferCSSPageSize,
+      margin: getMargin(margin),
+      omitBackground,
+      tagged,
+      outline,
+      waitForFonts,
+      timeout
+    }).filter(([, value]) => value !== undefined)
+  )
 
 const getMargin = unit => {
   if (!unit) return unit
@@ -59,6 +107,11 @@ const getPageSnapshot = page =>
 const isPaintedContent = ({ painted = 0, text = 0, fonts = true } = {}) =>
   painted > 0 || (text >= TEXT_PAINTED_MIN && fonts)
 
+const resolveScrollTimeout = (goto, timeout) =>
+  typeof goto.timeouts.goto === 'function'
+    ? goto.timeouts.goto(timeout)
+    : goto.timeouts.action(timeout)
+
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
 
@@ -66,25 +119,20 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
   // a single load can be reused across page-range chunks (microlink-api's
   // parallel renderer) without re-navigating.
   const render = async (page, opts = {}) => {
-    const {
-      margin = PDF_DEFAULT_OPTS.margin,
-      scale = PDF_DEFAULT_OPTS.scale,
-      printBackground = PDF_DEFAULT_OPTS.printBackground,
-      ...rest
-    } = opts
+    const pdfOpts = toPdfOpts({
+      ...opts,
+      margin: opts.margin ?? PDF_DEFAULT_OPTS.margin,
+      scale: opts.scale ?? PDF_DEFAULT_OPTS.scale,
+      printBackground: opts.printBackground ?? PDF_DEFAULT_OPTS.printBackground
+    })
 
     await pReflect(page.evaluate(expandOverflow))
 
-    return captureWithNavigationRetry(
-      () =>
-        page.pdf({
-          ...rest,
-          margin: getMargin(margin),
-          printBackground,
-          scale
-        }),
-      { page, goto, timeout: goto.timeouts.action(rest.timeout) }
-    )
+    return captureWithNavigationRetry(() => page.pdf(pdfOpts), {
+      page,
+      goto,
+      timeout: goto.timeouts.action(opts.timeout)
+    })
   }
 
   // Navigate `page` to `url` and wait until it is ready to print: DOM stability
@@ -96,7 +144,9 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       margin,
       scale,
       printBackground,
-      mediaType = PDF_DEFAULT_OPTS.mediaType,
+      // Unset → Chromium's native print CSS for `page.pdf()`. Pass `screen` (or
+      // another type) via opts when the caller needs emulateMediaType.
+      mediaType,
       waitUntil = PDF_DEFAULT_OPTS.waitUntil,
       waitForDom = PDF_DEFAULT_OPTS.waitForDom,
       isPageReady = PDF_DEFAULT_OPTS.isPageReady,
@@ -117,6 +167,22 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       )
     }
 
+    const checkPageReady = async (page, { response, screenshot, isWhite } = {}) => {
+      const pageSnapshot = await pReflect(getPageSnapshot(page))
+      const pageMeta = pageSnapshot.isRejected ? {} : pageSnapshot.value
+      const pageReadyResult = await pReflect(
+        isPageReady({
+          page,
+          response,
+          screenshot,
+          isWhite,
+          isWhiteScreenshot,
+          ...pageMeta
+        })
+      )
+      return !pageReadyResult.isRejected && !!pageReadyResult.value
+    }
+
     if (waitUntil !== 'auto') {
       await goto(page, { ...gotoOpts, url, waitUntil })
       await waitForDomStabilityResult(page)
@@ -133,16 +199,16 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
 
     // Same full-document prep as fullPage screenshot (scroll + unwrap overflow).
     if (isReady) {
-      const scrollTimeout =
-        typeof goto.timeouts.goto === 'function'
-          ? goto.timeouts.goto(rest.timeout)
-          : goto.timeouts.action(rest.timeout)
-      readiness = await prepareFullDocument(page, { goto, timeout: scrollTimeout })
+      const prep = await prepareFullDocument(page, {
+        goto,
+        timeout: resolveScrollTimeout(goto, rest.timeout)
+      })
+      readiness = { ...readiness, ...prep }
     }
 
     return readiness
 
-    async function waitUntilAuto (page, { timeout: autoTimeout } = {}) {
+    async function waitUntilAuto (page, { response, timeout: autoTimeout } = {}) {
       await waitForDomStabilityResult(page)
       const timeout = autoTimeout ?? goto.timeouts.action(rest.timeout)
 
@@ -155,13 +221,21 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
 
       const elapsed = timeSpan()
       const pollTimeout = Math.max(0, timeout - readyTime())
+      let hydrated = false
 
+      // Painted-content fast path still must clear `isPageReady` (bot-check /
+      // verification). Prefer a page-meta check without a probe shot.
       isReady =
         !ready.timedOut &&
         isPaintedContent(ready) &&
         !ready.covered &&
         ready.viewport > 0 &&
         ready.height > ready.viewport
+
+      if (isReady) {
+        isReady = await checkPageReady(page, { response, isWhite: false })
+        if (!isReady) debug('ready:isPageReady', { rejected: true })
+      }
 
       if (!isReady) {
         let retry = -1
@@ -178,18 +252,16 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
             { page, goto, timeout: Math.max(0, pollTimeout - elapsed()) }
           )
           const isWhite = await isWhiteScreenshot(screenshot)
-          const pageSnapshot = await pReflect(getPageSnapshot(page))
-          const pageMeta = pageSnapshot.isRejected ? {} : pageSnapshot.value
-          const pageReadyResult = await pReflect(
-            isPageReady({
-              page,
-              screenshot,
-              isWhite,
-              isWhiteScreenshot,
-              ...pageMeta
-            })
-          )
-          isReady = !pageReadyResult.isRejected && !!pageReadyResult.value
+          isReady = await checkPageReady(page, { response, screenshot, isWhite })
+
+          // One bounded scroll so overflow/lazy shells can paint before the
+          // next readiness check — without waiting for a final prepare gate.
+          const remaining = pollTimeout - elapsed()
+          if (!isReady && !hydrated && !isWhite && remaining > 1000) {
+            hydrated = true
+            await pReflect(scrollFullPageToLoadContent(page, Math.min(remaining / 2, 8000)))
+            debug('ready:hydrateScroll', { remaining })
+          }
 
           if (!isReady) await goto.waitUntilAuto(page, { timeout: rest.timeout })
           debug('retry', {

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -115,10 +115,11 @@ const resolveScrollTimeout = (goto, timeout) =>
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
 
-  // Set by `prepare` when the page cleared readiness (or used a non-auto wait).
-  // `render` only unwraps overflow for prepared pages so bot-check shells that
-  // never pass `isPageReady` are not expanded at print time.
-  let documentPrepared = false
+  // Per-page: set by `prepare` when that page cleared readiness (or used a
+  // non-auto wait). `render` only unwraps overflow for prepared pages so
+  // bot-check shells that never pass `isPageReady` are not expanded at print
+  // time. WeakMap keeps concurrent prepare/render jobs from racing a shared flag.
+  const documentPrepared = new WeakMap()
 
   // Render an already-prepared page to a PDF buffer. Split out from the load so
   // a single load can be reused across page-range chunks (microlink-api's
@@ -131,7 +132,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       printBackground: opts.printBackground ?? PDF_DEFAULT_OPTS.printBackground
     })
 
-    if (documentPrepared) {
+    if (documentPrepared.get(page)) {
       await pReflect(page.evaluate(expandOverflow))
     }
 
@@ -161,7 +162,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     } = opts
     const waitForDomOpts = resolveWaitForDom(waitForDom)
     const gotoOpts = { ...rest, mediaType }
-    documentPrepared = false
+    documentPrepared.set(page, false)
 
     const waitForDomStabilityResult = async page => {
       if (!waitForDomOpts) return
@@ -194,7 +195,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     if (waitUntil !== 'auto') {
       await goto(page, { ...gotoOpts, url, waitUntil })
       await waitForDomStabilityResult(page)
-      documentPrepared = true
+      documentPrepared.set(page, true)
       return
     }
 
@@ -213,7 +214,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
         timeout: resolveScrollTimeout(goto, rest.timeout)
       })
       readiness = { ...readiness, ...prep }
-      documentPrepared = true
+      documentPrepared.set(page, true)
     }
 
     return readiness

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -10,6 +10,8 @@ const {
   isWhiteScreenshot,
   waitForDomStability,
   waitForReady,
+  snapshot,
+  scrollFullPageToLoadContent,
   resolveWaitForDom,
   SCREENSHOT_DEFAULT_OPTS
 } = require('@browserless/screenshot')
@@ -19,7 +21,8 @@ const PDF_DEFAULT_OPTS = {
   margin: '0.35cm',
   scale: 0.65,
   printBackground: true,
-  waitUntil: 'auto'
+  waitUntil: 'auto',
+  isPageReady: SCREENSHOT_DEFAULT_OPTS.isPageReady
 }
 
 // Share of the phase's load allowance the readiness gate may consume in `auto`
@@ -46,25 +49,149 @@ const getMargin = unit => {
   }
 }
 
+const getPageSnapshot = page =>
+  page.evaluate(() => ({
+    title: document.title || '',
+    bodyText: document.body ? document.body.innerText || '' : '',
+    url: window.location.href || ''
+  }))
+
+const isPaintedContent = ({ painted = 0, text = 0, fonts = true } = {}) =>
+  painted > 0 || (text >= TEXT_PAINTED_MIN && fonts)
+
+// A quiet document with nothing visible yet — black SPA shell after a bot
+// checkpoint, empty root before hydrate. `isWhiteScreenshot` only catches
+// near-white frames, so these must be rejected on paint signals.
+const isBlankShell = ({ painted = 0, text = 0, covered = false } = {}) =>
+  covered || (painted === 0 && text === 0)
+
+// App shells keep slides in an overflow scroller (`doc` ≈ viewport). `page.pdf()`
+// only paginates the document flow, so unwrap that scroller (and hide reader
+// chrome) when content is taller than the viewport.
+const expandOverflowForPdf = () => {
+  for (const sel of [
+    '.theme-report-nav',
+    '.theme-project-header',
+    '.theme-report-mobile-nav',
+    '.report-page-label'
+  ]) {
+    for (const el of document.querySelectorAll(sel)) {
+      el.style.setProperty('display', 'none', 'important')
+    }
+  }
+
+  const scroll =
+    document.querySelector('.report-canvas-scroll') ||
+    [...document.querySelectorAll('*')]
+      .filter(el => {
+        const s = window.getComputedStyle(el)
+        return (
+          (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
+          el.scrollHeight > el.clientHeight + 200
+        )
+      })
+      .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
+
+  if (!scroll) return false
+
+  let el = scroll
+  while (el) {
+    const pos = window.getComputedStyle(el).position
+    el.style.setProperty('overflow', 'visible', 'important')
+    el.style.setProperty('height', 'auto', 'important')
+    el.style.setProperty('max-height', 'none', 'important')
+    if (pos === 'absolute' || pos === 'fixed') {
+      el.style.setProperty('position', 'relative', 'important')
+      el.style.setProperty('inset', 'auto', 'important')
+    }
+    if (el === document.documentElement) break
+    el = el.parentElement
+  }
+  return true
+}
+
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
 
   // Render an already-prepared page to a PDF buffer. Split out from the load so
   // a single load can be reused across page-range chunks (microlink-api's
   // parallel renderer) without re-navigating.
-  const render = (page, opts = {}) => {
+  const render = async (page, opts = {}) => {
     const {
       margin = PDF_DEFAULT_OPTS.margin,
       scale = PDF_DEFAULT_OPTS.scale,
       printBackground = PDF_DEFAULT_OPTS.printBackground,
+      mediaType = PDF_DEFAULT_OPTS.mediaType,
       waitUntil,
       waitForDom,
+      isPageReady,
       ...rest
     } = opts
-    return captureWithNavigationRetry(
-      () => page.pdf({ ...rest, margin: getMargin(margin), printBackground, scale }),
-      { page, goto, timeout: goto.timeouts.action(rest.timeout) }
-    )
+
+    if (mediaType) await pReflect(page.emulateMediaType(mediaType))
+    const expanded = await pReflect(page.evaluate(expandOverflowForPdf))
+    debug('expandOverflowForPdf', {
+      mediaType,
+      expanded: !expanded.isRejected && expanded.value
+    })
+
+    const pdfOpts = {
+      ...rest,
+      margin: getMargin(margin),
+      printBackground,
+      scale
+    }
+
+    // Report builders (e.g. oviond) lay out fixed-size `.report-page-sheet`
+    // slides. Letter + scale 0.65 letterboxes them; when the user hasn't picked
+    // a paper size, size each PDF page to the slide and break between anchors.
+    if (!rest.format && rest.width == null && rest.height == null) {
+      const sheet = await pReflect(
+        page.evaluate(() => {
+          let best = null
+          for (const el of document.querySelectorAll('.report-page-sheet')) {
+            const { width, height } = el.getBoundingClientRect()
+            if (width < 100 || height < 100) continue
+            if (!best || width * height > best.width * best.height) {
+              best = { width: Math.round(width), height: Math.round(height) }
+            }
+          }
+          return best
+        })
+      )
+      if (!sheet.isRejected && sheet.value) {
+        pdfOpts.width = sheet.value.width
+        pdfOpts.height = sheet.value.height
+        pdfOpts.scale = 1
+        pdfOpts.margin = getMargin(0)
+        await pReflect(
+          page.addStyleTag({
+            content: `
+              .report-page-anchor {
+                break-after: page;
+                page-break-after: always;
+              }
+              .report-page-anchor:last-child {
+                break-after: auto;
+                page-break-after: auto;
+              }
+            `
+          })
+        )
+        debug('pdfPageSize', sheet.value)
+      } else {
+        debug('pdfPageSize', {
+          skipped: true,
+          error: sheet.isRejected ? sheet.reason.message : 'no sheet'
+        })
+      }
+    }
+
+    return captureWithNavigationRetry(() => page.pdf(pdfOpts), {
+      page,
+      goto,
+      timeout: goto.timeouts.action(rest.timeout)
+    })
   }
 
   // Navigate `page` to `url` and wait until it is ready to print: DOM stability
@@ -76,11 +203,14 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       margin,
       scale,
       printBackground,
+      mediaType = PDF_DEFAULT_OPTS.mediaType,
       waitUntil = PDF_DEFAULT_OPTS.waitUntil,
       waitForDom = PDF_DEFAULT_OPTS.waitForDom,
+      isPageReady = PDF_DEFAULT_OPTS.isPageReady,
       ...rest
     } = opts
     const waitForDomOpts = resolveWaitForDom(waitForDom)
+    const gotoOpts = { ...rest, mediaType }
 
     const waitForDomStabilityResult = async page => {
       if (!waitForDomOpts) return
@@ -95,7 +225,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     }
 
     if (waitUntil !== 'auto') {
-      await goto(page, { ...rest, url, waitUntil })
+      await goto(page, { ...gotoOpts, url, waitUntil })
       await waitForDomStabilityResult(page)
       return
     }
@@ -105,12 +235,14 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     // load across page-ranges can choose a fresh context instead.
     let readiness
 
-    await goto(page, { ...rest, url, waitUntil, waitUntilAuto })
+    await goto(page, { ...gotoOpts, url, waitUntil, waitUntilAuto })
     return readiness
 
     async function waitUntilAuto (page, { timeout: autoTimeout } = {}) {
       await waitForDomStabilityResult(page)
-      const timeout = goto.timeouts.action(rest.timeout)
+      // Checkpoint + SPA hydrate needs more than `timeouts.action` (~2.7s): budget
+      // the blank poll from the same load allowance as the readiness gate.
+      const timeout = autoTimeout ?? goto.timeouts.action(rest.timeout)
 
       // The readiness gate waits for a page to settle — page-load work, not a
       // small action. Budgeting it from `timeouts.action` (timeout/11) gave it
@@ -120,14 +252,15 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       // returns as soon as the page is quiet, so this is a cap, not a cost.
       const readyTime = timeSpan()
       const ready = await waitForReady(page, {
-        timeout: Math.round((autoTimeout ?? timeout) * READY_BUDGET_RATIO)
+        timeout: Math.round(timeout * READY_BUDGET_RATIO)
       })
       readiness = ready
       debug('ready', { ...ready, duration: readyTime() })
 
-      // The blank-page poll keeps its own action budget, measured from here so
-      // a slow gate cannot starve it.
+      // The blank-page poll keeps its own clock, measured from here so a slow
+      // gate cannot starve it. Remaining load allowance is the cap.
       const elapsed = timeSpan()
+      const pollTimeout = Math.max(0, timeout - readyTime())
 
       // Fast path: the page settled with real painted content in a document
       // taller than the viewport — a visibly rendered image (not a tracking
@@ -141,45 +274,87 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       // and an unknown viewport skips the fast path rather than dropping the
       // taller-than-viewport guard. A gate that timed out never settled, so
       // don't trust its partial snapshot: fall through to the blank check.
-      const painted = ready.painted > 0 || (ready.text >= TEXT_PAINTED_MIN && ready.fonts)
-      if (
+      let isReady =
         !ready.timedOut &&
-        painted &&
+        isPaintedContent(ready) &&
         !ready.covered &&
         ready.viewport > 0 &&
         ready.height > ready.viewport
-      ) {
-        return
-      }
 
       // Otherwise fall back to the screenshot poll — re-wait while the first
-      // paint is still blank — to keep the blank-SPA protection. The page has
-      // already settled, so the first capture won't race a navigation, and a
-      // non-blank page exits after that single shot without an extra re-wait.
-      let isWhite = false
-      let retry = -1
-      do {
-        ++retry
-        const screenshotTime = timeSpan()
-        const screenshot = await captureWithNavigationRetry(
-          () =>
-            page.screenshot({
-              ...rest,
-              optimizeForSpeed: true,
-              type: 'jpeg',
-              quality: 30
-            }),
-          // The retry loop keeps its own clock, so hand it only what is left
-          // of the shared budget — a fresh full `timeout` here would let one
-          // navigation-racing capture double the worst-case prepare time.
-          { page, goto, timeout: Math.max(0, timeout - elapsed()) }
-        )
-        isWhite = await isWhiteScreenshot(screenshot)
-        if (isWhite) await goto.waitUntilAuto(page, { timeout: rest.timeout })
-        debug('retry', { waitUntil, isWhite, retry, duration: screenshotTime() })
-      } while (isWhite && elapsed() < timeout)
+      // paint is still blank — to keep the blank-SPA protection. Also reject
+      // black/empty shells and (via `isPageReady`) bot-check interstitial
+      // pages: those fail the white-pixel check while still being unprintable.
+      if (!isReady) {
+        let retry = -1
+        do {
+          ++retry
+          const screenshotTime = timeSpan()
+          const screenshot = await captureWithNavigationRetry(
+            () =>
+              page.screenshot({
+                ...rest,
+                optimizeForSpeed: true,
+                type: 'jpeg',
+                quality: 30
+              }),
+            // The retry loop keeps its own clock, so hand it only what is left
+            // of the shared budget — a fresh full `timeout` here would let one
+            // navigation-racing capture double the worst-case prepare time.
+            { page, goto, timeout: Math.max(0, pollTimeout - elapsed()) }
+          )
+          const isWhite = await isWhiteScreenshot(screenshot)
+          const [pageSnapshot, paintSnapshot] = await Promise.all([
+            pReflect(getPageSnapshot(page)),
+            pReflect(page.evaluate(snapshot))
+          ])
+          const pageMeta = pageSnapshot.isRejected ? {} : pageSnapshot.value
+          const paint = paintSnapshot.isRejected ? {} : paintSnapshot.value
+          const pageReadyResult = await pReflect(
+            isPageReady({
+              page,
+              screenshot,
+              isWhite,
+              isWhiteScreenshot,
+              ...pageMeta,
+              ...paint
+            })
+          )
+          isReady = !pageReadyResult.isRejected && !!pageReadyResult.value && !isBlankShell(paint)
 
-      debug({ waitUntil, isWhite, timeout, duration: require('pretty-ms')(elapsed()) })
+          if (!isReady) await goto.waitUntilAuto(page, { timeout: rest.timeout })
+          debug('retry', {
+            waitUntil,
+            isReady,
+            isWhite,
+            blank: isBlankShell(paint),
+            retry,
+            duration: screenshotTime()
+          })
+        } while (!isReady && elapsed() < pollTimeout)
+      }
+
+      // PDF is inherently full-page: scroll the document (or its tallest
+      // overflow scroller) so lazy sections hydrate before print, then wait
+      // for the fetches that scroll triggered to go idle and the DOM to settle.
+      if (isReady && elapsed() < pollTimeout) {
+        const scrollTimeout = Math.max(0, pollTimeout - elapsed())
+        await goto.run({
+          fn: scrollFullPageToLoadContent(page, scrollTimeout),
+          timeout: Math.max(scrollTimeout * 2, scrollTimeout + 1000),
+          debug: 'scrollFullPageToLoadContent'
+        })
+        await goto.waitUntilAuto(page, {
+          timeout: Math.max(0, pollTimeout - elapsed())
+        })
+        const settle = await waitForReady(page, {
+          timeout: Math.max(0, pollTimeout - elapsed())
+        })
+        readiness = settle
+        debug('settle', { ...settle, duration: elapsed() })
+      }
+
+      debug({ waitUntil, isReady, timeout: pollTimeout, duration: require('pretty-ms')(elapsed()) })
     }
   }
 

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -24,21 +24,9 @@ const PDF_DEFAULT_OPTS = {
   printBackground: true,
   waitUntil: 'auto',
   isPageReady: SCREENSHOT_DEFAULT_OPTS.isPageReady
-  // mediaType intentionally unset: `page.pdf()` already uses Chromium print
-  // CSS. Pass `mediaType: 'screen' | 'print'` to call emulateMediaType.
 }
 
-// Share of the phase's load allowance the readiness gate may consume in `auto`
-// mode. Pages observed settling in 0.6-3.3s (a hydrating document is the slow
-// end), so a quarter of the allowance — ~3.9s at the default request budget —
-// covers them with margin while keeping the cap well short of the render's
-// share. The gate returns as soon as the page is quiet, so this bounds only a
-// page that never settles.
 const READY_BUDGET_RATIO = 0.25
-
-// Minimum visible characters for the text fast path. Matches the counting cap
-// in `waitForReady`'s paintSignals, which stops walking text nodes once reached —
-// raising this above the cap would make the text fast path unreachable.
 const TEXT_PAINTED_MIN = 200
 
 const getMargin = unit => {
@@ -70,15 +58,6 @@ const resolveScrollTimeout = (goto, timeout) =>
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
 
-  // Per-page: set by `prepare` when that page cleared readiness (or used a
-  // non-auto wait). `render` only unwraps overflow for prepared pages so
-  // bot-check shells that never pass `isPageReady` are not expanded at print
-  // time. WeakMap keeps concurrent prepare/render jobs from racing a shared flag.
-  const documentPrepared = new WeakMap()
-
-  // Render an already-prepared page to a PDF buffer. Split out from the load so
-  // a single load can be reused across page-range chunks (microlink-api's
-  // parallel renderer) without re-navigating.
   const render = async (page, opts = {}) => {
     const {
       margin = PDF_DEFAULT_OPTS.margin,
@@ -87,9 +66,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       ...rest
     } = opts
 
-    if (documentPrepared.get(page)) {
-      await pReflect(page.evaluate(expandOverflow))
-    }
+    await pReflect(page.evaluate(expandOverflow))
 
     return captureWithNavigationRetry(
       () =>
@@ -103,26 +80,14 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     )
   }
 
-  // Navigate `page` to `url` and wait until it is ready to print: DOM stability
-  // plus, in `auto` mode, a navigation-tolerant readiness gate. Only a page that
-  // settles still-blank falls back to the (expensive, navigation-fragile)
-  // screenshot poll.
   const prepare = async (page, url, opts = {}) => {
     const {
-      margin,
-      scale,
-      printBackground,
-      // Unset → Chromium's native print CSS for `page.pdf()`. Pass `screen` (or
-      // another type) via opts when the caller needs emulateMediaType.
-      mediaType,
       waitUntil = PDF_DEFAULT_OPTS.waitUntil,
       waitForDom = PDF_DEFAULT_OPTS.waitForDom,
       isPageReady = PDF_DEFAULT_OPTS.isPageReady,
       ...rest
     } = opts
     const waitForDomOpts = resolveWaitForDom(waitForDom)
-    const gotoOpts = { ...rest, mediaType }
-    documentPrepared.set(page, false)
 
     const waitForDomStabilityResult = async page => {
       if (!waitForDomOpts) return
@@ -153,34 +118,26 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     }
 
     if (waitUntil !== 'auto') {
-      await goto(page, { ...gotoOpts, url, waitUntil })
+      await goto(page, { ...rest, url, waitUntil })
       await waitForDomStabilityResult(page)
-      // Match fullPage screenshot: explicit waitUntil still needs overflow
-      // hydrate + unwrap so lazy SPA shells print the full document.
       await prepareFullDocument(page, {
         goto,
         timeout: resolveScrollTimeout(goto, rest.timeout)
       })
-      documentPrepared.set(page, true)
       return
     }
 
-    // Surfaced to the caller: a page whose readiness could not be confirmed
-    // (`timedOut`) is a poor one to keep rendering on, so a caller reusing this
-    // load across page-ranges can choose a fresh context instead.
     let readiness
     let isReady = false
 
-    await goto(page, { ...gotoOpts, url, waitUntil, waitUntilAuto })
+    await goto(page, { ...rest, url, waitUntil, waitUntilAuto })
 
-    // Same full-document prep as fullPage screenshot (scroll + unwrap overflow).
     if (isReady) {
       const prep = await prepareFullDocument(page, {
         goto,
         timeout: resolveScrollTimeout(goto, rest.timeout)
       })
       readiness = { ...readiness, ...prep }
-      documentPrepared.set(page, true)
     }
 
     return readiness
@@ -198,10 +155,8 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
 
       const elapsed = timeSpan()
       const pollTimeout = Math.max(0, timeout - readyTime())
-      let hydrated = false
+      let didHydrateScroll = false
 
-      // Painted-content fast path still must clear `isPageReady` (bot-check /
-      // verification). Prefer a page-meta check without a probe shot.
       isReady =
         !ready.timedOut &&
         isPaintedContent(ready) &&
@@ -231,11 +186,9 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
           const isWhite = await isWhiteScreenshot(screenshot)
           isReady = await checkPageReady(page, { response, screenshot, isWhite })
 
-          // One bounded scroll so overflow/lazy shells can paint before the
-          // next readiness check — without waiting for a final prepare gate.
           const remaining = pollTimeout - elapsed()
-          if (!isReady && !hydrated && !isWhite && remaining > 1000) {
-            hydrated = true
+          if (!isReady && !didHydrateScroll && !isWhite && remaining > 1000) {
+            didHydrateScroll = true
             await pReflect(scrollFullPageToLoadContent(page, Math.min(remaining / 2, 8000)))
             debug('ready:hydrateScroll', { remaining })
           }

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -155,6 +155,12 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     if (waitUntil !== 'auto') {
       await goto(page, { ...gotoOpts, url, waitUntil })
       await waitForDomStabilityResult(page)
+      // Match fullPage screenshot: explicit waitUntil still needs overflow
+      // hydrate + unwrap so lazy SPA shells print the full document.
+      await prepareFullDocument(page, {
+        goto,
+        timeout: resolveScrollTimeout(goto, rest.timeout)
+      })
       documentPrepared.set(page, true)
       return
     }

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -65,32 +65,19 @@ const isPaintedContent = ({ painted = 0, text = 0, fonts = true } = {}) =>
 const isBlankShell = ({ painted = 0, text = 0, covered = false } = {}) =>
   covered || (painted === 0 && text === 0)
 
-// App shells keep slides in an overflow scroller (`doc` ≈ viewport). `page.pdf()`
-// only paginates the document flow, so unwrap that scroller (and hide reader
-// chrome) when content is taller than the viewport.
+// App shells often keep content in an overflow scroller (`doc` ≈ viewport).
+// `page.pdf()` only paginates the document flow, so unwrap the tallest
+// overflow root when it is taller than the viewport.
 const expandOverflowForPdf = () => {
-  for (const sel of [
-    '.theme-report-nav',
-    '.theme-project-header',
-    '.theme-report-mobile-nav',
-    '.report-page-label'
-  ]) {
-    for (const el of document.querySelectorAll(sel)) {
-      el.style.setProperty('display', 'none', 'important')
-    }
-  }
-
-  const scroll =
-    document.querySelector('.report-canvas-scroll') ||
-    [...document.querySelectorAll('*')]
-      .filter(el => {
-        const s = window.getComputedStyle(el)
-        return (
-          (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
-          el.scrollHeight > el.clientHeight + 200
-        )
-      })
-      .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
+  const scroll = [...document.querySelectorAll('*')]
+    .filter(el => {
+      const s = window.getComputedStyle(el)
+      return (
+        (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
+        el.scrollHeight > el.clientHeight + 200
+      )
+    })
+    .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
 
   if (!scroll) return false
 
@@ -140,51 +127,6 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       margin: getMargin(margin),
       printBackground,
       scale
-    }
-
-    // Report builders (e.g. oviond) lay out fixed-size `.report-page-sheet`
-    // slides. Letter + scale 0.65 letterboxes them; when the user hasn't picked
-    // a paper size, size each PDF page to the slide and break between anchors.
-    if (!rest.format && rest.width == null && rest.height == null) {
-      const sheet = await pReflect(
-        page.evaluate(() => {
-          let best = null
-          for (const el of document.querySelectorAll('.report-page-sheet')) {
-            const { width, height } = el.getBoundingClientRect()
-            if (width < 100 || height < 100) continue
-            if (!best || width * height > best.width * best.height) {
-              best = { width: Math.round(width), height: Math.round(height) }
-            }
-          }
-          return best
-        })
-      )
-      if (!sheet.isRejected && sheet.value) {
-        pdfOpts.width = sheet.value.width
-        pdfOpts.height = sheet.value.height
-        pdfOpts.scale = 1
-        pdfOpts.margin = getMargin(0)
-        await pReflect(
-          page.addStyleTag({
-            content: `
-              .report-page-anchor {
-                break-after: page;
-                page-break-after: always;
-              }
-              .report-page-anchor:last-child {
-                break-after: auto;
-                page-break-after: auto;
-              }
-            `
-          })
-        )
-        debug('pdfPageSize', sheet.value)
-      } else {
-        debug('pdfPageSize', {
-          skipped: true,
-          error: sheet.isRejected ? sheet.reason.message : 'no sheet'
-        })
-      }
     }
 
     return captureWithNavigationRetry(() => page.pdf(pdfOpts), {

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -41,51 +41,6 @@ const READY_BUDGET_RATIO = 0.25
 // raising this above the cap would make the text fast path unreachable.
 const TEXT_PAINTED_MIN = 200
 
-// Puppeteer `page.pdf()` options only — keep navigation/readiness keys out of
-// the CDP payload even though unknown keys are usually ignored.
-const toPdfOpts = ({
-  path,
-  scale,
-  displayHeaderFooter,
-  headerTemplate,
-  footerTemplate,
-  printBackground,
-  landscape,
-  pageRanges,
-  format,
-  width,
-  height,
-  preferCSSPageSize,
-  margin,
-  omitBackground,
-  tagged,
-  outline,
-  waitForFonts,
-  timeout
-}) =>
-  Object.fromEntries(
-    Object.entries({
-      path,
-      scale,
-      displayHeaderFooter,
-      headerTemplate,
-      footerTemplate,
-      printBackground,
-      landscape,
-      pageRanges,
-      format,
-      width,
-      height,
-      preferCSSPageSize,
-      margin: getMargin(margin),
-      omitBackground,
-      tagged,
-      outline,
-      waitForFonts,
-      timeout
-    }).filter(([, value]) => value !== undefined)
-  )
-
 const getMargin = unit => {
   if (!unit) return unit
   if (typeof unit === 'object') return unit
@@ -97,7 +52,7 @@ const getMargin = unit => {
   }
 }
 
-const getPageSnapshot = page =>
+const getPageMeta = page =>
   page.evaluate(() => ({
     title: document.title || '',
     bodyText: document.body ? document.body.innerText || '' : '',
@@ -125,22 +80,27 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
   // a single load can be reused across page-range chunks (microlink-api's
   // parallel renderer) without re-navigating.
   const render = async (page, opts = {}) => {
-    const pdfOpts = toPdfOpts({
-      ...opts,
-      margin: opts.margin ?? PDF_DEFAULT_OPTS.margin,
-      scale: opts.scale ?? PDF_DEFAULT_OPTS.scale,
-      printBackground: opts.printBackground ?? PDF_DEFAULT_OPTS.printBackground
-    })
+    const {
+      margin = PDF_DEFAULT_OPTS.margin,
+      scale = PDF_DEFAULT_OPTS.scale,
+      printBackground = PDF_DEFAULT_OPTS.printBackground,
+      ...rest
+    } = opts
 
     if (documentPrepared.get(page)) {
       await pReflect(page.evaluate(expandOverflow))
     }
 
-    return captureWithNavigationRetry(() => page.pdf(pdfOpts), {
-      page,
-      goto,
-      timeout: goto.timeouts.action(opts.timeout)
-    })
+    return captureWithNavigationRetry(
+      () =>
+        page.pdf({
+          ...rest,
+          margin: getMargin(margin),
+          printBackground,
+          scale
+        }),
+      { page, goto, timeout: goto.timeouts.action(rest.timeout) }
+    )
   }
 
   // Navigate `page` to `url` and wait until it is ready to print: DOM stability
@@ -177,8 +137,8 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     }
 
     const checkPageReady = async (page, { response, screenshot, isWhite } = {}) => {
-      const pageSnapshot = await pReflect(getPageSnapshot(page))
-      const pageMeta = pageSnapshot.isRejected ? {} : pageSnapshot.value
+      const pageMetaResult = await pReflect(getPageMeta(page))
+      const pageMeta = pageMetaResult.isRejected ? {} : pageMetaResult.value
       const pageReadyResult = await pReflect(
         isPageReady({
           page,

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -82,7 +82,6 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     let readiness
     let isReady = false
     let didHydrateScroll = false
-    let didHydrateAttempt = false
 
     await goto(page, { ...rest, url, waitUntil, waitUntilAuto })
 
@@ -99,6 +98,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
 
     async function waitUntilAuto (page, { response, timeout: autoTimeout } = {}) {
       const timeout = autoTimeout ?? goto.timeouts.action(rest.timeout)
+      let didHydrateAttempt = false
 
       const readyTime = timeSpan()
       const ready = await waitForReady(page, {

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -52,7 +52,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       ...rest
     } = opts
 
-    await pReflect(page.evaluate(expandOverflow))
+    await pReflect(expandOverflow(page))
 
     return captureWithNavigationRetry(
       () =>

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -140,7 +140,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
           isReady = await checkPageReady(page, { isPageReady, response, screenshot, isWhite })
 
           const remaining = pollTimeout - elapsed()
-          if (!isReady && !didHydrateAttempt && !isWhite && remaining > 1000) {
+          if (!isReady && !didHydrateAttempt && !isWhite) {
             didHydrateAttempt = true
             const { hydrated, info } = await tryHydrateScroll(page, remaining)
             didHydrateScroll = hydrated

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -11,7 +11,8 @@ const {
   waitForReady,
   prepareFullDocument,
   expandOverflow,
-  scrollFullPageToLoadContent,
+  checkPageReady,
+  tryHydrateScroll,
   SCREENSHOT_DEFAULT_OPTS
 } = require('@browserless/screenshot')
 
@@ -37,20 +38,8 @@ const getMargin = unit => {
   }
 }
 
-const getPageMeta = page =>
-  page.evaluate(() => ({
-    title: document.title || '',
-    bodyText: document.body ? document.body.innerText || '' : '',
-    url: window.location.href || ''
-  }))
-
 const isPaintedContent = ({ painted = 0, text = 0, fonts = true } = {}) =>
   painted > 0 || (text >= TEXT_PAINTED_MIN && fonts)
-
-const resolveScrollTimeout = (goto, timeout) =>
-  typeof goto.timeouts.goto === 'function'
-    ? goto.timeouts.goto(timeout)
-    : goto.timeouts.action(timeout)
 
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
@@ -84,28 +73,9 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       ...rest
     } = opts
 
-    const checkPageReady = async (page, { response, screenshot, isWhite } = {}) => {
-      const pageMetaResult = await pReflect(getPageMeta(page))
-      const pageMeta = pageMetaResult.isRejected ? {} : pageMetaResult.value
-      const pageReadyResult = await pReflect(
-        isPageReady({
-          page,
-          response,
-          screenshot,
-          isWhite,
-          isWhiteScreenshot,
-          ...pageMeta
-        })
-      )
-      return !pageReadyResult.isRejected && !!pageReadyResult.value
-    }
-
     if (waitUntil !== 'auto') {
       await goto(page, { ...rest, url, waitUntil })
-      await prepareFullDocument(page, {
-        goto,
-        timeout: resolveScrollTimeout(goto, rest.timeout)
-      })
+      await prepareFullDocument(page, { goto, timeout: rest.timeout })
       return
     }
 
@@ -119,7 +89,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
     if (isReady) {
       const prep = await prepareFullDocument(page, {
         goto,
-        timeout: resolveScrollTimeout(goto, rest.timeout),
+        timeout: rest.timeout,
         scrolled: didHydrateScroll
       })
       readiness = { ...readiness, ...prep }
@@ -148,7 +118,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
         ready.height > ready.viewport
 
       if (isReady) {
-        isReady = await checkPageReady(page, { response, isWhite: false })
+        isReady = await checkPageReady(page, { isPageReady, response, isWhite: false })
         if (!isReady) debug('ready:isPageReady', { rejected: true })
       }
 
@@ -167,20 +137,14 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
             { page, goto, timeout: Math.max(0, pollTimeout - elapsed()) }
           )
           const isWhite = await isWhiteScreenshot(screenshot)
-          isReady = await checkPageReady(page, { response, screenshot, isWhite })
+          isReady = await checkPageReady(page, { isPageReady, response, screenshot, isWhite })
 
           const remaining = pollTimeout - elapsed()
           if (!isReady && !didHydrateAttempt && !isWhite && remaining > 1000) {
             didHydrateAttempt = true
-            const hydrate = await pReflect(
-              scrollFullPageToLoadContent(page, Math.min(remaining / 2, 5000))
-            )
-            didHydrateScroll = !hydrate.isRejected && !!hydrate.value?.hydrated
-            debug('ready:hydrateScroll', {
-              remaining,
-              hydrated: didHydrateScroll,
-              ...(hydrate.isRejected ? {} : hydrate.value)
-            })
+            const { hydrated, info } = await tryHydrateScroll(page, remaining)
+            didHydrateScroll = hydrated
+            debug('ready:hydrateScroll', { remaining, hydrated, ...info })
           }
 
           if (!isReady) await goto.waitUntilAuto(page, { timeout: rest.timeout })

--- a/packages/screenshot/README.md
+++ b/packages/screenshot/README.md
@@ -69,7 +69,6 @@ const buffer = await browserless.screenshot('https://example.com', {
 | `element`     | `string`   | —                           | CSS selector for element screenshot                                           |
 | `codeScheme`  | `string`   | `'atom-dark'`               | Prism.js theme for code highlighting                                          |
 | `waitUntil`   | `string`   | `'auto'`                    | When to consider navigation done                                              |
-| `waitForDom`  | `number`   | `0`                         | DOM stability window in ms (idle is `waitForDom / 10`, `0` disables DOM wait) |
 | `isPageReady` | `function` | `({ isWhite }) => !isWhite` | Custom readiness predicate for retry loop                                     |
 | `overlay`     | `object`   | `{}`                        | Browser overlay options                                                       |
 

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -20,11 +20,6 @@ const {
 
 const timeSpan = require('@kikobeats/time-span')()
 
-// Retry a page capture (screenshot/pdf) that races with a client-side
-// navigation. When the execution context is destroyed mid-capture, the page is
-// navigating: wait for it to settle via `waitUntilAuto` and retry in-place,
-// bounded by `timeout`, rather than failing the whole request. SPAs (e.g.
-// scribd) navigate client-side after load, so the initial capture often races.
 const captureWithNavigationRetry = async (capture, { page, goto, timeout }) => {
   const elapsed = timeSpan()
   while (true) {
@@ -195,7 +190,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
         let retry = 0
         let isWhite = false
         let isReady = false
-        let hydrated = false
+        let didHydrateScroll = false
 
         do {
           screenshot = await captureWithNavigationRetry(
@@ -222,11 +217,9 @@ module.exports = ({ goto, ...gotoOpts }) => {
 
           if (isReady || elapsed() >= timeout) break
 
-          // Full-page captures: one mid-poll scroll so lazy/overflow content can
-          // paint before readiness gives up (bot/white pages stay unscrolled).
           const remaining = timeout - elapsed()
-          if (opts.fullPage && !hydrated && !isWhite && remaining > 1000) {
-            hydrated = true
+          if (opts.fullPage && !didHydrateScroll && !isWhite && remaining > 1000) {
+            didHydrateScroll = true
             await pReflect(scrollFullPageToLoadContent(page, Math.min(remaining / 2, 8000)))
             debug('screenshot:hydrateScroll', { remaining })
           }
@@ -235,9 +228,6 @@ module.exports = ({ goto, ...gotoOpts }) => {
           await goto.waitUntilAuto(page, { timeout })
         } while (!isReady)
 
-        // Always return a fullPage buffer when requested — readiness probes stay
-        // viewport-only. Overflow unwrap stays gated on isReady so bot shells
-        // are not expanded; timed-out pages still get a document-height shot.
         if (opts.fullPage) {
           const scrollTimeout =
             typeof goto.timeouts.goto === 'function'

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -38,7 +38,7 @@ const captureWithNavigationRetry = async (capture, { page, goto, timeout }) => {
   }
 }
 
-const getPageSnapshot = page =>
+const getPageMeta = page =>
   page.evaluate(() => ({
     title: document.title || '',
     bodyText: document.body ? document.body.innerText || '' : '',
@@ -206,8 +206,8 @@ module.exports = ({ goto, ...gotoOpts }) => {
             { page, goto, timeout }
           )
           isWhite = await isWhiteScreenshot(screenshot)
-          const snapshotResult = await pReflect(getPageSnapshot(page))
-          const pageSnapshot = snapshotResult.isRejected ? {} : snapshotResult.value
+          const pageMetaResult = await pReflect(getPageMeta(page))
+          const pageMeta = pageMetaResult.isRejected ? {} : pageMetaResult.value
           const pageReadyResult = await pReflect(
             opts.isPageReady({
               page,
@@ -215,7 +215,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
               screenshot,
               isWhite,
               isWhiteScreenshot,
-              ...pageSnapshot
+              ...pageMeta
             })
           )
           isReady = !pageReadyResult.isRejected && !!pageReadyResult.value

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -235,15 +235,20 @@ module.exports = ({ goto, ...gotoOpts }) => {
           await goto.waitUntilAuto(page, { timeout })
         } while (!isReady)
 
-        if (isReady && opts.fullPage) {
+        // Always return a fullPage buffer when requested — readiness probes stay
+        // viewport-only. Overflow unwrap stays gated on isReady so bot shells
+        // are not expanded; timed-out pages still get a document-height shot.
+        if (opts.fullPage) {
           const scrollTimeout =
             typeof goto.timeouts.goto === 'function'
               ? goto.timeouts.goto(opts.timeout)
               : goto.timeouts.action(opts.timeout)
-          await prepareFullDocument(page, { goto, timeout: scrollTimeout })
+          if (isReady) {
+            await prepareFullDocument(page, { goto, timeout: scrollTimeout })
+          }
           screenshot = await captureWithNavigationRetry(
             async () => {
-              await pReflect(page.evaluate(expandOverflow))
+              if (isReady) await pReflect(page.evaluate(expandOverflow))
               return page.screenshot(toScreenshotOpts(opts, { fullPage: true }))
             },
             { page, goto, timeout: scrollTimeout }

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -10,7 +10,7 @@ const waitForPrism = require('./pretty')
 const prettyTimeSpan = require('./time-span')
 const overlay = require('./overlay')
 const { waitForDomStability, resolveWaitForDom, DEFAULT_WAIT_FOR_DOM } = require('./wait-for-dom')
-const { waitForReady } = require('./wait-for-ready')
+const { waitForReady, snapshot } = require('./wait-for-ready')
 
 const timeSpan = require('@kikobeats/time-span')()
 
@@ -64,39 +64,84 @@ const waitForImagesOnViewport = page =>
     )
   )
 
+// Walk the page (window, or the tallest overflow scroller when the document
+// itself isn't tall — report viewers / app shells) so lazy sections and
+// intersection-observer fetches actually run before capture/print.
 const scrollFullPageToLoadContent = async (page, timeout) => {
   const debug = require('debug-logfmt')('browserless:goto')
-
   const duration = debug.duration()
-  const result = await page.evaluate(waitForDomStability, {
-    idle: timeout / 2 / 2,
-    timeout: timeout / 2
-  })
 
-  duration('waitForDomStability', result)
+  // Most of the budget goes to scrolling: each step needs dwell time for
+  // intersection-observer fetches. A short pre-scroll quiet is enough to avoid
+  // racing a still-mounting shell; the post-scroll quiet waits for skeletons
+  // to be swapped out.
+  const preQuiet = Math.min(500, Math.floor(timeout / 8))
+  const postQuiet = Math.min(Math.floor(timeout / 4), Math.floor((timeout - preQuiet) / 2))
+  const scrollBudget = Math.max(0, timeout - preQuiet - postQuiet)
+
+  if (preQuiet > 0) {
+    const result = await page.evaluate(waitForDomStability, {
+      idle: preQuiet / 2,
+      timeout: preQuiet
+    })
+    duration('waitForDomStability:pre', result)
+  }
 
   await page.evaluate(
-    timeout =>
+    scrollBudget =>
       new Promise(resolve => {
-        let currentScrollPosition = 0
-        const scrollStep = Math.floor(window.innerHeight)
-        const pageHeight = document.body.scrollHeight
-        const totalSteps = Math.ceil(pageHeight / scrollStep)
-        const stepDelay = timeout / 2 / totalSteps
-        const scrollNext = async () => {
-          if (currentScrollPosition >= pageHeight) {
-            resolve()
-            return
+        const doc = document.scrollingElement || document.documentElement
+        let root = null
+        let pageHeight = doc ? doc.scrollHeight : 0
+        let viewport = window.innerHeight
+
+        // Document isn't scrollable: prefer the tallest overflow scroller
+        // (e.g. `.report-canvas-scroll`) so below-fold slides still hydrate.
+        if (pageHeight <= viewport + 1 && document.body) {
+          let best = null
+          for (const el of document.body.querySelectorAll('*')) {
+            if (el.scrollHeight <= el.clientHeight + 20) continue
+            const { overflowY } = window.getComputedStyle(el)
+            if (overflowY !== 'auto' && overflowY !== 'scroll') continue
+            if (!best || el.scrollHeight > best.scrollHeight) best = el
           }
-          window.scrollBy(0, scrollStep)
+          if (best) {
+            root = best
+            pageHeight = best.scrollHeight
+            viewport = best.clientHeight
+          }
+        }
+
+        let currentScrollPosition = 0
+        const scrollStep = Math.max(1, Math.floor(viewport * 0.8))
+        const totalSteps = Math.max(1, Math.ceil(pageHeight / scrollStep))
+        // Floor dwell so lazy sections actually fetch; if the budget can't
+        // cover every step at that pace, steps stretch to fit the budget.
+        const stepDelay = Math.max(400, Math.floor(scrollBudget / totalSteps))
+        const reset = () => {
+          window.scrollTo(0, 0)
+          if (root) root.scrollTop = 0
+          resolve()
+        }
+        const scrollNext = () => {
+          if (currentScrollPosition >= pageHeight) return reset()
+          if (root) root.scrollBy(0, scrollStep)
+          else window.scrollBy(0, scrollStep)
           currentScrollPosition += scrollStep
           setTimeout(scrollNext, stepDelay)
         }
         scrollNext()
       }),
-    timeout
+    scrollBudget
   )
-  await page.evaluate(() => window.scrollTo(0, 0))
+
+  if (postQuiet > 0) {
+    const result = await page.evaluate(waitForDomStability, {
+      idle: Math.min(300, postQuiet / 2),
+      timeout: postQuiet
+    })
+    duration('waitForDomStability:post', result)
+  }
 }
 
 const waitForElement = async (page, element) => {
@@ -279,4 +324,6 @@ module.exports.isWhiteScreenshot = isWhiteScreenshot
 module.exports.waitForDomStability = waitForDomStability
 module.exports.resolveWaitForDom = resolveWaitForDom
 module.exports.waitForReady = waitForReady
+module.exports.snapshot = snapshot
+module.exports.scrollFullPageToLoadContent = scrollFullPageToLoadContent
 module.exports.SCREENSHOT_DEFAULT_OPTS = SCREENSHOT_DEFAULT_OPTS

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -11,6 +11,12 @@ const prettyTimeSpan = require('./time-span')
 const overlay = require('./overlay')
 const { waitForDomStability, resolveWaitForDom, DEFAULT_WAIT_FOR_DOM } = require('./wait-for-dom')
 const { waitForReady, paintSignals } = require('./wait-for-ready')
+const {
+  waitForOverflowHeight,
+  expandOverflow,
+  scrollFullPageToLoadContent,
+  prepareFullDocument
+} = require('./prepare-full-document')
 
 const timeSpan = require('@kikobeats/time-span')()
 
@@ -64,86 +70,6 @@ const waitForImagesOnViewport = page =>
     )
   )
 
-// Walk the page (window, or the tallest overflow scroller when the document
-// itself isn't tall — report viewers / app shells) so lazy sections and
-// intersection-observer fetches actually run before capture/print.
-const scrollFullPageToLoadContent = async (page, timeout) => {
-  const debug = require('debug-logfmt')('browserless:goto')
-  const duration = debug.duration()
-
-  // Most of the budget goes to scrolling: each step needs dwell time for
-  // intersection-observer fetches. A short pre-scroll quiet is enough to avoid
-  // racing a still-mounting shell; the post-scroll quiet waits for skeletons
-  // to be swapped out.
-  const preQuiet = Math.min(500, Math.floor(timeout / 8))
-  const postQuiet = Math.min(Math.floor(timeout / 4), Math.floor((timeout - preQuiet) / 2))
-  const scrollBudget = Math.max(0, timeout - preQuiet - postQuiet)
-
-  if (preQuiet > 0) {
-    const result = await page.evaluate(waitForDomStability, {
-      idle: preQuiet / 2,
-      timeout: preQuiet
-    })
-    duration('waitForDomStability:pre', result)
-  }
-
-  await page.evaluate(
-    scrollBudget =>
-      new Promise(resolve => {
-        const doc = document.scrollingElement || document.documentElement
-        let root = null
-        let pageHeight = doc ? doc.scrollHeight : 0
-        let viewport = window.innerHeight
-
-        // Document isn't scrollable: prefer the tallest overflow scroller
-        // so below-fold lazy sections still hydrate.
-        if (pageHeight <= viewport + 1 && document.body) {
-          let best = null
-          for (const el of document.body.querySelectorAll('*')) {
-            if (el.scrollHeight <= el.clientHeight + 20) continue
-            const { overflowY } = window.getComputedStyle(el)
-            if (overflowY !== 'auto' && overflowY !== 'scroll') continue
-            if (!best || el.scrollHeight > best.scrollHeight) best = el
-          }
-          if (best) {
-            root = best
-            pageHeight = best.scrollHeight
-            viewport = best.clientHeight
-          }
-        }
-
-        let currentScrollPosition = 0
-        const scrollStep = Math.max(1, Math.floor(viewport * 0.8))
-        const totalSteps = Math.max(1, Math.ceil(pageHeight / scrollStep))
-        // Floor dwell so lazy sections actually fetch; if the budget can't
-        // cover every step at that pace, steps stretch to fit the budget.
-        const stepDelay = Math.max(400, Math.floor(scrollBudget / totalSteps))
-        const reset = () => {
-          window.scrollTo(0, 0)
-          if (root) root.scrollTop = 0
-          resolve()
-        }
-        const scrollNext = () => {
-          if (currentScrollPosition >= pageHeight) return reset()
-          if (root) root.scrollBy(0, scrollStep)
-          else window.scrollBy(0, scrollStep)
-          currentScrollPosition += scrollStep
-          setTimeout(scrollNext, stepDelay)
-        }
-        scrollNext()
-      }),
-    scrollBudget
-  )
-
-  if (postQuiet > 0) {
-    const result = await page.evaluate(waitForDomStability, {
-      idle: Math.min(300, postQuiet / 2),
-      timeout: postQuiet
-    })
-    duration('waitForDomStability:post', result)
-  }
-}
-
 const waitForElement = async (page, element) => {
   const screenshotOpts = {}
   if (element) {
@@ -153,6 +79,36 @@ const waitForElement = async (page, element) => {
     return screenshotOpts
   }
   return screenshotOpts
+}
+
+// Puppeteer screenshot options only — goto/readiness fields must not be
+// forwarded (and readiness probes must not write `--path`).
+const toScreenshotOpts = (opts, overrides = {}) => {
+  const {
+    path,
+    type,
+    quality,
+    omitBackground,
+    encoding,
+    captureBeyondViewport,
+    fromSurface,
+    optimizeForSpeed,
+    clip,
+    fullPage
+  } = opts
+  return {
+    path,
+    type,
+    quality,
+    omitBackground,
+    encoding,
+    captureBeyondViewport,
+    fromSurface,
+    optimizeForSpeed,
+    clip,
+    fullPage,
+    ...overrides
+  }
 }
 
 const SCREENSHOT_DEFAULT_OPTS = {
@@ -211,12 +167,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
           })
         }
 
-        if (fullPage) {
-          tasks.push({
-            fn: () => scrollFullPageToLoadContent(page, timeout, goto),
-            debug: 'beforeScreenshot:scrollFullPageToLoadContent'
-          })
-        } else if (element) {
+        if (element && !fullPage) {
           tasks.push({
             fn: async () => {
               screenshotOpts = await waitForElement(page, element)
@@ -230,7 +181,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
             goto.run({
               fn: fn(),
               ...opts,
-              timeout: fullPage ? timeout * 2 : timeout
+              timeout
             })
           )
         )
@@ -246,11 +197,13 @@ module.exports = ({ goto, ...gotoOpts }) => {
         let isReady = false
 
         do {
-          screenshot = await captureWithNavigationRetry(() => page.screenshot(opts), {
-            page,
-            goto,
-            timeout
-          })
+          screenshot = await captureWithNavigationRetry(
+            () =>
+              page.screenshot(
+                toScreenshotOpts(opts, opts.fullPage ? { fullPage: false, path: undefined } : {})
+              ),
+            { page, goto, timeout }
+          )
           isWhite = await isWhiteScreenshot(screenshot)
           const snapshotResult = await pReflect(getPageSnapshot(page))
           const pageSnapshot = snapshotResult.isRejected ? {} : snapshotResult.value
@@ -272,6 +225,21 @@ module.exports = ({ goto, ...gotoOpts }) => {
           await goto.waitUntilAuto(page, { timeout })
         } while (!isReady)
 
+        if (isReady && opts.fullPage) {
+          await prepareFullDocument(page, {
+            goto,
+            timeout: goto.timeouts.goto(opts.timeout)
+          })
+          screenshot = await captureWithNavigationRetry(
+            async () => {
+              await pReflect(page.evaluate(expandOverflow))
+              return page.screenshot(toScreenshotOpts(opts, { fullPage: true }))
+            },
+            { page, goto, timeout: goto.timeouts.goto(opts.timeout) }
+          )
+          isWhite = await isWhiteScreenshot(screenshot)
+        }
+
         return { isWhite, isReady, retry }
       }
 
@@ -284,8 +252,17 @@ module.exports = ({ goto, ...gotoOpts }) => {
         if (waitUntil !== 'auto') {
           ;({ response } = await goto(page, { ...opts, url, waitUntil }))
           const screenshotOpts = await beforeScreenshot(page, response, opts)
+          if (opts.fullPage) {
+            await prepareFullDocument(page, {
+              goto,
+              timeout: goto.timeouts.goto(opts.timeout)
+            })
+          }
           screenshot = await captureWithNavigationRetry(
-            () => page.screenshot({ ...opts, ...screenshotOpts }),
+            async () => {
+              if (opts.fullPage) await pReflect(page.evaluate(expandOverflow))
+              return page.screenshot(toScreenshotOpts({ ...opts, ...screenshotOpts }))
+            },
             { page, goto, timeout: goto.timeouts.action(opts.timeout) }
           )
           debug('screenshot', { waitUntil, duration: timeScreenshot() })
@@ -326,4 +303,7 @@ module.exports.resolveWaitForDom = resolveWaitForDom
 module.exports.waitForReady = waitForReady
 module.exports.paintSignals = paintSignals
 module.exports.scrollFullPageToLoadContent = scrollFullPageToLoadContent
+module.exports.waitForOverflowHeight = waitForOverflowHeight
+module.exports.expandOverflow = expandOverflow
+module.exports.prepareFullDocument = prepareFullDocument
 module.exports.SCREENSHOT_DEFAULT_OPTS = SCREENSHOT_DEFAULT_OPTS

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -9,7 +9,7 @@ const isWhiteScreenshot = require('./is-white-screenshot')
 const waitForPrism = require('./pretty')
 const prettyTimeSpan = require('./time-span')
 const overlay = require('./overlay')
-const { waitForDomStability, resolveWaitForDom, DEFAULT_WAIT_FOR_DOM } = require('./wait-for-dom')
+const { waitForDomStability } = require('./wait-for-dom')
 const { waitForReady, paintSignals } = require('./wait-for-ready')
 const {
   waitForOverflowHeight,
@@ -110,7 +110,6 @@ const SCREENSHOT_DEFAULT_OPTS = {
   codeScheme: 'atom-dark',
   overlay: {},
   waitUntil: 'auto',
-  waitForDom: DEFAULT_WAIT_FOR_DOM,
   isPageReady: defaultIsPageReady
 }
 
@@ -124,7 +123,6 @@ module.exports = ({ goto, ...gotoOpts }) => {
         codeScheme = SCREENSHOT_DEFAULT_OPTS.codeScheme,
         overlay: overlayOpts = SCREENSHOT_DEFAULT_OPTS.overlay,
         waitUntil = SCREENSHOT_DEFAULT_OPTS.waitUntil,
-        waitForDom = SCREENSHOT_DEFAULT_OPTS.waitForDom,
         isPageReady = SCREENSHOT_DEFAULT_OPTS.isPageReady,
         ...opts
       } = {}
@@ -134,7 +132,6 @@ module.exports = ({ goto, ...gotoOpts }) => {
 
       const beforeScreenshot = async (page, response, { element, fullPage = false } = {}) => {
         const timeout = goto.timeouts.action(opts.timeout)
-        const waitForDomOpts = resolveWaitForDom(waitForDom)
 
         let screenshotOpts = {}
         const tasks = [
@@ -147,13 +144,6 @@ module.exports = ({ goto, ...gotoOpts }) => {
             debug: 'beforeScreenshot:waitForImagesOnViewport'
           }
         ]
-
-        if (waitForDomOpts) {
-          tasks.push({
-            fn: () => page.evaluate(waitForDomStability, waitForDomOpts),
-            debug: 'beforeScreenshot:waitForDomStability'
-          })
-        }
 
         if (codeScheme && response) {
           tasks.push({
@@ -306,7 +296,6 @@ module.exports = ({ goto, ...gotoOpts }) => {
 module.exports.captureWithNavigationRetry = captureWithNavigationRetry
 module.exports.isWhiteScreenshot = isWhiteScreenshot
 module.exports.waitForDomStability = waitForDomStability
-module.exports.resolveWaitForDom = resolveWaitForDom
 module.exports.waitForReady = waitForReady
 module.exports.paintSignals = paintSignals
 module.exports.scrollFullPageToLoadContent = scrollFullPageToLoadContent

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -76,36 +76,6 @@ const waitForElement = async (page, element) => {
   return screenshotOpts
 }
 
-// Puppeteer screenshot options only — goto/readiness fields must not be
-// forwarded (and readiness probes must not write `--path`).
-const toScreenshotOpts = (opts, overrides = {}) => {
-  const {
-    path,
-    type,
-    quality,
-    omitBackground,
-    encoding,
-    captureBeyondViewport,
-    fromSurface,
-    optimizeForSpeed,
-    clip,
-    fullPage
-  } = opts
-  return {
-    path,
-    type,
-    quality,
-    omitBackground,
-    encoding,
-    captureBeyondViewport,
-    fromSurface,
-    optimizeForSpeed,
-    clip,
-    fullPage,
-    ...overrides
-  }
-}
-
 const SCREENSHOT_DEFAULT_OPTS = {
   codeScheme: 'atom-dark',
   overlay: {},
@@ -186,9 +156,10 @@ module.exports = ({ goto, ...gotoOpts }) => {
         do {
           screenshot = await captureWithNavigationRetry(
             () =>
-              page.screenshot(
-                toScreenshotOpts(opts, opts.fullPage ? { fullPage: false, path: undefined } : {})
-              ),
+              page.screenshot({
+                ...opts,
+                ...(opts.fullPage ? { fullPage: false, path: undefined } : {})
+              }),
             { page, goto, timeout }
           )
           isWhite = await isWhiteScreenshot(screenshot)
@@ -241,7 +212,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
           screenshot = await captureWithNavigationRetry(
             async () => {
               if (isReady) await pReflect(page.evaluate(expandOverflow))
-              return page.screenshot(toScreenshotOpts(opts, { fullPage: true }))
+              return page.screenshot({ ...opts, fullPage: true })
             },
             { page, goto, timeout: scrollTimeout }
           )
@@ -270,7 +241,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
           screenshot = await captureWithNavigationRetry(
             async () => {
               if (opts.fullPage) await pReflect(page.evaluate(expandOverflow))
-              return page.screenshot(toScreenshotOpts({ ...opts, ...screenshotOpts }))
+              return page.screenshot({ ...opts, ...screenshotOpts })
             },
             { page, goto, timeout: goto.timeouts.action(opts.timeout) }
           )

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -10,7 +10,7 @@ const waitForPrism = require('./pretty')
 const prettyTimeSpan = require('./time-span')
 const overlay = require('./overlay')
 const { waitForDomStability, resolveWaitForDom, DEFAULT_WAIT_FOR_DOM } = require('./wait-for-dom')
-const { waitForReady, snapshot } = require('./wait-for-ready')
+const { waitForReady, paintSignals } = require('./wait-for-ready')
 
 const timeSpan = require('@kikobeats/time-span')()
 
@@ -324,6 +324,6 @@ module.exports.isWhiteScreenshot = isWhiteScreenshot
 module.exports.waitForDomStability = waitForDomStability
 module.exports.resolveWaitForDom = resolveWaitForDom
 module.exports.waitForReady = waitForReady
-module.exports.snapshot = snapshot
+module.exports.paintSignals = paintSignals
 module.exports.scrollFullPageToLoadContent = scrollFullPageToLoadContent
 module.exports.SCREENSHOT_DEFAULT_OPTS = SCREENSHOT_DEFAULT_OPTS

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -195,6 +195,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
         let retry = 0
         let isWhite = false
         let isReady = false
+        let hydrated = false
 
         do {
           screenshot = await captureWithNavigationRetry(
@@ -220,6 +221,15 @@ module.exports = ({ goto, ...gotoOpts }) => {
           isReady = !pageReadyResult.isRejected && !!pageReadyResult.value
 
           if (isReady || elapsed() >= timeout) break
+
+          // Full-page captures: one mid-poll scroll so lazy/overflow content can
+          // paint before readiness gives up (bot/white pages stay unscrolled).
+          const remaining = timeout - elapsed()
+          if (opts.fullPage && !hydrated && !isWhite && remaining > 1000) {
+            hydrated = true
+            await pReflect(scrollFullPageToLoadContent(page, Math.min(remaining / 2, 8000)))
+            debug('screenshot:hydrateScroll', { remaining })
+          }
 
           retry += 1
           await goto.waitUntilAuto(page, { timeout })

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -181,6 +181,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
         let isWhite = false
         let isReady = false
         let didHydrateScroll = false
+        let didHydrateAttempt = false
 
         do {
           screenshot = await captureWithNavigationRetry(
@@ -208,10 +209,17 @@ module.exports = ({ goto, ...gotoOpts }) => {
           if (isReady || elapsed() >= timeout) break
 
           const remaining = timeout - elapsed()
-          if (opts.fullPage && !didHydrateScroll && !isWhite && remaining > 1000) {
-            didHydrateScroll = true
-            await pReflect(scrollFullPageToLoadContent(page, Math.min(remaining / 2, 8000)))
-            debug('screenshot:hydrateScroll', { remaining })
+          if (opts.fullPage && !didHydrateAttempt && !isWhite && remaining > 1000) {
+            didHydrateAttempt = true
+            const hydrate = await pReflect(
+              scrollFullPageToLoadContent(page, Math.min(remaining / 2, 5000))
+            )
+            didHydrateScroll = !hydrate.isRejected && !!hydrate.value?.hydrated
+            debug('screenshot:hydrateScroll', {
+              remaining,
+              hydrated: didHydrateScroll,
+              ...(hydrate.isRejected ? {} : hydrate.value)
+            })
           }
 
           retry += 1
@@ -224,7 +232,11 @@ module.exports = ({ goto, ...gotoOpts }) => {
               ? goto.timeouts.goto(opts.timeout)
               : goto.timeouts.action(opts.timeout)
           if (isReady) {
-            await prepareFullDocument(page, { goto, timeout: scrollTimeout })
+            await prepareFullDocument(page, {
+              goto,
+              timeout: scrollTimeout,
+              scrolled: didHydrateScroll
+            })
           }
           screenshot = await captureWithNavigationRetry(
             async () => {

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -96,7 +96,7 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
         let viewport = window.innerHeight
 
         // Document isn't scrollable: prefer the tallest overflow scroller
-        // (e.g. `.report-canvas-scroll`) so below-fold slides still hydrate.
+        // so below-fold lazy sections still hydrate.
         if (pageHeight <= viewport + 1 && document.body) {
           let best = null
           for (const el of document.body.querySelectorAll('*')) {

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -226,16 +226,17 @@ module.exports = ({ goto, ...gotoOpts }) => {
         } while (!isReady)
 
         if (isReady && opts.fullPage) {
-          await prepareFullDocument(page, {
-            goto,
-            timeout: goto.timeouts.goto(opts.timeout)
-          })
+          const scrollTimeout =
+            typeof goto.timeouts.goto === 'function'
+              ? goto.timeouts.goto(opts.timeout)
+              : goto.timeouts.action(opts.timeout)
+          await prepareFullDocument(page, { goto, timeout: scrollTimeout })
           screenshot = await captureWithNavigationRetry(
             async () => {
               await pReflect(page.evaluate(expandOverflow))
               return page.screenshot(toScreenshotOpts(opts, { fullPage: true }))
             },
-            { page, goto, timeout: goto.timeouts.goto(opts.timeout) }
+            { page, goto, timeout: scrollTimeout }
           )
           isWhite = await isWhiteScreenshot(screenshot)
         }
@@ -253,10 +254,11 @@ module.exports = ({ goto, ...gotoOpts }) => {
           ;({ response } = await goto(page, { ...opts, url, waitUntil }))
           const screenshotOpts = await beforeScreenshot(page, response, opts)
           if (opts.fullPage) {
-            await prepareFullDocument(page, {
-              goto,
-              timeout: goto.timeouts.goto(opts.timeout)
-            })
+            const scrollTimeout =
+              typeof goto.timeouts.goto === 'function'
+                ? goto.timeouts.goto(opts.timeout)
+                : goto.timeouts.action(opts.timeout)
+            await prepareFullDocument(page, { goto, timeout: scrollTimeout })
           }
           screenshot = await captureWithNavigationRetry(
             async () => {

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -113,6 +113,15 @@ module.exports = ({ goto, ...gotoOpts }) => {
       let screenshot
       let response
 
+      const captureExpanded = (expand, screenshotOpts, timeout) =>
+        captureWithNavigationRetry(
+          async () => {
+            if (expand) await pReflect(expandOverflow(page))
+            return page.screenshot(screenshotOpts)
+          },
+          { page, goto, timeout }
+        )
+
       const beforeScreenshot = async (page, response, { element, fullPage = false } = {}) => {
         const timeout = goto.timeouts.action(opts.timeout)
 
@@ -186,7 +195,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
           if (isReady || elapsed() >= timeout) break
 
           const remaining = timeout - elapsed()
-          if (opts.fullPage && !didHydrateAttempt && !isWhite && remaining > 1000) {
+          if (opts.fullPage && !didHydrateAttempt && !isWhite) {
             didHydrateAttempt = true
             const { hydrated, info } = await tryHydrateScroll(page, remaining)
             didHydrateScroll = hydrated
@@ -205,12 +214,10 @@ module.exports = ({ goto, ...gotoOpts }) => {
               scrolled: didHydrateScroll
             })
           }
-          screenshot = await captureWithNavigationRetry(
-            async () => {
-              if (isReady) await pReflect(expandOverflow(page))
-              return page.screenshot({ ...opts, fullPage: true })
-            },
-            { page, goto, timeout: resolveScrollTimeout(goto, opts.timeout) }
+          screenshot = await captureExpanded(
+            isReady,
+            { ...opts, fullPage: true },
+            resolveScrollTimeout(goto, opts.timeout)
           )
           isWhite = await isWhiteScreenshot(screenshot)
         }
@@ -230,12 +237,10 @@ module.exports = ({ goto, ...gotoOpts }) => {
           if (opts.fullPage) {
             await prepareFullDocument(page, { goto, timeout: opts.timeout })
           }
-          screenshot = await captureWithNavigationRetry(
-            async () => {
-              if (opts.fullPage) await pReflect(expandOverflow(page))
-              return page.screenshot({ ...opts, ...screenshotOpts })
-            },
-            { page, goto, timeout: goto.timeouts.action(opts.timeout) }
+          screenshot = await captureExpanded(
+            opts.fullPage,
+            { ...opts, ...screenshotOpts },
+            goto.timeouts.action(opts.timeout)
           )
           debug('screenshot', { waitUntil, duration: timeScreenshot() })
         } else {

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -277,5 +277,7 @@ module.exports.scrollFullPageToLoadContent = scrollFullPageToLoadContent
 module.exports.expandOverflow = expandOverflow
 module.exports.getPageMeta = getPageMeta
 module.exports.checkPageReady = checkPageReady
+module.exports.tryHydrateScroll = tryHydrateScroll
+module.exports.resolveScrollTimeout = resolveScrollTimeout
 module.exports.prepareFullDocument = prepareFullDocument
 module.exports.SCREENSHOT_DEFAULT_OPTS = SCREENSHOT_DEFAULT_OPTS

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -207,7 +207,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
           }
           screenshot = await captureWithNavigationRetry(
             async () => {
-              if (isReady) await pReflect(page.evaluate(expandOverflow))
+              if (isReady) await pReflect(expandOverflow(page))
               return page.screenshot({ ...opts, fullPage: true })
             },
             { page, goto, timeout: resolveScrollTimeout(goto, opts.timeout) }
@@ -232,7 +232,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
           }
           screenshot = await captureWithNavigationRetry(
             async () => {
-              if (opts.fullPage) await pReflect(page.evaluate(expandOverflow))
+              if (opts.fullPage) await pReflect(expandOverflow(page))
               return page.screenshot({ ...opts, ...screenshotOpts })
             },
             { page, goto, timeout: goto.timeouts.action(opts.timeout) }

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -12,10 +12,11 @@ const overlay = require('./overlay')
 const { waitForDomStability } = require('./wait-for-dom')
 const { waitForReady, paintSignals } = require('./wait-for-ready')
 const {
-  waitForOverflowHeight,
   expandOverflow,
   scrollFullPageToLoadContent,
-  prepareFullDocument
+  prepareFullDocument,
+  resolveScrollTimeout,
+  tryHydrateScroll
 } = require('./prepare-full-document')
 
 const timeSpan = require('@kikobeats/time-span')()
@@ -41,6 +42,18 @@ const getPageMeta = page =>
   }))
 
 const defaultIsPageReady = ({ isWhite }) => !isWhite
+
+const checkPageReady = async (page, { isPageReady, response, screenshot, isWhite } = {}) => {
+  let pageMeta = {}
+  if (isPageReady !== defaultIsPageReady) {
+    const pageMetaResult = await pReflect(getPageMeta(page))
+    pageMeta = pageMetaResult.isRejected ? {} : pageMetaResult.value
+  }
+  const pageReadyResult = await pReflect(
+    isPageReady({ page, response, screenshot, isWhite, isWhiteScreenshot, ...pageMeta })
+  )
+  return !pageReadyResult.isRejected && !!pageReadyResult.value
+}
 
 const getBoundingClientRect = element => {
   const { top, left, height, width, x, y } = element.getBoundingClientRect()
@@ -163,34 +176,21 @@ module.exports = ({ goto, ...gotoOpts }) => {
             { page, goto, timeout }
           )
           isWhite = await isWhiteScreenshot(screenshot)
-          const pageMetaResult = await pReflect(getPageMeta(page))
-          const pageMeta = pageMetaResult.isRejected ? {} : pageMetaResult.value
-          const pageReadyResult = await pReflect(
-            opts.isPageReady({
-              page,
-              response: opts.response,
-              screenshot,
-              isWhite,
-              isWhiteScreenshot,
-              ...pageMeta
-            })
-          )
-          isReady = !pageReadyResult.isRejected && !!pageReadyResult.value
+          isReady = await checkPageReady(page, {
+            isPageReady: opts.isPageReady,
+            response: opts.response,
+            screenshot,
+            isWhite
+          })
 
           if (isReady || elapsed() >= timeout) break
 
           const remaining = timeout - elapsed()
           if (opts.fullPage && !didHydrateAttempt && !isWhite && remaining > 1000) {
             didHydrateAttempt = true
-            const hydrate = await pReflect(
-              scrollFullPageToLoadContent(page, Math.min(remaining / 2, 5000))
-            )
-            didHydrateScroll = !hydrate.isRejected && !!hydrate.value?.hydrated
-            debug('screenshot:hydrateScroll', {
-              remaining,
-              hydrated: didHydrateScroll,
-              ...(hydrate.isRejected ? {} : hydrate.value)
-            })
+            const { hydrated, info } = await tryHydrateScroll(page, remaining)
+            didHydrateScroll = hydrated
+            debug('screenshot:hydrateScroll', { remaining, hydrated, ...info })
           }
 
           retry += 1
@@ -198,14 +198,10 @@ module.exports = ({ goto, ...gotoOpts }) => {
         } while (!isReady)
 
         if (opts.fullPage) {
-          const scrollTimeout =
-            typeof goto.timeouts.goto === 'function'
-              ? goto.timeouts.goto(opts.timeout)
-              : goto.timeouts.action(opts.timeout)
           if (isReady) {
             await prepareFullDocument(page, {
               goto,
-              timeout: scrollTimeout,
+              timeout: opts.timeout,
               scrolled: didHydrateScroll
             })
           }
@@ -214,7 +210,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
               if (isReady) await pReflect(page.evaluate(expandOverflow))
               return page.screenshot({ ...opts, fullPage: true })
             },
-            { page, goto, timeout: scrollTimeout }
+            { page, goto, timeout: resolveScrollTimeout(goto, opts.timeout) }
           )
           isWhite = await isWhiteScreenshot(screenshot)
         }
@@ -232,11 +228,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
           ;({ response } = await goto(page, { ...opts, url, waitUntil }))
           const screenshotOpts = await beforeScreenshot(page, response, opts)
           if (opts.fullPage) {
-            const scrollTimeout =
-              typeof goto.timeouts.goto === 'function'
-                ? goto.timeouts.goto(opts.timeout)
-                : goto.timeouts.action(opts.timeout)
-            await prepareFullDocument(page, { goto, timeout: scrollTimeout })
+            await prepareFullDocument(page, { goto, timeout: opts.timeout })
           }
           screenshot = await captureWithNavigationRetry(
             async () => {
@@ -282,7 +274,8 @@ module.exports.waitForDomStability = waitForDomStability
 module.exports.waitForReady = waitForReady
 module.exports.paintSignals = paintSignals
 module.exports.scrollFullPageToLoadContent = scrollFullPageToLoadContent
-module.exports.waitForOverflowHeight = waitForOverflowHeight
 module.exports.expandOverflow = expandOverflow
+module.exports.getPageMeta = getPageMeta
+module.exports.checkPageReady = checkPageReady
 module.exports.prepareFullDocument = prepareFullDocument
 module.exports.SCREENSHOT_DEFAULT_OPTS = SCREENSHOT_DEFAULT_OPTS

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -5,18 +5,9 @@ const pReflect = require('p-reflect')
 
 const { waitForDomStability } = require('./wait-for-dom')
 
-// Per-step dwell for intersection-observer / lazy fetches. Kept as a fixed
-// cap — scaling delay with the request budget made tall pages crawl (e.g.
-// 20 steps × multi-second delays) without improving hydrate rate.
 const SCROLL_STEP_MS = 250
-
-// Same floor for “is this an app-shell scroller?” across wait / scroll / expand
-// so hydration and unwrap target the same overflow root.
 const OVERFLOW_MIN_PX = 200
 
-// Wait until the tallest overflow scroller's height stops growing. App shells
-// often mount lazy sections after chrome paints; scrolling before that walks a
-// short scroller and never triggers below-fold fetches.
 const waitForOverflowHeight = (page, timeout = 3000) =>
   page.evaluate(
     (timeout, minPx) =>
@@ -52,10 +43,6 @@ const waitForOverflowHeight = (page, timeout = 3000) =>
     OVERFLOW_MIN_PX
   )
 
-// App shells often keep content in an overflow scroller (`doc` ≈ viewport).
-// `fullPage` screenshots and `page.pdf()` only see the document flow, so unwrap
-// the tallest overflow root when it is taller than the viewport.
-// `minPx` default is a literal so `page.evaluate(expandOverflow)` serializes cleanly.
 const expandOverflow = (minPx = 200) => {
   const scroll = [...document.querySelectorAll('*')]
     .filter(el => {
@@ -85,8 +72,6 @@ const expandOverflow = (minPx = 200) => {
   return true
 }
 
-// Walk the page (window, or the tallest overflow scroller when the document
-// itself isn't tall) so lazy sections and intersection-observer fetches run.
 const scrollFullPageToLoadContent = async (page, timeout) => {
   const duration = debug.duration()
   const preQuiet = Math.min(300, Math.floor(timeout / 10))
@@ -157,8 +142,6 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
   }
 }
 
-// Shared by fullPage screenshot and PDF: after the page is ready, hydrate
-// overflow content and unwrap it so capture sees the full document flow.
 const resolveScrollTimeout = (goto, timeout) => {
   if (timeout != null) return timeout
   if (typeof goto?.timeouts?.goto === 'function') return goto.timeouts.goto()
@@ -181,8 +164,6 @@ const prepareFullDocument = async (page, { goto, timeout } = {}) => {
   await scrollFullPageToLoadContent(page, scrollTimeout)
   debug('prepareFullDocument:scroll', { duration: elapsed() })
 
-  // Brief network settle for fetches the scroll triggered — keep this off
-  // `goto.waitUntilAuto` so readiness-retry mocks stay countable.
   const settleMs = Math.min(1500, Math.max(0, scrollTimeout - elapsed()))
   if (settleMs > 0 && typeof page.waitForNetworkIdle === 'function') {
     await pReflect(page.waitForNetworkIdle({ idleTime: 300, concurrency: 2, timeout: settleMs }))

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -1,0 +1,191 @@
+'use strict'
+
+const debug = require('debug-logfmt')('browserless:screenshot')
+const pReflect = require('p-reflect')
+
+const { waitForDomStability } = require('./wait-for-dom')
+
+// Per-step dwell for intersection-observer / lazy fetches. Kept as a fixed
+// cap — scaling delay with the request budget made tall pages crawl (e.g.
+// 20 steps × multi-second delays) without improving hydrate rate.
+const SCROLL_STEP_MS = 250
+
+// Wait until the tallest overflow scroller's height stops growing. App shells
+// often mount lazy sections after chrome paints; scrolling before that walks a
+// short scroller and never triggers below-fold fetches.
+const waitForOverflowHeight = (page, timeout = 3000) =>
+  page.evaluate(
+    timeout =>
+      new Promise(resolve => {
+        const started = Date.now()
+        let last = 0
+        let stable = 0
+        const tick = () => {
+          const scroll = [...document.querySelectorAll('*')]
+            .filter(el => {
+              const s = window.getComputedStyle(el)
+              return (
+                (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
+                el.scrollHeight > el.clientHeight + 200
+              )
+            })
+            .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
+          const height = scroll
+            ? scroll.scrollHeight
+            : (document.scrollingElement || document.documentElement).scrollHeight
+          if (height === last && height > window.innerHeight + 200) {
+            if (++stable >= 2) return resolve(height)
+          } else {
+            stable = 0
+            last = height
+          }
+          if (Date.now() - started >= timeout) return resolve(height)
+          setTimeout(tick, 200)
+        }
+        tick()
+      }),
+    timeout
+  )
+
+// App shells often keep content in an overflow scroller (`doc` ≈ viewport).
+// `fullPage` screenshots and `page.pdf()` only see the document flow, so unwrap
+// the tallest overflow root when it is taller than the viewport.
+const expandOverflow = () => {
+  const scroll = [...document.querySelectorAll('*')]
+    .filter(el => {
+      const s = window.getComputedStyle(el)
+      return (
+        (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
+        el.scrollHeight > el.clientHeight + 200
+      )
+    })
+    .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
+
+  if (!scroll) return false
+
+  let el = scroll
+  while (el) {
+    const pos = window.getComputedStyle(el).position
+    el.style.setProperty('overflow', 'visible', 'important')
+    el.style.setProperty('height', 'auto', 'important')
+    el.style.setProperty('max-height', 'none', 'important')
+    if (pos === 'absolute' || pos === 'fixed') {
+      el.style.setProperty('position', 'relative', 'important')
+      el.style.setProperty('inset', 'auto', 'important')
+    }
+    if (el === document.documentElement) break
+    el = el.parentElement
+  }
+  return true
+}
+
+// Walk the page (window, or the tallest overflow scroller when the document
+// itself isn't tall) so lazy sections and intersection-observer fetches run.
+const scrollFullPageToLoadContent = async (page, timeout) => {
+  const duration = debug.duration()
+  const preQuiet = Math.min(300, Math.floor(timeout / 10))
+  const postQuiet = Math.min(800, Math.floor(timeout / 6))
+  const scrollBudget = Math.max(0, timeout - preQuiet - postQuiet)
+
+  if (preQuiet > 0) {
+    const result = await page.evaluate(waitForDomStability, {
+      idle: preQuiet / 2,
+      timeout: preQuiet
+    })
+    duration('waitForDomStability:pre', result)
+  }
+
+  await page.evaluate(
+    (scrollBudget, stepMs) =>
+      new Promise(resolve => {
+        const doc = document.scrollingElement || document.documentElement
+        let root = null
+        let pageHeight = doc ? doc.scrollHeight : 0
+        let viewport = window.innerHeight
+
+        if (pageHeight <= viewport + 1 && document.body) {
+          let best = null
+          for (const el of document.body.querySelectorAll('*')) {
+            if (el.scrollHeight <= el.clientHeight + 20) continue
+            const { overflowY } = window.getComputedStyle(el)
+            if (overflowY !== 'auto' && overflowY !== 'scroll') continue
+            if (!best || el.scrollHeight > best.scrollHeight) best = el
+          }
+          if (best) {
+            root = best
+            pageHeight = best.scrollHeight
+            viewport = best.clientHeight
+          }
+        }
+
+        const started = Date.now()
+        let currentScrollPosition = 0
+        const scrollStep = Math.max(1, Math.floor(viewport * 0.85))
+        const reset = () => {
+          window.scrollTo(0, 0)
+          if (root) root.scrollTop = 0
+          resolve()
+        }
+        const scrollNext = () => {
+          if (currentScrollPosition >= pageHeight || Date.now() - started >= scrollBudget) {
+            return reset()
+          }
+          if (root) root.scrollBy(0, scrollStep)
+          else window.scrollBy(0, scrollStep)
+          currentScrollPosition += scrollStep
+          setTimeout(scrollNext, stepMs)
+        }
+        scrollNext()
+      }),
+    scrollBudget,
+    SCROLL_STEP_MS
+  )
+
+  if (postQuiet > 0) {
+    const result = await page.evaluate(waitForDomStability, {
+      idle: Math.min(200, postQuiet / 2),
+      timeout: postQuiet
+    })
+    duration('waitForDomStability:post', result)
+  }
+}
+
+// Shared by fullPage screenshot and PDF: after the page is ready, hydrate
+// overflow content and unwrap it so capture sees the full document flow.
+const prepareFullDocument = async (page, { goto, timeout } = {}) => {
+  const scrollTimeout = timeout ?? (goto && goto.timeouts.goto())
+  const elapsed = require('@kikobeats/time-span')({ format: n => Math.round(n) })()
+
+  const height = await pReflect(
+    waitForOverflowHeight(page, Math.min(3000, Math.round(scrollTimeout / 5)))
+  )
+  debug('prepareFullDocument:overflowHeight', {
+    height: height.isRejected ? null : height.value,
+    duration: elapsed()
+  })
+
+  await scrollFullPageToLoadContent(page, scrollTimeout)
+  debug('prepareFullDocument:scroll', { duration: elapsed() })
+
+  if (goto) {
+    await goto.waitUntilAuto(page, {
+      timeout: Math.min(2000, Math.max(0, scrollTimeout - elapsed()))
+    })
+  }
+
+  const expanded = await pReflect(page.evaluate(expandOverflow))
+  debug('prepareFullDocument:expandOverflow', {
+    expanded: !expanded.isRejected && expanded.value,
+    duration: elapsed()
+  })
+
+  return { expanded: !expanded.isRejected && expanded.value, duration: elapsed() }
+}
+
+module.exports = {
+  waitForOverflowHeight,
+  expandOverflow,
+  scrollFullPageToLoadContent,
+  prepareFullDocument,
+  SCROLL_STEP_MS
+}

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -5,10 +5,14 @@ const pReflect = require('p-reflect')
 
 const { waitForDomStability } = require('./wait-for-dom')
 
-const SCROLL_STEP_MS = 250
+const SCROLL_STEP_MS = 50
 const OVERFLOW_MIN_PX = 200
+const OVERFLOW_WAIT_MS = 1500
+const PRE_QUIET_MS = 50
+const POST_QUIET_MS = 200
+const SETTLE_MS = 400
 
-const waitForOverflowHeight = (page, timeout = 3000) =>
+const waitForOverflowHeight = (page, timeout = OVERFLOW_WAIT_MS) =>
   page.evaluate(
     (timeout, minPx) =>
       new Promise(resolve => {
@@ -28,14 +32,16 @@ const waitForOverflowHeight = (page, timeout = 3000) =>
           const height = scroll
             ? scroll.scrollHeight
             : (document.scrollingElement || document.documentElement).scrollHeight
-          if (height === last && height > window.innerHeight + minPx) {
+          const tall = height > window.innerHeight + minPx
+          if (height === last && tall) {
             if (++stable >= 2) return resolve(height)
           } else {
             stable = 0
             last = height
           }
           if (Date.now() - started >= timeout) return resolve(height)
-          setTimeout(tick, 200)
+          // Shell pages grow late — poll a bit slower until content appears.
+          setTimeout(tick, tall ? 100 : 150)
         }
         tick()
       }),
@@ -73,28 +79,24 @@ const expandOverflow = (minPx = 200) => {
 }
 
 const scrollFullPageToLoadContent = async (page, timeout) => {
-  const duration = debug.duration()
-  const preQuiet = Math.min(300, Math.floor(timeout / 10))
-  const postQuiet = Math.min(800, Math.floor(timeout / 6))
+  const preQuiet = Math.min(PRE_QUIET_MS, Math.floor(timeout / 20))
+  const postQuiet = Math.min(POST_QUIET_MS, Math.floor(timeout / 20))
   const scrollBudget = Math.max(0, timeout - preQuiet - postQuiet)
+  const started = Date.now()
 
   if (preQuiet > 0) {
     const result = await page.evaluate(waitForDomStability, {
       idle: preQuiet / 2,
       timeout: preQuiet
     })
-    duration('waitForDomStability:pre', result)
+    debug('waitForDomStability:pre', { ...result, duration: Date.now() - started })
   }
 
-  await page.evaluate(
+  const scroll = await page.evaluate(
     (scrollBudget, stepMs, minPx) =>
       new Promise(resolve => {
-        const doc = document.scrollingElement || document.documentElement
-        let root = null
-        let pageHeight = doc ? doc.scrollHeight : 0
-        let viewport = window.innerHeight
-
-        if (pageHeight <= viewport + 1 && document.body) {
+        const findOverflow = () => {
+          if (!document.body) return null
           let best = null
           for (const el of document.body.querySelectorAll('*')) {
             if (el.scrollHeight <= el.clientHeight + minPx) continue
@@ -102,29 +104,66 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
             if (overflowY !== 'auto' && overflowY !== 'scroll') continue
             if (!best || el.scrollHeight > best.scrollHeight) best = el
           }
-          if (best) {
-            root = best
-            pageHeight = best.scrollHeight
-            viewport = best.clientHeight
+          return best
+        }
+
+        const doc = () => document.scrollingElement || document.documentElement
+        let root = null
+        let pageHeight = doc() ? doc().scrollHeight : 0
+        let viewport = window.innerHeight
+        let currentScrollPosition = 0
+        const scrollStarted = Date.now()
+
+        const measure = () => {
+          if (!root) {
+            const overflow = findOverflow()
+            if (overflow) root = overflow
+          }
+          if (root) {
+            pageHeight = root.scrollHeight
+            viewport = root.clientHeight || window.innerHeight
+          } else {
+            const el = doc()
+            pageHeight = el ? el.scrollHeight : 0
+            viewport = window.innerHeight
           }
         }
 
-        const started = Date.now()
-        let currentScrollPosition = 0
-        const scrollStep = Math.max(1, Math.floor(viewport * 0.85))
-        const reset = () => {
+        const finish = () => {
           window.scrollTo(0, 0)
           if (root) root.scrollTop = 0
-          resolve()
+          resolve({
+            hasOverflow: !!root,
+            pageHeight,
+            viewport,
+            scrolledPx: currentScrollPosition,
+            duration: Date.now() - scrollStarted
+          })
         }
+
         const scrollNext = () => {
-          if (currentScrollPosition >= pageHeight || Date.now() - started >= scrollBudget) {
-            return reset()
+          measure()
+          const step = Math.max(1, Math.floor(viewport * 0.95))
+          if (currentScrollPosition >= pageHeight || Date.now() - scrollStarted >= scrollBudget) {
+            return finish()
           }
-          if (root) root.scrollBy(0, scrollStep)
-          else window.scrollBy(0, scrollStep)
-          currentScrollPosition += scrollStep
+          if (root) root.scrollBy(0, step)
+          else window.scrollBy(0, step)
+          currentScrollPosition += step
           setTimeout(scrollNext, stepMs)
+        }
+
+        measure()
+        // Viewport-sized shell with no overflow yet: brief wait for the SPA
+        // scroller before falling through to window scroll / budget exit.
+        if (pageHeight <= viewport + 1 && !root) {
+          const waitUntil = scrollStarted + Math.min(1000, Math.floor(scrollBudget / 4))
+          const waitForRoot = () => {
+            measure()
+            if (root || Date.now() >= waitUntil) return scrollNext()
+            setTimeout(waitForRoot, stepMs)
+          }
+          return waitForRoot()
         }
         scrollNext()
       }),
@@ -132,14 +171,19 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
     SCROLL_STEP_MS,
     OVERFLOW_MIN_PX
   )
+  debug('scrollFullPage', { ...scroll, duration: Date.now() - started })
 
   if (postQuiet > 0) {
+    const postStarted = Date.now()
     const result = await page.evaluate(waitForDomStability, {
-      idle: Math.min(200, postQuiet / 2),
+      idle: Math.min(100, postQuiet / 2),
       timeout: postQuiet
     })
-    duration('waitForDomStability:post', result)
+    debug('waitForDomStability:post', { ...result, duration: Date.now() - postStarted })
   }
+
+  const hydrated = !!(scroll?.hasOverflow && scroll.scrolledPx >= (scroll.viewport || 0))
+  return { ...scroll, hydrated, duration: Date.now() - started }
 }
 
 const resolveScrollTimeout = (goto, timeout) => {
@@ -149,24 +193,28 @@ const resolveScrollTimeout = (goto, timeout) => {
   return 15000
 }
 
-const prepareFullDocument = async (page, { goto, timeout } = {}) => {
+const prepareFullDocument = async (page, { goto, timeout, scrolled = false } = {}) => {
   const scrollTimeout = resolveScrollTimeout(goto, timeout)
   const elapsed = require('@kikobeats/time-span')({ format: n => Math.round(n) })()
 
-  const height = await pReflect(
-    waitForOverflowHeight(page, Math.min(3000, Math.round(scrollTimeout / 5)))
-  )
-  debug('prepareFullDocument:overflowHeight', {
-    height: height.isRejected ? null : height.value,
-    duration: elapsed()
-  })
+  if (!scrolled) {
+    const height = await pReflect(
+      waitForOverflowHeight(page, Math.min(OVERFLOW_WAIT_MS, Math.round(scrollTimeout / 8)))
+    )
+    debug('prepareFullDocument:overflowHeight', {
+      height: height.isRejected ? null : height.value,
+      duration: elapsed()
+    })
 
-  await scrollFullPageToLoadContent(page, scrollTimeout)
-  debug('prepareFullDocument:scroll', { duration: elapsed() })
+    await scrollFullPageToLoadContent(page, scrollTimeout)
+    debug('prepareFullDocument:scroll', { duration: elapsed() })
+  } else {
+    debug('prepareFullDocument:skipScroll', { duration: elapsed() })
+  }
 
-  const settleMs = Math.min(1500, Math.max(0, scrollTimeout - elapsed()))
+  const settleMs = Math.min(SETTLE_MS, Math.max(0, scrollTimeout - elapsed()))
   if (settleMs > 0 && typeof page.waitForNetworkIdle === 'function') {
-    await pReflect(page.waitForNetworkIdle({ idleTime: 300, concurrency: 2, timeout: settleMs }))
+    await pReflect(page.waitForNetworkIdle({ idleTime: 200, concurrency: 2, timeout: settleMs }))
   }
 
   const expanded = await pReflect(page.evaluate(expandOverflow, OVERFLOW_MIN_PX))
@@ -175,7 +223,7 @@ const prepareFullDocument = async (page, { goto, timeout } = {}) => {
     duration: elapsed()
   })
 
-  return { expanded: !expanded.isRejected && expanded.value, duration: elapsed() }
+  return { expanded: !expanded.isRejected && expanded.value, duration: elapsed(), scrolled }
 }
 
 module.exports = {

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -152,8 +152,15 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
 
 // Shared by fullPage screenshot and PDF: after the page is ready, hydrate
 // overflow content and unwrap it so capture sees the full document flow.
+const resolveScrollTimeout = (goto, timeout) => {
+  if (timeout != null) return timeout
+  if (typeof goto?.timeouts?.goto === 'function') return goto.timeouts.goto()
+  if (typeof goto?.timeouts?.action === 'function') return goto.timeouts.action()
+  return 15000
+}
+
 const prepareFullDocument = async (page, { goto, timeout } = {}) => {
-  const scrollTimeout = timeout ?? (goto && goto.timeouts.goto())
+  const scrollTimeout = resolveScrollTimeout(goto, timeout)
   const elapsed = require('@kikobeats/time-span')({ format: n => Math.round(n) })()
 
   const height = await pReflect(
@@ -167,10 +174,13 @@ const prepareFullDocument = async (page, { goto, timeout } = {}) => {
   await scrollFullPageToLoadContent(page, scrollTimeout)
   debug('prepareFullDocument:scroll', { duration: elapsed() })
 
-  if (goto) {
-    await goto.waitUntilAuto(page, {
-      timeout: Math.min(2000, Math.max(0, scrollTimeout - elapsed()))
-    })
+  // Brief network settle for fetches the scroll triggered — keep this off
+  // `goto.waitUntilAuto` so readiness-retry mocks stay countable.
+  const settleMs = Math.min(1500, Math.max(0, scrollTimeout - elapsed()))
+  if (settleMs > 0 && typeof page.waitForNetworkIdle === 'function') {
+    await pReflect(
+      require('p-timeout')(page.waitForNetworkIdle({ idleTime: 300, concurrency: 2 }), settleMs)
+    )
   }
 
   const expanded = await pReflect(page.evaluate(expandOverflow))

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -178,9 +178,7 @@ const prepareFullDocument = async (page, { goto, timeout } = {}) => {
   // `goto.waitUntilAuto` so readiness-retry mocks stay countable.
   const settleMs = Math.min(1500, Math.max(0, scrollTimeout - elapsed()))
   if (settleMs > 0 && typeof page.waitForNetworkIdle === 'function') {
-    await pReflect(
-      require('p-timeout')(page.waitForNetworkIdle({ idleTime: 300, concurrency: 2 }), settleMs)
-    )
+    await pReflect(page.waitForNetworkIdle({ idleTime: 300, concurrency: 2, timeout: settleMs }))
   }
 
   const expanded = await pReflect(page.evaluate(expandOverflow))

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const debug = require('debug-logfmt')('browserless:screenshot')
+const debug = require('debug-logfmt')('browserless:prepare')
 const pReflect = require('p-reflect')
 
 const { waitForDomStability } = require('./wait-for-dom')

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -10,12 +10,16 @@ const { waitForDomStability } = require('./wait-for-dom')
 // 20 steps × multi-second delays) without improving hydrate rate.
 const SCROLL_STEP_MS = 250
 
+// Same floor for “is this an app-shell scroller?” across wait / scroll / expand
+// so hydration and unwrap target the same overflow root.
+const OVERFLOW_MIN_PX = 200
+
 // Wait until the tallest overflow scroller's height stops growing. App shells
 // often mount lazy sections after chrome paints; scrolling before that walks a
 // short scroller and never triggers below-fold fetches.
 const waitForOverflowHeight = (page, timeout = 3000) =>
   page.evaluate(
-    timeout =>
+    (timeout, minPx) =>
       new Promise(resolve => {
         const started = Date.now()
         let last = 0
@@ -26,14 +30,14 @@ const waitForOverflowHeight = (page, timeout = 3000) =>
               const s = window.getComputedStyle(el)
               return (
                 (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
-                el.scrollHeight > el.clientHeight + 200
+                el.scrollHeight > el.clientHeight + minPx
               )
             })
             .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
           const height = scroll
             ? scroll.scrollHeight
             : (document.scrollingElement || document.documentElement).scrollHeight
-          if (height === last && height > window.innerHeight + 200) {
+          if (height === last && height > window.innerHeight + minPx) {
             if (++stable >= 2) return resolve(height)
           } else {
             stable = 0
@@ -44,19 +48,21 @@ const waitForOverflowHeight = (page, timeout = 3000) =>
         }
         tick()
       }),
-    timeout
+    timeout,
+    OVERFLOW_MIN_PX
   )
 
 // App shells often keep content in an overflow scroller (`doc` ≈ viewport).
 // `fullPage` screenshots and `page.pdf()` only see the document flow, so unwrap
 // the tallest overflow root when it is taller than the viewport.
-const expandOverflow = () => {
+// `minPx` default is a literal so `page.evaluate(expandOverflow)` serializes cleanly.
+const expandOverflow = (minPx = 200) => {
   const scroll = [...document.querySelectorAll('*')]
     .filter(el => {
       const s = window.getComputedStyle(el)
       return (
         (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
-        el.scrollHeight > el.clientHeight + 200
+        el.scrollHeight > el.clientHeight + minPx
       )
     })
     .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
@@ -96,7 +102,7 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
   }
 
   await page.evaluate(
-    (scrollBudget, stepMs) =>
+    (scrollBudget, stepMs, minPx) =>
       new Promise(resolve => {
         const doc = document.scrollingElement || document.documentElement
         let root = null
@@ -106,7 +112,7 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
         if (pageHeight <= viewport + 1 && document.body) {
           let best = null
           for (const el of document.body.querySelectorAll('*')) {
-            if (el.scrollHeight <= el.clientHeight + 20) continue
+            if (el.scrollHeight <= el.clientHeight + minPx) continue
             const { overflowY } = window.getComputedStyle(el)
             if (overflowY !== 'auto' && overflowY !== 'scroll') continue
             if (!best || el.scrollHeight > best.scrollHeight) best = el
@@ -138,7 +144,8 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
         scrollNext()
       }),
     scrollBudget,
-    SCROLL_STEP_MS
+    SCROLL_STEP_MS,
+    OVERFLOW_MIN_PX
   )
 
   if (postQuiet > 0) {
@@ -181,7 +188,7 @@ const prepareFullDocument = async (page, { goto, timeout } = {}) => {
     await pReflect(page.waitForNetworkIdle({ idleTime: 300, concurrency: 2, timeout: settleMs }))
   }
 
-  const expanded = await pReflect(page.evaluate(expandOverflow))
+  const expanded = await pReflect(page.evaluate(expandOverflow, OVERFLOW_MIN_PX))
   debug('prepareFullDocument:expandOverflow', {
     expanded: !expanded.isRejected && expanded.value,
     duration: elapsed()
@@ -195,5 +202,6 @@ module.exports = {
   expandOverflow,
   scrollFullPageToLoadContent,
   prepareFullDocument,
-  SCROLL_STEP_MS
+  SCROLL_STEP_MS,
+  OVERFLOW_MIN_PX
 }

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -12,23 +12,39 @@ const PRE_QUIET_MS = 50
 const POST_QUIET_MS = 200
 const SETTLE_MS = 400
 
+// The single overflow scanner: the tallest whole-document element that scrolls
+// its own overflow past minPx. Runs in the page.
+function findTallestOverflowScroller (minPx) {
+  let best = null
+  for (const el of document.querySelectorAll('*')) {
+    const style = window.getComputedStyle(el)
+    if (style.overflowY !== 'auto' && style.overflowY !== 'scroll') continue
+    if (el.scrollHeight <= el.clientHeight + minPx) continue
+    if (!best || el.scrollHeight > best.scrollHeight) best = el
+  }
+  return best
+}
+
+// page.evaluate only serializes the function it is given, so an in-page helper
+// can't be shared across evaluates by reference. Compose the scanner source in
+// front of `fn` on the Node side (no in-page eval, so page CSP is untouched) to
+// give every caller the same scanner.
+const evaluateInPage = (page, fn, ...args) => {
+  const source = `${findTallestOverflowScroller}\nreturn (${fn}).apply(null, arguments)`
+  // eslint-disable-next-line no-new-func
+  return page.evaluate(new Function(source), ...args)
+}
+
 const waitForOverflowHeight = (page, timeout = OVERFLOW_WAIT_MS) =>
-  page.evaluate(
+  evaluateInPage(
+    page,
     (timeout, minPx) =>
       new Promise(resolve => {
         const started = Date.now()
         let last = 0
         let stable = 0
         const tick = () => {
-          const scroll = [...document.querySelectorAll('*')]
-            .filter(el => {
-              const s = window.getComputedStyle(el)
-              return (
-                (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
-                el.scrollHeight > el.clientHeight + minPx
-              )
-            })
-            .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
+          const scroll = findTallestOverflowScroller(minPx)
           const height = scroll
             ? scroll.scrollHeight
             : (document.scrollingElement || document.documentElement).scrollHeight
@@ -49,34 +65,29 @@ const waitForOverflowHeight = (page, timeout = OVERFLOW_WAIT_MS) =>
     OVERFLOW_MIN_PX
   )
 
-const expandOverflow = (minPx = 200) => {
-  const scroll = [...document.querySelectorAll('*')]
-    .filter(el => {
-      const s = window.getComputedStyle(el)
-      return (
-        (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
-        el.scrollHeight > el.clientHeight + minPx
-      )
-    })
-    .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
-
-  if (!scroll) return false
-
-  let el = scroll
-  while (el) {
-    const pos = window.getComputedStyle(el).position
-    el.style.setProperty('overflow', 'visible', 'important')
-    el.style.setProperty('height', 'auto', 'important')
-    el.style.setProperty('max-height', 'none', 'important')
-    if (pos === 'absolute' || pos === 'fixed') {
-      el.style.setProperty('position', 'relative', 'important')
-      el.style.setProperty('inset', 'auto', 'important')
-    }
-    if (el === document.documentElement) break
-    el = el.parentElement
-  }
-  return true
-}
+const expandOverflow = (page, minPx = OVERFLOW_MIN_PX) =>
+  evaluateInPage(
+    page,
+    minPx => {
+      const scroll = findTallestOverflowScroller(minPx)
+      if (!scroll) return false
+      let el = scroll
+      while (el) {
+        const pos = window.getComputedStyle(el).position
+        el.style.setProperty('overflow', 'visible', 'important')
+        el.style.setProperty('height', 'auto', 'important')
+        el.style.setProperty('max-height', 'none', 'important')
+        if (pos === 'absolute' || pos === 'fixed') {
+          el.style.setProperty('position', 'relative', 'important')
+          el.style.setProperty('inset', 'auto', 'important')
+        }
+        if (el === document.documentElement) break
+        el = el.parentElement
+      }
+      return true
+    },
+    minPx
+  )
 
 const scrollFullPageToLoadContent = async (page, timeout) => {
   const preQuiet = Math.min(PRE_QUIET_MS, Math.floor(timeout / 20))
@@ -92,21 +103,10 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
     debug('waitForDomStability:pre', { ...result, duration: Date.now() - started })
   }
 
-  const scroll = await page.evaluate(
+  const scroll = await evaluateInPage(
+    page,
     (scrollBudget, stepMs, minPx) =>
       new Promise(resolve => {
-        const findOverflow = () => {
-          if (!document.body) return null
-          let best = null
-          for (const el of document.body.querySelectorAll('*')) {
-            if (el.scrollHeight <= el.clientHeight + minPx) continue
-            const { overflowY } = window.getComputedStyle(el)
-            if (overflowY !== 'auto' && overflowY !== 'scroll') continue
-            if (!best || el.scrollHeight > best.scrollHeight) best = el
-          }
-          return best
-        }
-
         const doc = () => document.scrollingElement || document.documentElement
         let root = null
         let pageHeight = doc() ? doc().scrollHeight : 0
@@ -116,7 +116,7 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
 
         const measure = () => {
           if (!root) {
-            const overflow = findOverflow()
+            const overflow = findTallestOverflowScroller(minPx)
             if (overflow) root = overflow
           }
           if (root) {
@@ -223,7 +223,7 @@ const prepareFullDocument = async (page, { goto, timeout, scrolled = false } = {
     await pReflect(page.waitForNetworkIdle({ idleTime: 200, concurrency: 2, timeout: settleMs }))
   }
 
-  const expanded = await pReflect(page.evaluate(expandOverflow, OVERFLOW_MIN_PX))
+  const expanded = await pReflect(expandOverflow(page))
   debug('prepareFullDocument:expandOverflow', {
     expanded: !expanded.isRejected && expanded.value,
     duration: elapsed()

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -233,12 +233,9 @@ const prepareFullDocument = async (page, { goto, timeout, scrolled = false } = {
 }
 
 module.exports = {
-  waitForOverflowHeight,
   expandOverflow,
   scrollFullPageToLoadContent,
   prepareFullDocument,
   resolveScrollTimeout,
-  tryHydrateScroll,
-  SCROLL_STEP_MS,
-  OVERFLOW_MIN_PX
+  tryHydrateScroll
 }

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -186,11 +186,17 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
   return { ...scroll, hydrated, duration: Date.now() - started }
 }
 
-const resolveScrollTimeout = (goto, timeout) => {
-  if (timeout != null) return timeout
-  if (typeof goto?.timeouts?.goto === 'function') return goto.timeouts.goto()
-  if (typeof goto?.timeouts?.action === 'function') return goto.timeouts.action()
-  return 15000
+const resolveScrollTimeout = (goto, timeout) =>
+  typeof goto.timeouts.goto === 'function'
+    ? goto.timeouts.goto(timeout)
+    : goto.timeouts.action(timeout)
+
+const tryHydrateScroll = async (page, remaining) => {
+  const hydrate = await pReflect(scrollFullPageToLoadContent(page, Math.min(remaining / 2, 5000)))
+  return {
+    hydrated: !hydrate.isRejected && !!hydrate.value?.hydrated,
+    info: hydrate.isRejected ? {} : hydrate.value
+  }
 }
 
 const prepareFullDocument = async (page, { goto, timeout, scrolled = false } = {}) => {
@@ -231,6 +237,8 @@ module.exports = {
   expandOverflow,
   scrollFullPageToLoadContent,
   prepareFullDocument,
+  resolveScrollTimeout,
+  tryHydrateScroll,
   SCROLL_STEP_MS,
   OVERFLOW_MIN_PX
 }

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -89,6 +89,12 @@ const expandOverflow = (page, minPx = OVERFLOW_MIN_PX) =>
     minPx
   )
 
+const settleDom = async (page, { idle, timeout }, label) => {
+  const started = Date.now()
+  const result = await page.evaluate(waitForDomStability, { idle, timeout })
+  debug(label, { ...result, duration: Date.now() - started })
+}
+
 const scrollFullPageToLoadContent = async (page, timeout) => {
   const preQuiet = Math.min(PRE_QUIET_MS, Math.floor(timeout / 20))
   const postQuiet = Math.min(POST_QUIET_MS, Math.floor(timeout / 20))
@@ -96,11 +102,7 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
   const started = Date.now()
 
   if (preQuiet > 0) {
-    const result = await page.evaluate(waitForDomStability, {
-      idle: preQuiet / 2,
-      timeout: preQuiet
-    })
-    debug('waitForDomStability:pre', { ...result, duration: Date.now() - started })
+    await settleDom(page, { idle: preQuiet / 2, timeout: preQuiet }, 'waitForDomStability:pre')
   }
 
   const scroll = await evaluateInPage(
@@ -174,12 +176,11 @@ const scrollFullPageToLoadContent = async (page, timeout) => {
   debug('scrollFullPage', { ...scroll, duration: Date.now() - started })
 
   if (postQuiet > 0) {
-    const postStarted = Date.now()
-    const result = await page.evaluate(waitForDomStability, {
-      idle: Math.min(100, postQuiet / 2),
-      timeout: postQuiet
-    })
-    debug('waitForDomStability:post', { ...result, duration: Date.now() - postStarted })
+    await settleDom(
+      page,
+      { idle: Math.min(100, postQuiet / 2), timeout: postQuiet },
+      'waitForDomStability:post'
+    )
   }
 
   const hydrated = !!(scroll?.hasOverflow && scroll.scrolledPx >= (scroll.viewport || 0))
@@ -223,13 +224,11 @@ const prepareFullDocument = async (page, { goto, timeout, scrolled = false } = {
     await pReflect(page.waitForNetworkIdle({ idleTime: 200, concurrency: 2, timeout: settleMs }))
   }
 
-  const expanded = await pReflect(expandOverflow(page))
-  debug('prepareFullDocument:expandOverflow', {
-    expanded: !expanded.isRejected && expanded.value,
-    duration: elapsed()
-  })
+  const expandResult = await pReflect(expandOverflow(page))
+  const expanded = !expandResult.isRejected && expandResult.value
+  debug('prepareFullDocument:expandOverflow', { expanded, duration: elapsed() })
 
-  return { expanded: !expanded.isRejected && expanded.value, duration: elapsed(), scrolled }
+  return { expanded, duration: elapsed(), scrolled }
 }
 
 module.exports = {

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -192,8 +192,17 @@ const resolveScrollTimeout = (goto, timeout) =>
     ? goto.timeouts.goto(timeout)
     : goto.timeouts.action(timeout)
 
+// A hydrate scroll spends up to half the remaining budget (capped) scrolling,
+// and the capture that follows still needs time. Below HYDRATE_MIN_BUDGET_MS
+// there isn't enough left for both, so skip it.
+const HYDRATE_MIN_BUDGET_MS = 1000
+const HYDRATE_MAX_SCROLL_MS = 5000
+
 const tryHydrateScroll = async (page, remaining) => {
-  const hydrate = await pReflect(scrollFullPageToLoadContent(page, Math.min(remaining / 2, 5000)))
+  if (remaining <= HYDRATE_MIN_BUDGET_MS) return { hydrated: false, info: {} }
+  const hydrate = await pReflect(
+    scrollFullPageToLoadContent(page, Math.min(remaining / 2, HYDRATE_MAX_SCROLL_MS))
+  )
   return {
     hydrated: !hydrate.isRejected && !!hydrate.value?.hydrated,
     info: hydrate.isRejected ? {} : hydrate.value

--- a/packages/screenshot/src/wait-for-dom.js
+++ b/packages/screenshot/src/wait-for-dom.js
@@ -1,19 +1,5 @@
 'use strict'
 
-const DEFAULT_WAIT_FOR_DOM = 0
-const WAIT_FOR_DOM_IDLE_RATIO = 10
-
-const resolveWaitForDom = waitForDom => {
-  const timeout = Number.isFinite(waitForDom) && waitForDom >= 0 ? waitForDom : DEFAULT_WAIT_FOR_DOM
-
-  if (timeout === 0) return undefined
-
-  return {
-    timeout,
-    idle: timeout / WAIT_FOR_DOM_IDLE_RATIO
-  }
-}
-
 const waitForDomStability = ({ idle, timeout } = {}) =>
   new Promise(resolve => {
     if (!document.body) return resolve({ status: 'no-body' })
@@ -45,9 +31,4 @@ const waitForDomStability = ({ idle, timeout } = {}) =>
     })()
   })
 
-module.exports = {
-  DEFAULT_WAIT_FOR_DOM,
-  WAIT_FOR_DOM_IDLE_RATIO,
-  resolveWaitForDom,
-  waitForDomStability
-}
+module.exports = { waitForDomStability }

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -1,47 +1,21 @@
 'use strict'
 
-// Navigation-tolerant readiness gate. Resolves once the page has been visually
-// quiet — document height stable, every image decoded, `readyState` complete —
-// for `quietMs`, bounded by `timeout`. Unlike a screenshot poll it takes no
-// screenshots (which are expensive under software rendering, e.g. the GPU-less
-// fleet's llvmpipe) and it survives a client-side navigation: when the
-// execution context is destroyed mid-check the quiet window resets and polling
-// continues instead of throwing (SPAs re-commit their own URL after load).
-
 const { setTimeout: sleep } = require('node:timers/promises')
 const { isContextDestroyed } = require('@browserless/errors')
 
-// Evaluated in-page: cheap paint/settle signals (not a screenshot). `images`
-// counts only images expected to settle: a lazy image well below the viewport
-// sits outside Chromium's lazy-load fetch threshold and never starts loading
-// without a scroll, so counting it could only stall the gate into its timeout.
-// `decoded` counts every counted image that finished loading — a broken `<img>`
-// counts too, so it can't stall the settle gate — while `painted` counts only
-// images a screenshot would actually see: successfully decoded, rendered at a
-// visible size (a 16×16 box or larger, so a tracking pixel doesn't count),
-// inside the viewport, and not hidden via CSS — so a blank shell can't pass for
-// content. `text` is the equivalent paint signal for imageless pages: visible
-// characters inside the viewport, counted up to 200 (the threshold consumers
-// rely on) and skipping text whose color matches its effective background
-// (invisible on capture), and `fonts` reports whether webfonts finished
-// loading — during a `font-display: block` period text renders invisible,
-// exactly when a capture would be white. `covered` reports whether the counted
-// content hides behind an opaque viewport-covering layer (a fixed white
-// loading overlay passes every DOM signal while a capture stays white):
-// hit-testing catches interactive overlays, and a root-level scan catches
-// `pointer-events: none` layers hit-testing can't see. `viewport` is the
-// in-page viewport height, so consumers can compare it against `height`
-// without relying on `page.viewport()`, which is null under
-// `defaultViewport: null`.
+const DEFAULT_QUIET_MS = 300
+const DEFAULT_POLL_MS = 150
+
 const paintSignals = () => {
-  // A document that is mid-parse or detached can have a null `documentElement`
-  // (the same state the text walk below guards against), so every dereference
-  // of it goes through `root`.
+  const TEXT_PAINT_CAP = 200
+  const MIN_PAINTED_AREA_PX = 256
+  const LAZY_IMAGE_VIEWPORTS = 2
+  const CONTENT_SAMPLE_LIMIT = 4
+
   const root = document.documentElement
   const vw = window.innerWidth || (root ? root.clientWidth : 0)
   const vh = window.innerHeight || (root ? root.clientHeight : 0)
 
-  // Computed colors resolve to `rgb()`/`rgba()`; anything else is unknown.
   const parseColor = value => {
     const match = /rgba?\(([^)]+)\)/.exec(value || '')
     if (!match) return null
@@ -49,8 +23,6 @@ const paintSignals = () => {
     return { r: parts[0], g: parts[1], b: parts[2], a: parts.length === 4 ? parts[3] : 1 }
   }
 
-  // First opaque background up the ancestor chain; the canvas default (white)
-  // when every ancestor is transparent.
   const effectiveBackground = el => {
     for (let node = el; node; node = node.parentElement) {
       const color = parseColor(window.getComputedStyle(node).backgroundColor)
@@ -62,8 +34,6 @@ const paintSignals = () => {
   const sameColor = (a, b) =>
     Math.abs(a.r - b.r) < 10 && Math.abs(a.g - b.g) < 10 && Math.abs(a.b - b.b) < 10
 
-  // A layer only blanks a capture when it is itself painted solid: visible,
-  // full opacity, and an opaque background color or a background image.
   const isOpaqueLayer = el => {
     const style = window.getComputedStyle(el)
     if (style.visibility === 'hidden' || parseFloat(style.opacity) < 0.99) return false
@@ -78,13 +48,9 @@ const paintSignals = () => {
     return width > 0 && height > 0 && width * height >= vw * vh * 0.9
   }
 
-  // Up to a handful of counted content samples — enough to hit-test without
-  // turning the probe into a layout storm. The clamp keeps each probe point
-  // inside the viewport; the rect checks below guarantee it stays inside the
-  // sampled content's own box.
   const contentPoints = []
   const samplePoint = (el, rect) => {
-    if (contentPoints.length >= 4) return
+    if (contentPoints.length >= CONTENT_SAMPLE_LIMIT) return
     contentPoints.push({
       el,
       x: Math.max(0, Math.min(vw - 1, rect.left + rect.width / 2)),
@@ -99,11 +65,9 @@ const paintSignals = () => {
   for (let i = 0; i < imgs.length; i++) {
     const img = imgs[i]
     if (!img.complete) {
-      // Two viewports of headroom stays inside the smallest fetch threshold
-      // Chromium uses for lazy images (~1250px on fast connections), so an
-      // undecoded lazy image within it is loading and worth waiting for;
-      // beyond it, the fetch never starts.
-      if (img.loading === 'lazy' && img.getBoundingClientRect().top > vh * 2) continue
+      if (img.loading === 'lazy' && img.getBoundingClientRect().top > vh * LAZY_IMAGE_VIEWPORTS) {
+        continue
+      }
       images++
       continue
     }
@@ -111,7 +75,7 @@ const paintSignals = () => {
     decoded++
     if (img.naturalWidth === 0) continue
     const rect = img.getBoundingClientRect()
-    if (rect.width * rect.height < 256) continue
+    if (rect.width * rect.height < MIN_PAINTED_AREA_PX) continue
     if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= vh || rect.left >= vw) continue
     if (
       typeof img.checkVisibility === 'function' &&
@@ -122,21 +86,14 @@ const paintSignals = () => {
     painted++
     samplePoint(img, rect)
   }
-  // Counting stops at 200 chars, so a text-heavy page costs a handful of nodes,
-  // not a full DOM walk; only a near-blank shell walks every text node.
+
   let text = 0
-  // A document that is mid-parse or detached can have neither `body` nor
-  // `documentElement`, and `createTreeWalker` throws on a null root. Text is only
-  // a paint signal, so a count that cannot be taken means "no text seen yet": the
-  // gate stays conservative and re-polls, rather than failing a render that would
-  // otherwise succeed. The same holds mid-walk — a DOM mutating under the walker
-  // must not take the capture down with it.
   const textRoot = document.body || root
   const walker = textRoot
     ? document.createTreeWalker(textRoot, window.NodeFilter.SHOW_TEXT)
     : { nextNode: () => null }
   try {
-    while (text < 200) {
+    while (text < TEXT_PAINT_CAP) {
       const node = walker.nextNode()
       if (!node) break
       const value = node.nodeValue.trim()
@@ -156,22 +113,13 @@ const paintSignals = () => {
       const rect = range.getBoundingClientRect()
       if (rect.width === 0 || rect.height === 0) continue
       if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= vh || rect.left >= vw) continue
-      // White-on-white (or any color-on-same-color) text passes every geometry
-      // check while a capture shows nothing: don't count it as painted text.
       const color = parseColor(window.getComputedStyle(el).color)
       if (color && (color.a < 0.05 || sameColor(color, effectiveBackground(el)))) continue
       text += value.length
       samplePoint(el, rect)
     }
-  } catch {
-    // Keep whatever was counted before the DOM shifted underneath the walk.
-  }
+  } catch {}
 
-  // Is this content sample's paint hidden behind an unrelated opaque,
-  // viewport-covering layer? Walk up from the hit-tested element: anything
-  // related to the sample (itself, an ancestor, a descendant) paints with it,
-  // and the walk stops at the first common ancestor — an ancestor's background
-  // always paints below its own descendants.
   const coveredAt = ({ el, x, y }) => {
     const top = document.elementFromPoint(x, y)
     if (!top) return false
@@ -182,14 +130,9 @@ const paintSignals = () => {
     return false
   }
 
-  // Only pages the fast path could trust get the (layout-forcing) cover check.
   let covered = false
-  if (painted > 0 || text >= 200) {
+  if (painted > 0 || text >= TEXT_PAINT_CAP) {
     covered = contentPoints.some(coveredAt)
-    // `elementFromPoint` skips `pointer-events: none` elements, exactly how
-    // fading loading overlays are styled — scan root-level layers for one.
-    // Overlays mount as direct children of <body>; a deeper scan would cost a
-    // full styled DOM walk on every poll for a marginal case.
     if (!covered && document.body) {
       const layers = document.body.children
       for (let i = 0; i < layers.length && !covered; i++) {
@@ -222,20 +165,13 @@ const paintSignals = () => {
   }
 }
 
-// 300ms of held quiet plus one 150ms poll to prove height stability puts the
-// gate's floor at ~450ms. The hold guards against lulls (a page momentarily
-// stable between async chunks); height stability + all images decoded +
-// `readyState === 'complete'` carry most of the settle signal, so a longer
-// hold buys little — below ~300ms it would start trusting coincidences.
-const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) => {
+const waitForReady = async (
+  page,
+  { timeout, quietMs = DEFAULT_QUIET_MS, poll = DEFAULT_POLL_MS } = {}
+) => {
   if (!Number.isFinite(timeout)) throw new TypeError('timeout must be a finite number')
-  // The quiet window must fit within the budget with room to observe it, or the
-  // gate could never satisfy its own requirement and would always time out.
   quietMs = Math.min(quietMs, Math.floor(timeout / 2))
   const deadline = Date.now() + timeout
-  // Never sleep past the deadline: with a poll larger than the remaining
-  // budget, a full-length sleep would overshoot the timeout and steal time
-  // from whatever shares the caller's budget (the blank-SPA screenshot poll).
   const nextPoll = () => sleep(Math.min(poll, Math.max(0, deadline - Date.now())))
   let lastHeight = -1
   let quietSince = 0
@@ -257,10 +193,6 @@ const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) =
     try {
       signals = await page.evaluate(paintSignals)
     } catch (error) {
-      // Only a client-side navigation tearing down the execution context is
-      // absorbed: reset the quiet window and keep polling. Any other evaluate
-      // failure is a real error and surfaces instead of masquerading as a
-      // timeout.
       if (!isContextDestroyed(error)) throw error
       resets++
       lastHeight = -1

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -287,4 +287,4 @@ const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) =
   return { ...last, resets, timedOut: true }
 }
 
-module.exports = { waitForReady }
+module.exports = { waitForReady, snapshot }

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -11,7 +11,7 @@
 const { setTimeout: sleep } = require('node:timers/promises')
 const { isContextDestroyed } = require('@browserless/errors')
 
-// Evaluated in-page: a cheap snapshot of the paint/settle signals. `images`
+// Evaluated in-page: cheap paint/settle signals (not a screenshot). `images`
 // counts only images expected to settle: a lazy image well below the viewport
 // sits outside Chromium's lazy-load fetch threshold and never starts loading
 // without a scroll, so counting it could only stall the gate into its timeout.
@@ -33,10 +33,10 @@ const { isContextDestroyed } = require('@browserless/errors')
 // in-page viewport height, so consumers can compare it against `height`
 // without relying on `page.viewport()`, which is null under
 // `defaultViewport: null`.
-const snapshot = () => {
+const paintSignals = () => {
   // A document that is mid-parse or detached can have a null `documentElement`
   // (the same state the text walk below guards against), so every dereference
-  // of it in this snapshot goes through `root`.
+  // of it goes through `root`.
   const root = document.documentElement
   const vw = window.innerWidth || (root ? root.clientWidth : 0)
   const vh = window.innerHeight || (root ? root.clientHeight : 0)
@@ -79,7 +79,7 @@ const snapshot = () => {
   }
 
   // Up to a handful of counted content samples — enough to hit-test without
-  // turning the snapshot into a layout storm. The clamp keeps each probe point
+  // turning the probe into a layout storm. The clamp keeps each probe point
   // inside the viewport; the rect checks below guarantee it stays inside the
   // sampled content's own box.
   const contentPoints = []
@@ -253,9 +253,9 @@ const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) =
   }
 
   while (Date.now() < deadline) {
-    let snap
+    let signals
     try {
-      snap = await page.evaluate(snapshot)
+      signals = await page.evaluate(paintSignals)
     } catch (error) {
       // Only a client-side navigation tearing down the execution context is
       // absorbed: reset the quiet window and keep polling. Any other evaluate
@@ -269,16 +269,16 @@ const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) =
       continue
     }
 
-    last = snap
-    const imagesDecoded = snap.images === 0 || snap.decoded >= snap.images
-    const quiet = snap.complete && imagesDecoded && snap.height === lastHeight
+    last = signals
+    const imagesDecoded = signals.images === 0 || signals.decoded >= signals.images
+    const quiet = signals.complete && imagesDecoded && signals.height === lastHeight
 
     if (quiet) {
       if (quietSince === 0) quietSince = Date.now()
-      if (Date.now() - quietSince >= quietMs) return { ...snap, resets, timedOut: false }
+      if (Date.now() - quietSince >= quietMs) return { ...signals, resets, timedOut: false }
     } else {
       quietSince = 0
-      lastHeight = snap.height
+      lastHeight = signals.height
     }
 
     await nextPoll()
@@ -287,4 +287,4 @@ const waitForReady = async (page, { timeout, quietMs = 300, poll = 150 } = {}) =
   return { ...last, resets, timedOut: true }
 }
 
-module.exports = { waitForReady, snapshot }
+module.exports = { waitForReady, paintSignals }

--- a/packages/screenshot/test/wait-for-ready-live.js
+++ b/packages/screenshot/test/wait-for-ready-live.js
@@ -5,7 +5,7 @@ const test = require('ava')
 
 const { waitForReady } = require('..')
 
-// Exercises the real in-page `snapshot()` against a live DOM — the part the
+// Exercises the real in-page `paintSignals()` against a live DOM — the part the
 // unit tests can't reach, since `getBoundingClientRect`/`checkVisibility` only
 // mean anything in a browser. A 1×1 transparent PNG stands in for real imagery;
 // what distinguishes "painted" is the rendered box, viewport, and visibility.
@@ -178,7 +178,7 @@ test('below-viewport text does not count toward the text signal', async t => {
   t.is(r.text, 0)
 })
 
-test('no document root: the snapshot degrades to zeros instead of failing the capture', async t => {
+test('no document root: paintSignals degrades to zeros instead of failing the capture', async t => {
   const browserless = await getBrowserContext(t)
   const url = await runServer(t, ({ res }) => {
     res.setHeader('content-type', 'text/html')
@@ -187,7 +187,7 @@ test('no document root: the snapshot degrades to zeros instead of failing the ca
   const r = await browserless.withPage((page, goto) => async () => {
     await goto(page, { url, waitUntil: 'load', adblock: false, timeout: 5000 })
     // The production failure state behind #845: a mid-parse or detached
-    // document exposes neither `body` nor `documentElement`. Every snapshot
+    // document exposes neither `body` nor `documentElement`. Every paintSignals
     // dereference of the root must survive it — `createTreeWalker` threw on
     // the null walker root, and `scrollHeight`/`clientWidth` sit one null
     // dereference away from the same capture-killing rethrow.

--- a/packages/screenshot/test/wait-for-ready.js
+++ b/packages/screenshot/test/wait-for-ready.js
@@ -55,7 +55,7 @@ test('clamps the quiet window to the budget so a tiny timeout still resolves', a
 })
 
 test('a non-navigation evaluate error surfaces instead of spinning to a timeout', async t => {
-  const boom = new Error('Evaluation failed: ReferenceError: snapshot is not defined')
+  const boom = new Error('Evaluation failed: ReferenceError: paintSignals is not defined')
   const page = scriptedPage([READY, boom])
   await t.throwsAsync(() => waitForReady(page, { timeout: 2000, quietMs: 40, poll: 10 }), {
     message: /Evaluation failed/

--- a/packages/screenshot/test/white-retry.js
+++ b/packages/screenshot/test/white-retry.js
@@ -55,9 +55,9 @@ const createGoto = ({ timeout = 1000, waitUntilAutoDelay = 0 } = {}) => {
   return goto
 }
 
-const createPage = (screenshots, { pageSnapshots = [] } = {}) => {
+const createPage = (screenshots, { pageMetas = [] } = {}) => {
   let screenshotCalls = 0
-  let pageSnapshotCall = 0
+  let pageMetaCall = 0
 
   return {
     on: () => {},
@@ -66,15 +66,15 @@ const createPage = (screenshots, { pageSnapshots = [] } = {}) => {
       if (expression === 'document.fonts.ready') return undefined
       if (typeof expression === 'function') {
         const source = expression.toString()
-        const isSnapshotEval =
+        const isPageMetaEval =
           source.includes('document.title') &&
           source.includes('document.body') &&
           source.includes('window.location.href')
 
-        if (!isSnapshotEval) return undefined
+        if (!isPageMetaEval) return undefined
 
         return (
-          pageSnapshots[pageSnapshotCall++] || {
+          pageMetas[pageMetaCall++] || {
             title: '',
             bodyText: '',
             url: 'https://example.com'
@@ -174,7 +174,7 @@ test('waits for verification interstitial to resolve before screenshot', async t
   const goto = createGoto({ timeout: 10000 })
   const screenshots = [Buffer.from('shot1'), Buffer.from('shot2'), Buffer.from('shot3')]
   const page = createPage(screenshots, {
-    pageSnapshots: [
+    pageMetas: [
       {
         title: 'Verifying you are human',
         bodyText: 'Please wait while we verify that you are not a robot.',


### PR DESCRIPTION
## Problem

SPA / app-shell pages often look “settled” before real content exists:

1. **Bot-check / verification** interstitials pass early settle signals, then get serialized as a blank or checkpoint PDF.
2. **Overflow shells** keep the document height ≈ viewport while real content lives in an inner scroller — so `window` scroll never hydrates lazy sections, and `fullPage` / `page.pdf()` only see the viewport-sized shell.
3. **Print CSS** (`@media print`) can collapse the on-screen layout; callers sometimes need `mediaType: 'screen'`.

Before this PR, PDF `waitUntil: 'auto'` did not share screenshot’s readiness path, and neither PDF nor fullPage screenshot prepared overflow documents consistently.

## Before vs after

```mermaid
flowchart LR
  subgraph before [Before]
    B1[goto settle] --> B2[PDF / viewport shot]
    B2 --> B3[Blank shell or checkpoint]
  end

  subgraph after [After]
    A1[goto settle] --> A2[paintSignals + isPageReady]
    A2 -->|not ready| A3[probe / hydrate scroll]
    A3 --> A2
    A2 -->|ready| A4[prepareFullDocument]
    A4 --> A5[scroll overflow → expand → capture]
  end
```

| | Before | After |
|---|---|---|
| PDF readiness | Settle signals only; no CLI `isPageReady` | Same gate as screenshot: `paintSignals` + `isPageReady` (bot-check aware) |
| Lazy / overflow content | Scroll `window` only (or not at all) | Shared `prepareFullDocument`: wait → scroll tallest overflow → expand |
| fullPage screenshot | Often viewport-sized shell | Viewport probes for readiness, then full-document prep + fullPage shot |
| Site-specific layout | — | Stays with the caller (`--styles`, `--scripts`, `--mediaType=screen`, …) |

```mermaid
sequenceDiagram
  participant CLI
  participant PDF as pdf.prepare
  participant Ready as waitForReady / isPageReady
  participant Prep as prepareFullDocument
  participant Chrome

  CLI->>PDF: url + opts
  PDF->>Chrome: goto (mediaType via goto)
  PDF->>Ready: paintSignals + isPageReady
  alt not ready
    Ready->>Chrome: cheap JPEG probe
    opt non-white + remaining budget
      Ready->>Chrome: one hydrate scroll
    end
  end
  Ready-->>PDF: isReady
  alt isReady
    PDF->>Prep: scroll + expandOverflow
    Prep-->>PDF: documentPrepared
  end
  PDF->>Chrome: page.pdf (expand only if prepared)
```

## What changed

- **`@browserless/pdf`** — `auto` mode mirrors screenshot readiness; overflow expand at print time only for pages that cleared prepare (`WeakMap` per page).
- **`@browserless/screenshot`** — new `prepare-full-document.js` shared by fullPage screenshot and PDF; one `OVERFLOW_MIN_PX` for wait / scroll / expand.
- **CLI** — PDF gets `isPageReady`; `--timeout` also applied to browser/context (so long prepares are not killed by the 30s default).
- **Callers own layout** — no site-specific selectors in core. Example for a slide-style report:

```bash
browserless pdf 'https://example.com/report' \
  --path=output.pdf --mediaType=screen --timeout=90000 \
  --width=960 --height=679 --margin=0 --scale=1 \
  --styles='.report-page-anchor{break-after:page}'

browserless screenshot 'https://example.com/report' \
  --path=output.png --fullPage --mediaType=screen --timeout=90000
```

## Test plan

- [ ] PDF of an SPA/report with `--mediaType=screen` shows real content (not skeleton/checkpoint)
- [ ] Same URL with `--fullPage` screenshot is tall (document flow), not viewport-only
- [ ] Bot-check / verification page is not expanded/printed as the “ready” document
- [ ] Default PDF (no `mediaType`) still works for ordinary printable pages
- [ ] `packages/browserless` + `@browserless/screenshot` tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core capture timing, DOM mutation (overflow expand), and default PDF/screenshot behavior for SPAs; broad test updates but real-site edge cases remain.
> 
> **Overview**
> **PDF and screenshot now share one readiness and full-document path** so SPAs, bot-check pages, and inner scrollers behave consistently before capture.
> 
> **`@browserless/pdf`** — `waitUntil: 'auto'` uses the same flow as screenshot: `waitForReady` / `paintSignals`, optional **`isPageReady`**, JPEG probes when not ready, a single **`tryHydrateScroll`** when the probe isn’t white, then **`prepareFullDocument`** when ready. The public **`waitForDom`** option is removed; non-`auto` navigations still run **`prepareFullDocument`**. **`render`** runs **`expandOverflow`** before **`page.pdf()`**.
> 
> **`@browserless/screenshot`** — Scroll, DOM quiet, and overflow expand move into **`prepare-full-document.js`** (tallest overflow scroller, hydrate scroll, expand). **`fullPage`** waits via viewport shots + **`checkPageReady`**, then prepares and captures expanded. **`waitForDom`** is dropped; helpers (**`prepareFullDocument`**, **`checkPageReady`**, **`paintSignals`**, etc.) are re-exported for PDF.
> 
> **CLI** — The **`pdf`** command forwards CLI **`isPageReady`** (verification markers); **`--timeout`** applies to browser launch and **`createContext`**.
> 
> Docs and tests updated; a regression test asserts every helper PDF imports from screenshot is re-exported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb7224f18e46de94557a5865383da059ba7a4e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->