### PR TITLE
fix: context leaks, screenshot readiness, and prepare scroll

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -150,7 +150,9 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
               const isRetryable =
                 error.code === 'EBRWSRCONTEXTCONNRESET' || error.code === 'EPROTOCOL'
               if (!isRetryable) throw error
+              const previousContextPromise = _contextPromise
               _contextPromise = createBrowserContext(contextOpts)
+              await pReflect(previousContextPromise.then(ctx => ctx.close()))
               const { message, attemptNumber, retriesLeft } = error
               debug('retry', { attemptNumber, retriesLeft, message })
             }

--- a/packages/browserless/test/index.js
+++ b/packages/browserless/test/index.js
@@ -494,6 +494,8 @@ test('withPage retries transient context disconnections', async t => {
   const originalSpawn = driver.spawn
   const originalClose = driver.close
   let pid = 4000
+  let createBrowserContextCalls = 0
+  let contextCloseCalls = 0
 
   driver.spawn = () => {
     let isClosed = false
@@ -504,18 +506,22 @@ test('withPage retries transient context disconnections', async t => {
       isClosed: () => isClosed
     }
 
-    const browserContext = {
-      id: `ctx-${pid}`,
-      close: () => Promise.resolve(),
-      newPage: () => Promise.resolve(page)
-    }
-
     return Promise.resolve({
       process: () => ({ pid: ++pid }),
       connected: true,
       once: () => {},
       version: () => Promise.resolve('mock'),
-      createBrowserContext: () => Promise.resolve(browserContext),
+      createBrowserContext: () => {
+        createBrowserContextCalls += 1
+        return Promise.resolve({
+          id: `ctx-${pid}-${createBrowserContextCalls}`,
+          close: () => {
+            contextCloseCalls += 1
+            return Promise.resolve()
+          },
+          newPage: () => Promise.resolve(page)
+        })
+      },
       close: () => Promise.resolve(),
       disconnect: () => Promise.resolve()
     })
@@ -546,6 +552,11 @@ test('withPage retries transient context disconnections', async t => {
 
   t.is(result, 'ok')
   t.is(attempts, 2)
+  t.is(createBrowserContextCalls, 2)
+  t.is(contextCloseCalls, 1)
+
+  await browserless.destroyContext()
+  t.is(contextCloseCalls, 2)
 })
 
 test('withPage retries transient protocol errors', async t => {

--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -69,42 +69,46 @@ module.exports = ({ tmpdir } = {}) => {
       const browser = await getBrowser()
       const browserless = await browser.createContext()
 
-      return browserless.withPage((page, goto) => async () => {
-        const { device, response } = await goto(page, { url, timeout, ...gotoOpts })
+      try {
+        return await browserless.withPage((page, goto) => async () => {
+          const { device, response } = await goto(page, { url, timeout, ...gotoOpts })
 
-        const targetId = await getTargetId(page)
+          const targetId = await getTargetId(page)
 
-        const runFunctionOpts = {
-          url,
-          code,
-          device,
-          ...opts,
-          ...fnOpts,
-          ...(isHttpResponse(response) && { _response: serializeResponse(response) })
-        }
+          const runFunctionOpts = {
+            url,
+            code,
+            device,
+            ...opts,
+            ...fnOpts,
+            ...(isHttpResponse(response) && { _response: serializeResponse(response) })
+          }
 
-        if (runFunctionOpts.code === code) {
-          runFunctionOpts.needsNetwork = needsNetwork
-          runFunctionOpts.source = source
-        }
+          if (runFunctionOpts.code === code) {
+            runFunctionOpts.needsNetwork = needsNetwork
+            runFunctionOpts.source = source
+          }
 
-        const browserFromPage = typeof page.browser === 'function' ? page.browser() : undefined
-        const browserWSEndpoint =
-          browserFromPage && typeof browserFromPage.wsEndpoint === 'function'
-            ? browserFromPage.wsEndpoint()
-            : undefined
+          const browserFromPage = typeof page.browser === 'function' ? page.browser() : undefined
+          const browserWSEndpoint =
+            browserFromPage && typeof browserFromPage.wsEndpoint === 'function'
+              ? browserFromPage.wsEndpoint()
+              : undefined
 
-        if (!browserWSEndpoint) throw new Error('Browser WebSocket endpoint not found')
-        runFunctionOpts.browserWSEndpoint = browserWSEndpoint
-        runFunctionOpts.targetId = targetId
+          if (!browserWSEndpoint) throw new Error('Browser WebSocket endpoint not found')
+          runFunctionOpts.browserWSEndpoint = browserWSEndpoint
+          runFunctionOpts.targetId = targetId
 
-        const result = await runFunction(runFunctionOpts)
+          const result = await runFunction(runFunctionOpts)
 
-        if (result.isFulfilled) return result
-        const error = ensureError(result.value)
-        if (isBrowserlessError(error)) throw error
-        return result
-      })()
+          if (result.isFulfilled) return result
+          const error = ensureError(result.value)
+          if (isBrowserlessError(error)) throw error
+          return result
+        })()
+      } finally {
+        await browserless.destroyContext()
+      }
     }
 
     const runWithoutBrowser = async (url, fnOpts) => {

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -338,7 +338,8 @@ test('response is serialized and reconstructed with callable methods (page funct
             device: { viewport: {}, userAgent: 'ua' },
             response: fakeResponse
           })
-        )()
+        )(),
+      destroyContext: async () => {}
     }
 
     const fn = browserlessFunction(
@@ -491,7 +492,8 @@ test('prefer page browser websocket endpoint when available', t => {
       browser: async () => {
         browserCalls += 1
         return { wsEndpoint: () => 'ws://from-browserless' }
-      }
+      },
+      destroyContext: async () => {}
     }
 
     const fn = browserlessFunction(({ page }) => page.title(), {
@@ -653,12 +655,16 @@ test('reuse browserless instance across page function invocations', t => {
     let getBrowserlessCalls = 0
     let createContextCalls = 0
 
+    let destroyContextCalls = 0
     const fakeBrowserless = {
       withPage: fn => async () =>
         fn(
           { browser: () => ({ wsEndpoint: () => 'ws://example' }) },
           async () => ({ device: { viewport: {}, userAgent: 'ua' } })
-        )()
+        )(),
+      destroyContext: async () => {
+        destroyContextCalls += 1
+      }
     }
 
     const fn = browserlessFunction(({ page }) => 'ok', {
@@ -676,7 +682,7 @@ test('reuse browserless instance across page function invocations', t => {
     Promise.resolve()
       .then(() => fn('https://example.com'))
       .then(() => fn('https://example.com'))
-      .then(result => process.stdout.write(JSON.stringify({ getBrowserlessCalls, createContextCalls })))
+      .then(result => process.stdout.write(JSON.stringify({ getBrowserlessCalls, createContextCalls, destroyContextCalls })))
       .catch(error => {
         process.stderr.write(String(error && error.stack ? error.stack : error))
         process.exit(1)
@@ -688,9 +694,10 @@ test('reuse browserless instance across page function invocations', t => {
   })
 
   t.is(status, 0, stderr)
-  const { getBrowserlessCalls, createContextCalls } = JSON.parse(stdout.trim())
+  const { getBrowserlessCalls, createContextCalls, destroyContextCalls } = JSON.parse(stdout.trim())
   t.is(getBrowserlessCalls, 1)
   t.is(createContextCalls, 2)
+  t.is(destroyContextCalls, 2)
 })
 
 test('retry getBrowserless on next call when initial creation fails', t => {
@@ -718,7 +725,8 @@ test('retry getBrowserless on next call when initial creation fails', t => {
         fn(
           { browser: () => ({ wsEndpoint: () => 'ws://example' }) },
           async () => ({ device: { viewport: {}, userAgent: 'ua' } })
-        )()
+        )(),
+      destroyContext: async () => {}
     }
 
     const fn = browserlessFunction(({ page }) => 'ok', {

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -700,6 +700,65 @@ test('reuse browserless instance across page function invocations', t => {
   t.is(destroyContextCalls, 2)
 })
 
+test('destroys the browser context when withPage fails (subprocess)', t => {
+  const browserlessFunctionPath = require.resolve('..')
+  const script = `
+    const Module = require('module')
+    const originalLoad = Module._load
+
+    Module._load = function (request, parent, isMain) {
+      if (request === 'isolated-function') {
+        return ({ tmpdir } = {}) => {
+          const instance = () => async () => ({ isFulfilled: true, value: 'ok' })
+          instance.teardown = async () => {}
+          return instance
+        }
+      }
+      return originalLoad(request, parent, isMain)
+    }
+
+    const browserlessFunction = require(${JSON.stringify(browserlessFunctionPath)})()
+    let destroyContextCalls = 0
+
+    const fakeBrowserless = {
+      withPage: () => async () => {
+        throw new Error('goto failed')
+      },
+      destroyContext: async () => {
+        destroyContextCalls += 1
+      }
+    }
+
+    const fn = browserlessFunction(({ page }) => 'ok', {
+      getBrowserless: async () => ({
+        createContext: async () => fakeBrowserless
+      })
+    })
+
+    Promise.resolve()
+      .then(() => fn('https://example.com'))
+      .then(() => {
+        process.stderr.write('expected rejection')
+        process.exit(1)
+      })
+      .catch(error => {
+        process.stdout.write(JSON.stringify({
+          message: error.message,
+          destroyContextCalls
+        }))
+      })
+  `
+
+  const { status, stdout, stderr } = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8'
+  })
+
+  t.is(status, 0, stderr)
+  const { message, destroyContextCalls } = JSON.parse(stdout.trim())
+  t.is(message, 'goto failed')
+  t.is(destroyContextCalls, 1)
+})
+
 test('retry getBrowserless on next call when initial creation fails', t => {
   const browserlessFunctionPath = require.resolve('..')
   const script = `

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -140,7 +140,7 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
           isReady = await checkPageReady(page, { isPageReady, response, screenshot, isWhite })
 
           const remaining = pollTimeout - elapsed()
-          if (!isReady && !didHydrateAttempt && !isWhite) {
+          if (!isReady && !didHydrateAttempt) {
             didHydrateAttempt = true
             const { hydrated, info } = await tryHydrateScroll(page, remaining)
             didHydrateScroll = hydrated

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -191,7 +191,9 @@ module.exports = ({ goto, ...gotoOpts }) => {
             () =>
               page.screenshot({
                 ...opts,
-                ...(opts.fullPage ? { fullPage: false, path: undefined } : {})
+                ...(opts.fullPage
+                  ? { fullPage: false, path: undefined, quality: undefined }
+                  : {})
               }),
             { page, goto, timeout }
           )

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -206,7 +206,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
           if (isReady || elapsed() >= timeout) break
 
           const remaining = timeout - elapsed()
-          if (opts.fullPage && !didHydrateAttempt && !isWhite) {
+          if (opts.fullPage && !didHydrateAttempt) {
             didHydrateAttempt = true
             const { hydrated, info } = await tryHydrateScroll(page, remaining)
             didHydrateScroll = hydrated

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -222,7 +222,7 @@ const prepareFullDocument = async (page, { goto, timeout, scrolled = false } = {
       duration: elapsed()
     })
 
-    await scrollFullPageToLoadContent(page, scrollTimeout)
+    await pReflect(scrollFullPageToLoadContent(page, scrollTimeout))
     debug('prepareFullDocument:scroll', { duration: elapsed() })
   } else {
     debug('prepareFullDocument:skipScroll', { duration: elapsed() })

--- a/packages/screenshot/test/prepare-full-document.js
+++ b/packages/screenshot/test/prepare-full-document.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const test = require('ava')
+
+const { prepareFullDocument } = require('../src/prepare-full-document')
+
+test('prepareFullDocument tolerates navigation during the scroll', async t => {
+  const goto = {
+    timeouts: {
+      action: () => 1000,
+      goto: () => 1000
+    }
+  }
+
+  const page = {
+    evaluate: async () => {
+      throw new Error('Execution context was destroyed, most likely because of a navigation.')
+    }
+  }
+
+  const result = await prepareFullDocument(page, { goto, timeout: 1000 })
+  t.is(result.expanded, false)
+  t.is(result.scrolled, false)
+  t.true(typeof result.duration === 'number')
+})

--- a/packages/screenshot/test/white-retry.js
+++ b/packages/screenshot/test/white-retry.js
@@ -166,6 +166,55 @@ test('stops white screenshot retries after timeout', async t => {
   t.is(page.getScreenshotCalls(), goto.getWaitUntilAutoCalls() + 1)
 })
 
+test('hydrates fullPage while the viewport is still white', async t => {
+  const prepareModulePath = require.resolve('../src/prepare-full-document.js')
+  const originalPrepareModule = require.cache[prepareModulePath]
+  let hydrateCalls = 0
+
+  const prepareExports = {
+    ...require('../src/prepare-full-document'),
+    tryHydrateScroll: async () => {
+      hydrateCalls += 1
+      return { hydrated: true, info: { hydrated: true } }
+    },
+    prepareFullDocument: async () => ({ expanded: false, duration: 0, scrolled: true }),
+    expandOverflow: async () => false
+  }
+
+  require.cache[prepareModulePath] = {
+    id: prepareModulePath,
+    filename: prepareModulePath,
+    loaded: true,
+    exports: prepareExports
+  }
+
+  let whiteCalls = 0
+  const isWhiteScreenshotMock = async () => ++whiteCalls === 1
+  const { createScreenshot, restore } = loadCreateScreenshot(isWhiteScreenshotMock)
+  t.teardown(() => {
+    restore()
+    delete require.cache[prepareModulePath]
+    if (originalPrepareModule) {
+      require.cache[prepareModulePath] = originalPrepareModule
+    }
+  })
+
+  const goto = createGoto({ timeout: 5000 })
+  const white = Buffer.from('white')
+  const ready = Buffer.from('ready')
+  const page = createPage([white, ready, ready])
+  const screenshot = createScreenshot({ goto })(page)
+
+  const result = await screenshot('https://example.com', {
+    waitUntil: 'auto',
+    fullPage: true,
+    codeScheme: false
+  })
+
+  t.deepEqual(result, ready)
+  t.is(hydrateCalls, 1)
+})
+
 test('waits for verification interstitial to resolve before screenshot', async t => {
   const isWhiteScreenshotMock = async () => false
   const { createScreenshot, restore } = loadCreateScreenshot(isWhiteScreenshotMock)

--- a/packages/screenshot/test/white-retry.js
+++ b/packages/screenshot/test/white-retry.js
@@ -256,3 +256,38 @@ test('waits for verification interstitial to resolve before screenshot', async t
   t.is(goto.getWaitUntilAutoCalls(), 2)
   t.is(page.getScreenshotCalls(), 3)
 })
+
+// #852's fullPage readiness probe clears `path` so it does not write during the
+// white check. #858 keeps `quality` when that path looked lossy. Together the
+// probe becomes `{ quality }` with puppeteer's png default and throws.
+test('fullPage readiness probe drops path-inferred quality', async t => {
+  const isWhiteScreenshotMock = async () => false
+  const { createScreenshot, restore } = loadCreateScreenshot(isWhiteScreenshotMock)
+  t.teardown(restore)
+
+  const goto = createGoto()
+  const page = createPage([Buffer.from('probe'), Buffer.from('full')])
+  const seen = []
+  page.screenshot = async opts => {
+    seen.push(opts)
+    return Buffer.from(`shot-${seen.length}`)
+  }
+
+  const screenshot = createScreenshot({ goto })(page)
+  const result = await screenshot('https://example.com', {
+    waitUntil: 'auto',
+    codeScheme: false,
+    fullPage: true,
+    path: '/tmp/out.jpg',
+    quality: 80
+  })
+
+  t.true(Buffer.isBuffer(result))
+  t.is(seen.length, 2)
+  t.is(seen[0].fullPage, false)
+  t.is(seen[0].path, undefined)
+  t.is(seen[0].quality, undefined)
+  t.is(seen[1].fullPage, true)
+  t.is(seen[1].path, '/tmp/out.jpg')
+  t.is(seen[1].quality, 80)
+})


### PR DESCRIPTION
## Summary

Combines draft PRs [#862](https://github.com/microlinkhq/browserless/pull/862), [#865](https://github.com/microlinkhq/browserless/pull/865), [#866](https://github.com/microlinkhq/browserless/pull/866), and [#867](https://github.com/microlinkhq/browserless/pull/867).

- **screenshot/pdf readiness:** allow `tryHydrateScroll` while the viewport is still white so overflow/lazy SPAs can recover before `prepareFullDocument` (#862)
- **screenshot probe + prepare:** drop `quality` from the fullPage white probe (avoids `png screenshots do not support 'quality'`), and wrap prepare scroll in `pReflect` for SPA mid-scroll navigations (#865)
- **function:** always `destroyContext()` after each page-using invocation so contexts do not accumulate (#866)
- **browserless:** close the previous BrowserContext when `withPage` retries create a replacement (#867)

## Test plan

- [ ] `pnpm exec ava test/white-retry.js test/prepare-full-document.js` (screenshot)
- [ ] `pnpm -C packages/function test`
- [ ] `pnpm exec ava test/index.js -m 'withPage retries transient context*'` (browserless)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser session recovery after temporary connection failures.
  * Ensured browser contexts are cleaned up after successful or failed page operations.
  * Improved full-page screenshot handling during navigation and scrolling errors.

* **Improvements**
  * PDF generation now hydrates pages even when the latest screenshot appears blank.
  * Full-page screenshots better support blank initial pages and preserve final capture quality settings.
  * Added more reliable readiness detection for dynamically loaded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->