### PR TITLE
feat(cli): add load timings to page-weight

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,7 +47,7 @@ The `@browserless/cli` package allows you to:
 | `html <url>` | Serialize the page content to HTML |
 | `text <url>` | Extract plain text content from the page |
 | `lighthouse <url>` | Run a Google Lighthouse audit and output JSON report |
-| `page-weight <url>` | Analyze network requests and resource sizes |
+| `page-weight <url>` | Analyze network requests, resource sizes, and basic load timings |
 | `ping <url>` | Get response info: status code, redirects, headers |
 | `status <url>` | Get the HTTP status code |
 | `goto <url>` | Navigate to a URL and return page/response info |

--- a/packages/cli/src/commands/page-weight.js
+++ b/packages/cli/src/commands/page-weight.js
@@ -2,7 +2,8 @@
 
 const prettyBytes = require('pretty-bytes')
 
-const prettyMs = ms => (ms == null ? null : `${Math.round(ms)} ms`)
+// Navigation Timing uses 0 for milestones that haven't been recorded.
+const timing = (ms, label) => (ms > 0 ? `${Math.round(ms)} ms ${label}` : null)
 
 module.exports = async ({ url, browserless, opts }) => {
   const getPageWeight = browserless.evaluate(async page =>
@@ -16,10 +17,10 @@ module.exports = async ({ url, browserless, opts }) => {
           transferredSize: resource.transferSize,
           decodedBodySize: resource.decodedBodySize
         })),
-        ttfb: nav?.responseStart ?? null,
-        fcp: fcp?.startTime ?? null,
-        domContentLoaded: nav?.domContentLoadedEventEnd ?? null,
-        loadEventEnd: nav?.loadEventEnd ?? null
+        ttfb: nav?.responseStart,
+        fcp: fcp?.startTime,
+        domContentLoaded: nav?.domContentLoadedEventEnd,
+        loadEventEnd: nav?.loadEventEnd
       }
     })
   )
@@ -41,10 +42,10 @@ module.exports = async ({ url, browserless, opts }) => {
     `${resources.length} network requests`,
     `${transferSize} transferred bytes`,
     `${resourcesSize} resources bytes`,
-    ttfb != null && `${prettyMs(ttfb)} TTFB`,
-    fcp != null && `${prettyMs(fcp)} FCP`,
-    domContentLoaded != null && `${prettyMs(domContentLoaded)} DOMContentLoaded`,
-    loadEventEnd != null && `${prettyMs(loadEventEnd)} load`
+    timing(ttfb, 'TTFB'),
+    timing(fcp, 'FCP'),
+    timing(domContentLoaded, 'DOMContentLoaded'),
+    timing(loadEventEnd, 'load')
   ].filter(Boolean)
 
   return ['\n' + lines.map(line => `  ⬩ ${line}`).join('\n')]

--- a/packages/cli/src/commands/page-weight.js
+++ b/packages/cli/src/commands/page-weight.js
@@ -2,17 +2,29 @@
 
 const prettyBytes = require('pretty-bytes')
 
+const prettyMs = ms => (ms == null ? null : `${Math.round(ms)} ms`)
+
 module.exports = async ({ url, browserless, opts }) => {
-  const pageResources = browserless.evaluate(async page =>
-    page.evaluate(() =>
-      window.performance.getEntriesByType('resource').map(resource => ({
-        transferredSize: resource.transferSize,
-        decodedBodySize: resource.decodedBodySize
-      }))
-    )
+  const getPageWeight = browserless.evaluate(async page =>
+    page.evaluate(() => {
+      const nav = performance.getEntriesByType('navigation')[0]
+      const paint = performance.getEntriesByType('paint')
+      const fcp = paint.find(e => e.name === 'first-contentful-paint')
+
+      return {
+        resources: performance.getEntriesByType('resource').map(resource => ({
+          transferredSize: resource.transferSize,
+          decodedBodySize: resource.decodedBodySize
+        })),
+        ttfb: nav?.responseStart ?? null,
+        fcp: fcp?.startTime ?? null,
+        domContentLoaded: nav?.domContentLoadedEventEnd ?? null,
+        loadEventEnd: nav?.loadEventEnd ?? null
+      }
+    })
   )
 
-  const resources = await pageResources(url, opts)
+  const { resources, ttfb, fcp, domContentLoaded, loadEventEnd } = await getPageWeight(url, opts)
 
   const [transferSize, resourcesSize] = resources
     .reduce(
@@ -25,10 +37,15 @@ module.exports = async ({ url, browserless, opts }) => {
     )
     .map(prettyBytes)
 
-  const resume = `
-  ⬩ ${resources.length} network requests
-  ⬩ ${transferSize} transferred bytes
-  ⬩ ${resourcesSize} resources bytes`
+  const lines = [
+    `${resources.length} network requests`,
+    `${transferSize} transferred bytes`,
+    `${resourcesSize} resources bytes`,
+    ttfb != null && `${prettyMs(ttfb)} TTFB`,
+    fcp != null && `${prettyMs(fcp)} FCP`,
+    domContentLoaded != null && `${prettyMs(domContentLoaded)} DOMContentLoaded`,
+    loadEventEnd != null && `${prettyMs(loadEventEnd)} load`
+  ].filter(Boolean)
 
-  return [resume]
+  return ['\n' + lines.map(line => `  ⬩ ${line}`).join('\n')]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI-only output change using standard Performance APIs; no security, auth, or data-handling impact.
> 
> **Overview**
> Extends the CLI **`page-weight`** command so it reports **basic load timings** in addition to request counts and byte totals.
> 
> The in-page evaluation now reads **Navigation Timing** and **Paint** entries and returns **TTFB**, **FCP**, **DOMContentLoaded**, and **load** alongside resource sizes. A small **`timing`** helper omits milestones that are still `0` (unrecorded). Output is built as a filtered bullet list with the same `⬩` formatting.
> 
> **README** updates the command description to mention load timings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f924286e2316998d8b08275307ab385693b951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the `page-weight` command to report key page load timings, including time to first byte, first contentful paint, DOM content loaded, and full load completion.
  * Timing values are displayed in milliseconds alongside network request and resource size details.

* **Documentation**
  * Updated command documentation to describe the new load timing metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->