### PR TITLE
fix(function): resolve nodePaths under an isolated store

### DIFF
--- a/packages/function/src/index.js
+++ b/packages/function/src/index.js
@@ -6,8 +6,15 @@ const requireOneOf = require('require-one-of')
 const createRunFunction = require('./function')
 const path = require('path')
 
+// `isolated-function` reads these to know which dependencies a snippet requires
+// are already on disk, so it can skip installing them. Walking up from a
+// dependency only lands on the consumer's `node_modules` under a flat install:
+// with pnpm it lands inside the isolated store, which holds that dependency's
+// own dependencies and nothing else, so every snippet paid a fresh install.
+// `module.paths` is the resolution chain Node itself would use from here, so it
+// reaches the consumer under either layout.
 const cloudflareDir = path.dirname(require.resolve('@cloudflare/puppeteer/package.json'))
-const nodePaths = [path.resolve(cloudflareDir, '..', '..')]
+const nodePaths = [...new Set([path.resolve(cloudflareDir, '..', '..'), ...module.paths])]
 
 const stringify = fn => fn.toString().trim().replace(/;$/, '')
 

--- a/packages/function/test/index.js
+++ b/packages/function/test/index.js
@@ -812,3 +812,15 @@ test('isHttpResponse rejects non-response values', t => {
   // serializeResponse with "response.status is not a function"
   t.false(isHttpResponse({ isFulfilled: true, isRejected: false, value: undefined }))
 })
+
+test('a dependency already present is not installed again', async t => {
+  // `lodash` is a devDependency of this package, so it is on disk before the
+  // snippet runs. Resolving `nodePaths` by walking up from `@cloudflare/puppeteer`
+  // only found it under a flat install; with pnpm it landed in the isolated store
+  // and every snippet paid a fresh install of something already there.
+  const code = async () => require('lodash').VERSION
+
+  const { profiling } = await browserlessFunction(code, opts)(fileUrl)
+
+  t.is(profiling.phases.install, 0)
+})


### PR DESCRIPTION
## Problem

`nodePaths` tells `isolated-function` which dependencies a snippet requires are already on disk, so it can skip installing them ([`compile/index.js`](https://github.com/microlinkhq/browserless/blob/master/packages/function/src/index.js) → `dependencies` filter).

It was derived by walking two levels up from `@cloudflare/puppeteer`:

```js
const cloudflareDir = path.dirname(require.resolve('@cloudflare/puppeteer/package.json'))
const nodePaths = [path.resolve(cloudflareDir, '..', '..')]
```

That lands on the consumer's `node_modules` only under a flat (npm/yarn) install. Under pnpm it lands inside the isolated store:

```
nodePath: node_modules/.pnpm/@cloudflare+puppeteer@1.2.0/node_modules
entries:  @cloudflare @puppeteer debug devtools-protocol ws
```

which holds that package's own dependencies and nothing else. The check never matches, so every snippet installs a package that is already present.

## Measured

Compiling a snippet that requires `cheerio`, clean tmpdir each round:

```
round 1  shipped install=414ms   fixed install=0ms
round 2  shipped install=403ms   fixed install=0ms
round 3  shipped install=402ms   fixed install=0ms
```

This repo installs with pnpm, so it is hitting this too — the existing `interact with npm modules` test reinstalls `lodash`, a devDependency of this package, on every run.

## Fix

`module.paths` is the resolution chain Node itself would use from this file, so it reaches the consumer under either layout. The original entry is kept ahead of it, which leaves a flat install byte-identical.

## Test

`a dependency already present is not installed again` asserts `profiling.phases.install === 0` for a snippet requiring `lodash`.

- without the fix: `420.096458` vs expected `0` — fails
- with the fix: passes
- full `packages/function` suite: 36 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to how install skip paths are computed; no auth, security, or API surface changes.
> 
> **Overview**
> **Fixes redundant npm installs** when user snippets `require()` packages that are already on disk under **pnpm** (and keeps flat npm/yarn behavior unchanged).
> 
> `nodePaths` passed to `isolated-function` is expanded from a single path (two levels up from `@cloudflare/puppeteer`) to a **deduped list** that still leads with that path and also includes **`module.paths`**, so dependency checks reach the consumer’s `node_modules` instead of stopping inside pnpm’s isolated store.
> 
> Adds a test that a snippet requiring **`lodash`** (already a devDependency) reports **`profiling.phases.install === 0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbdeb208fd08fd18a245aec2b5886897872886dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution across different package installation layouts.
  * Prevented unnecessary reinstallation of dependencies that are already available locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->