### PR TITLE
ci: auto-publish to npm when commits land on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - master
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  SKIP_INSTALL_SIMPLE_GIT_HOOKS: true
+
 jobs:
   contributors:
     if: "${{ github.event.head_commit.message != 'build: contributors' }}"
@@ -14,6 +21,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
@@ -32,6 +40,7 @@ jobs:
       - name: Push changes
         run: |
           git push origin ${{ github.head_ref }}
+
   matrix:
     runs-on: ubuntu-latest
     steps:
@@ -42,6 +51,25 @@ jobs:
       - run: echo ${{ steps.matrix.outputs.matrix }}
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+      - name: Install
+        run: pnpm install --dangerously-allow-all-builds
+      - name: Lint
+        run: pnpm lint
+
   test:
     name: Test ${{ matrix.package.name }}
     if: |
@@ -91,3 +119,42 @@ jobs:
         with:
           parallel-finished: true
           fail-on-error: false
+
+  release:
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+      - name: Install
+        run: pnpm install --dangerously-allow-all-builds
+      - name: Sync master
+        run: |
+          git config --global user.email ${{ secrets.GIT_EMAIL }}
+          git config --global user.name ${{ secrets.GIT_USERNAME }}
+          git pull origin master
+      - name: Install GL runtime
+        # libgl1-mesa-dri ships on the ubuntu-24.04 runner; only install (and
+        # refresh the index) on the off chance a future image drops it.
+        run: dpkg -s libgl1-mesa-dri >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y --no-install-recommends libgl1-mesa-dri)
+      - name: Test
+        run: xvfb-run -a pnpm --recursive --sequential test
+      - name: Release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
+          pnpm run release

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "cssnano-preset-advanced": "latest",
     "finepack": "latest",
     "git-authors-cli": "latest",
-    "github-generate-release": "latest",
     "gulp": "4",
     "gulp-concat": "latest",
     "gulp-postcss": "latest",
@@ -134,9 +133,8 @@
     "dev": "concurrently \"gulp\" \"npm run dev:server\"",
     "dev:server": "browser-sync start --server --files \"index.html, README.md, static/**/*.(css|js)\"",
     "lint": "standard",
-    "postrelease": "github-generate-release",
     "pretest": "pnpm run lint",
-    "release": "lerna publish --yes --sort --conventional-commits --changelog-preset conventionalcommits -m \"chore(release): %s\"",
+    "release": "lerna publish --yes --sort --conventional-commits --changelog-preset conventionalcommits --create-release github -m \"chore(release): %s\"",
     "test": "c8 pnpm --recursive --sequential test",
     "update": "pnpm --recursive --parallel exec ncu -u"
   },


### PR DESCRIPTION
## Summary
- Automate Lerna releases on `master` the same way as keyvhq: after lint/tests pass, CI runs `pnpm run release` with npm + GitHub Release publishing
- Keep browserless-specific xvfb/GL setup for the release re-test
- Drop manual `github-generate-release` / `postrelease` in favor of Lerna `--create-release github`

## Test plan
- [ ] Confirm repo secret `NPM_TOKEN` is set (currently missing; `GH_TOKEN`, `GIT_EMAIL`, `GIT_USERNAME` already exist)
- [ ] Merge a conventional commit to `master` and verify the release job publishes changed packages and creates a GitHub Release
- [ ] Confirm `chore(release):` commits skip the test/release loop
- [ ] Confirm lint + matrix tests still pass on master


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release reliability by adding lint validation and ensuring tests complete before publishing.
  * Prevented overlapping releases for the same branch or tag.

* **Chores**
  * Streamlined GitHub and npm authentication during releases.
  * Simplified the release process by removing an unnecessary release-generation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->