### PR TITLE
feat(pdf): add element option for print isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,20 @@ const buffer = await browserless.pdf(url.toString(), {
 })
 ```
 
+##### element
+
+type: `string` <br/>
+
+Prints only the first matching DOM element for the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). The operation waits until the element is visible or the maximum [timeout](#timeout) is reached.
+
+Unlike [screenshot `element`](#element), PDF has no native clip API, so this isolates the subtree for print (hides everything outside the match) before calling `page.pdf()`.
+
+```js
+const buffer = await browserless.pdf(url.toString(), {
+  element: '.report-pages-stack'
+})
+```
+
 ### .screenshot(url, options)
 
 Generates screenshots based on a specified `url`.

--- a/packages/browserless/test/pdf.js
+++ b/packages/browserless/test/pdf.js
@@ -382,6 +382,39 @@ test('waitUntil auto: text behind a loading webfont does not trip the fast path'
   t.is(pdfCalls, 1)
 })
 
+test('element waits for the selector and isolates it before pdf', async t => {
+  const calls = []
+
+  const page = {
+    screenshot: async () => noWhiteScreenshot,
+    evaluate: scriptEvaluate(PAINTED_READY, () => {}),
+    waitForSelector: async (selector, opts) => {
+      calls.push(['waitForSelector', selector, opts])
+    },
+    addStyleTag: async ({ content }) => {
+      calls.push(['addStyleTag', content])
+    },
+    pdf: async opts => {
+      calls.push(['pdf', opts])
+      return Buffer.from('pdf')
+    }
+  }
+
+  const pdf = createPdf({ goto: makeGoto() })(page)
+  await pdf('https://example.com', {
+    waitUntil: 'auto',
+    timeout: 500,
+    element: '.report-pages-stack'
+  })
+
+  t.deepEqual(calls[0], ['waitForSelector', '.report-pages-stack', { visible: true }])
+  t.is(calls[1][0], 'addStyleTag')
+  t.true(calls[1][1].includes('visibility: hidden'))
+  t.true(calls[1][1].includes('.report-pages-stack, .report-pages-stack *'))
+  t.is(calls[2][0], 'pdf')
+  t.is(calls[2][1].element, undefined)
+})
+
 // Regression: @browserless/pdf destructures helpers from @browserless/screenshot,
 // so every one of those names must be re-exported by the screenshot entry point.
 // A missing re-export (e.g. tryHydrateScroll) only throws once the matching code

--- a/packages/pdf/README.md
+++ b/packages/pdf/README.md
@@ -73,6 +73,7 @@ The package applies these optimized defaults:
 | `scale` | `number` | `0.65` | Scale of the webpage rendering (0.1 - 2) |
 | `printBackground` | `boolean` | `true` | Print background graphics |
 | `waitUntil` | `string` | `'auto'` | When to consider navigation done |
+| `element` | `string` | — | CSS selector; wait for it, then print only that subtree |
 | `format` | `string` | `'Letter'` | Paper format (A4, Letter, etc.) |
 | `landscape` | `boolean` | `false` | Paper orientation |
 | `width` | `string \| number` | — | Paper width (overrides format) |
@@ -161,6 +162,16 @@ const pdfBuffer = await browserless.pdf('https://example.com', {
 ```js
 const pdfBuffer = await browserless.pdf('https://example.com', {
   pageRanges: '1-3, 5'
+})
+```
+
+#### Print a specific element
+
+`page.pdf()` cannot clip like screenshots. When `element` is set, the package waits for the selector and isolates that subtree for print (everything else is hidden):
+
+```js
+const pdfBuffer = await browserless.pdf('https://example.com', {
+  element: '.report-pages-stack'
 })
 ```
 

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -41,6 +41,18 @@ const getMargin = unit => {
 const isPaintedContent = ({ painted = 0, text = 0, fonts = true } = {}) =>
   painted > 0 || (text >= TEXT_PAINTED_MIN && fonts)
 
+// page.pdf() has no clip API; hide everything outside the selector for print.
+const isolateElement = async (page, element) => {
+  await page.waitForSelector(element, { visible: true })
+  await page.addStyleTag({
+    content: [
+      'body * { visibility: hidden !important; }',
+      `${element}, ${element} * { visibility: visible !important; }`,
+      `${element} { position: absolute !important; left: 0 !important; top: 0 !important; width: 100% !important; }`
+    ].join('\n')
+  })
+}
+
 module.exports = ({ goto, ...gotoOpts } = {}) => {
   goto = goto || createGoto(gotoOpts)
 
@@ -49,10 +61,12 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       margin = PDF_DEFAULT_OPTS.margin,
       scale = PDF_DEFAULT_OPTS.scale,
       printBackground = PDF_DEFAULT_OPTS.printBackground,
+      element,
       ...rest
     } = opts
 
     await pReflect(expandOverflow(page))
+    if (element) await isolateElement(page, element)
 
     return captureWithNavigationRetry(
       () =>


### PR DESCRIPTION
## Summary
- Add `element` support to `@browserless/pdf`: wait for a CSS selector, then isolate that subtree for print before `page.pdf()`
- Work around Chromium’s missing PDF clip API with visibility-based print isolation (same idea as manual hide-chrome CSS)
- Document the option and cover it with a unit test

## Test plan
- [x] `pnpm exec ava test/pdf.js` in `packages/browserless`
- [ ] Manually: `browserless.pdf(url, { element: '.report-pages-stack', mediaType: 'screen' })` on a page with aside/header chrome
- [ ] Confirm omitting `element` still prints the full page unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `element` option for PDF generation.
  * Print only the first visible DOM element matching a CSS selector, including its descendants.
  * Non-matching page content is hidden before the PDF is created.

* **Documentation**
  * Added usage guidance and examples for the new PDF element-selection option.

* **Tests**
  * Added coverage verifying selector visibility, content isolation, and PDF generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->