### PR TITLE
feat(goto): add actions runner with locators and auto-batching

### DIFF
--- a/packages/goto/src/actions/batch.js
+++ b/packages/goto/src/actions/batch.js
@@ -1,0 +1,49 @@
+'use strict'
+
+/**
+ * Parallel-safe batch key, or null for barrier actions.
+ *
+ * `pdf` is a barrier: it toggles print media emulation on the shared page.
+ *
+ * @param {string} type
+ * @returns {'inject'|'screenshot'|null}
+ */
+const batchKey = type => {
+  if (type === 'inject') return 'inject'
+  if (type === 'screenshot') return 'screenshot'
+  return null
+}
+
+/**
+ * Group consecutive parallel-safe actions into waves.
+ *
+ * @param {Array<{ type: string }>} actions
+ * @returns {Array<{ key: string|null, actions: object[], startIndex: number }>}
+ */
+const batchActions = actions => {
+  const waves = []
+  let current = null
+
+  for (let i = 0; i < actions.length; i++) {
+    const action = actions[i]
+    const key = batchKey(action.type)
+
+    if (key && current && current.key === key) {
+      current.actions.push(action)
+      continue
+    }
+
+    if (key) {
+      current = { key, actions: [action], startIndex: i }
+      waves.push(current)
+      continue
+    }
+
+    current = null
+    waves.push({ key: null, actions: [action], startIndex: i })
+  }
+
+  return waves
+}
+
+module.exports = { batchActions, batchKey }

--- a/packages/goto/src/actions/handlers.js
+++ b/packages/goto/src/actions/handlers.js
@@ -1,0 +1,164 @@
+'use strict'
+
+const { setTimeout } = require('node:timers/promises')
+
+const { toSelector, hasElementLocator, isSet } = require('./locator')
+
+/**
+ * Clamp a per-action timeout to the remaining request budget.
+ *
+ * @param {string|number|undefined} value
+ * @param {number} budget
+ * @returns {number}
+ */
+const clampTimeout = (value, budget) => {
+  if (value == null || value === '') return budget
+  let ms = value
+  if (typeof value === 'string') {
+    const match = value.trim().match(/^(\d+(?:\.\d+)?)\s*(ms|s)?$/i)
+    if (!match) return budget
+    ms = match[2] && match[2].toLowerCase() === 's' ? Number(match[1]) * 1000 : Number(match[1])
+  }
+  if (!Number.isFinite(ms) || ms < 0) return budget
+  return Math.min(ms, budget)
+}
+
+const MAX_GLOB_LENGTH = 512
+
+const globToRegExp = pattern => {
+  const raw = String(pattern)
+  if (raw.length > MAX_GLOB_LENGTH) {
+    throw new Error(`wait: request pattern exceeds ${MAX_GLOB_LENGTH} characters`)
+  }
+  const source = raw
+    .split('*')
+    .map(part => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('[\\s\\S]*')
+  return new RegExp(`^${source}$`)
+}
+
+const waitForText = (page, action, timeout) =>
+  page.waitForFunction(
+    (text, hidden) => {
+      const body = document.body ? document.body.innerText || '' : ''
+      const present = body.includes(text)
+      return hidden ? !present : present
+    },
+    { timeout },
+    action.text,
+    Boolean(action.hidden)
+  )
+
+const waitForResponse = async (page, action, { timeout, responseBuffer }) => {
+  const pattern = globToRegExp(action.request)
+  const match = res => {
+    try {
+      return pattern.test(res.url())
+    } catch {
+      return false
+    }
+  }
+
+  const consume = response => {
+    const index = responseBuffer.indexOf(response)
+    if (index !== -1) responseBuffer.splice(index, 1)
+    return response
+  }
+
+  const buffered = responseBuffer.find(match)
+  if (buffered) return consume(buffered)
+
+  return consume(await page.waitForResponse(match, { timeout }))
+}
+
+const handlers = {
+  async inject (page, action, { inject, timeout }) {
+    await inject(page, {
+      timeout: clampTimeout(action.timeout, timeout),
+      styles: action.styles,
+      scripts: action.scripts,
+      modules: action.modules
+    })
+  },
+
+  async click (page, action, { timeout }) {
+    await page.locator(toSelector(action)).setTimeout(clampTimeout(action.timeout, timeout)).click()
+  },
+
+  async wait (page, action, { timeout, responseBuffer }) {
+    const budget = clampTimeout(action.timeout, timeout)
+
+    if (hasElementLocator(action)) {
+      return page.waitForSelector(toSelector(action), {
+        timeout: budget,
+        visible: action.visible,
+        hidden: action.hidden
+      })
+    }
+    if (isSet(action.text)) return waitForText(page, action, budget)
+    if (isSet(action.request)) {
+      return waitForResponse(page, action, { timeout: budget, responseBuffer })
+    }
+    if (isSet(action.timeout)) return setTimeout(budget)
+    throw new Error('wait: no target')
+  },
+
+  async scroll (page, action, { timeout }) {
+    if (hasElementLocator(action)) {
+      const selector = toSelector(action)
+      await page.waitForSelector(selector, { timeout: clampTimeout(action.timeout, timeout) })
+      await page.$eval(selector, el => el.scrollIntoView())
+      return
+    }
+    const x = action.x || 0
+    const y = action.y || 0
+    await page.evaluate((scrollX, scrollY) => window.scrollBy(scrollX, scrollY), x, y)
+  },
+
+  async fill (page, action, { timeout }) {
+    await page
+      .locator(toSelector(action))
+      .setTimeout(clampTimeout(action.timeout, timeout))
+      .fill(String(action.value ?? ''))
+  },
+
+  async evaluate (page, action) {
+    await page.evaluate(action.expression)
+  },
+
+  async screenshot (page, action, { actionCaptures, index, timeout }) {
+    const opts = {}
+    if (action.fullPage != null) opts.fullPage = action.fullPage
+    if (hasElementLocator(action)) {
+      const element = await page.waitForSelector(toSelector(action), {
+        timeout: clampTimeout(action.timeout, timeout)
+      })
+      if (element) {
+        try {
+          const box = await element.boundingBox()
+          if (box) opts.clip = box
+        } finally {
+          await element.dispose()
+        }
+      }
+    }
+    const buffer = await page.screenshot(opts)
+    actionCaptures.screenshots.push({ buffer, opts, index })
+    return buffer
+  },
+
+  async pdf (page, action, { actionCaptures, index }) {
+    const opts = {}
+    if (action.format != null) opts.format = action.format
+    if (action.scale != null) opts.scale = action.scale
+    if (action.margin != null) opts.margin = action.margin
+    if (action.printBackground != null) opts.printBackground = action.printBackground
+    const buffer = await page.pdf(opts)
+    actionCaptures.pdfs.push({ buffer, opts, index })
+    return buffer
+  }
+}
+
+module.exports = handlers
+module.exports.clampTimeout = clampTimeout
+module.exports.globToRegExp = globToRegExp

--- a/packages/goto/src/actions/index.js
+++ b/packages/goto/src/actions/index.js
@@ -1,0 +1,103 @@
+'use strict'
+
+const debug = require('debug-logfmt')('browserless:goto:actions')
+
+const { hasElementLocator, isSet } = require('./locator')
+const { batchActions } = require('./batch')
+const handlers = require('./handlers')
+
+const MAX_BUFFERED_RESPONSES = 100
+
+const waitMode = action => {
+  if (hasElementLocator(action)) return 'element'
+  if (isSet(action.text)) return 'text'
+  if (isSet(action.request)) return 'request'
+  if (isSet(action.timeout)) return 'timeout'
+  return 'unknown'
+}
+
+/**
+ * Run a flat ordered list of browser actions with internal auto-batching.
+ *
+ * `timeout` is the budget for the whole list: every action draws from the same
+ * deadline, so the total run time never grows with the action count.
+ *
+ * @param {import('puppeteer').Page} page
+ * @param {Array<Record<string, *>>} actions
+ * @param {object} ctx
+ * @param {Function} ctx.inject
+ * @param {Function} ctx.run
+ * @param {number} ctx.timeout
+ * @returns {Promise<{ screenshots: object[], pdfs: object[] }>}
+ */
+const runActions = async (page, actions, { inject, run, timeout }) => {
+  const actionCaptures = { screenshots: [], pdfs: [] }
+  const responseBuffer = []
+  const deadline = Date.now() + timeout
+  const remaining = () => Math.max(0, deadline - Date.now())
+
+  const onResponse = response => {
+    if (responseBuffer.length === MAX_BUFFERED_RESPONSES) responseBuffer.shift()
+    responseBuffer.push(response)
+  }
+  page.on('response', onResponse)
+
+  try {
+    const waves = batchActions(actions)
+
+    for (const wave of waves) {
+      const runOne = async (action, index) => {
+        const handler = handlers[action.type]
+        if (!handler) throw new Error(`actions[${index}]: unknown type "${action.type}"`)
+
+        const label = action.type === 'wait' ? `wait:${waitMode(action)}` : action.type
+        const budget = remaining()
+
+        // a zero budget disables the timeout in both `run` and Puppeteer
+        if (budget === 0) throw new Error(`actions[${index}] (${label}): budget exhausted`)
+
+        const result = await run({
+          fn: handler(page, action, {
+            inject,
+            timeout: budget,
+            responseBuffer,
+            actionCaptures,
+            index
+          }),
+          timeout: budget,
+          debug: { action: label, index }
+        })
+
+        if (result.isRejected) {
+          const message = result.reason?.message || String(result.reason)
+          const error = new Error(`actions[${index}] (${label}) failed: ${message}`)
+          error.cause = result.reason
+          throw error
+        }
+
+        return result.value
+      }
+
+      if (wave.actions.length === 1) {
+        await runOne(wave.actions[0], wave.startIndex)
+        continue
+      }
+
+      await Promise.all(
+        wave.actions.map((action, offset) => runOne(action, wave.startIndex + offset))
+      )
+    }
+  } finally {
+    page.off('response', onResponse)
+  }
+
+  debug('done', {
+    count: actions.length,
+    screenshots: actionCaptures.screenshots.length,
+    pdfs: actionCaptures.pdfs.length
+  })
+
+  return actionCaptures
+}
+
+module.exports = { runActions, batchActions, handlers, waitMode }

--- a/packages/goto/src/actions/locator.js
+++ b/packages/goto/src/actions/locator.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const LOCATOR_KEYS = ['selector', 'role', 'text', 'label', 'placeholder', 'testId', 'alt']
+
+const ELEMENT_LOCATOR_KEYS = LOCATOR_KEYS.filter(key => key !== 'text')
+
+const escape = value => String(value).replaceAll('\\', '\\\\').replaceAll('"', '\\"')
+
+const escapeText = value =>
+  String(value).replaceAll('\\', '\\\\').replaceAll('(', '\\(').replaceAll(')', '\\)')
+
+const isSet = value => value != null && value !== ''
+
+/**
+ * Compile an action's locator fields into a Puppeteer P-selector string.
+ *
+ * @param {Record<string, *>} action
+ * @returns {string}
+ */
+const toSelector = action => {
+  if (isSet(action.selector)) return action.selector
+  if (isSet(action.role)) {
+    const name = isSet(action.name) ? `[name="${escape(action.name)}"]` : ''
+    return `::-p-aria([role="${escape(action.role)}"]${name})`
+  }
+  if (isSet(action.text)) return `::-p-text(${escapeText(action.text)})`
+  if (isSet(action.label)) return `::-p-aria([name="${escape(action.label)}"])`
+  if (isSet(action.placeholder)) return `[placeholder="${escape(action.placeholder)}"]`
+  if (isSet(action.testId)) return `[data-testid="${escape(action.testId)}"]`
+  if (isSet(action.alt)) return `[alt="${escape(action.alt)}"]`
+  throw new Error('locator: no strategy')
+}
+
+/**
+ * Whether the action carries an element-locator strategy (not page-text wait mode).
+ * On `wait`, `text` is page-string mode — not an element locator.
+ *
+ * @param {Record<string, *>} action
+ * @returns {boolean}
+ */
+const hasElementLocator = action => {
+  const keys = action.type === 'wait' ? ELEMENT_LOCATOR_KEYS : LOCATOR_KEYS
+  return keys.some(key => isSet(action[key]))
+}
+
+module.exports = {
+  ELEMENT_LOCATOR_KEYS,
+  LOCATOR_KEYS,
+  escape,
+  escapeText,
+  hasElementLocator,
+  isSet,
+  toSelector
+}

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -12,6 +12,7 @@ const { DEFAULT_INTERCEPT_RESOLUTION_PRIORITY } = require('puppeteer')
 
 const adblock = require('./adblock')
 const dismiss = require('./dismiss')
+const { runActions } = require('./actions')
 
 const debug = require('debug-logfmt')('browserless:goto')
 debug.continue = require('debug-logfmt')('browserless:goto:continue')
@@ -227,6 +228,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
   const timeouts = {
     base: (milliseconds = globalTimeout) => Math.round(milliseconds * (2 / 3)),
     action: (milliseconds = globalTimeout) => Math.round(milliseconds * (1 / 11)),
+    actions: (milliseconds = globalTimeout) => Math.round(milliseconds * (1 / 2)),
     goto: (milliseconds = globalTimeout) => Math.round(milliseconds * (7 / 8))
   }
 
@@ -243,6 +245,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
     page,
     {
       abortTypes = [],
+      actions,
       adblock: withAdblock = true,
       animations = false,
       authenticate,
@@ -271,7 +274,10 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
   ) => {
     const baseTimeout = timeouts.base(timeout || globalTimeout)
     const actionTimeout = timeouts.action(baseTimeout)
+    const actionsTimeout = timeouts.actions(baseTimeout)
     const gotoTimeout = timeouts.goto(baseTimeout)
+
+    const hasActions = Array.isArray(actions) && actions.length > 0
 
     const isWaitUntilAuto = waitUntil === 'auto'
     if (isWaitUntilAuto) waitUntil = 'load'
@@ -288,7 +294,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       )
     }
 
-    if (modules || scripts || styles) {
+    if (modules || scripts || styles || hasActions) {
       prePromises.push(
         run({
           fn: page.setBypassCSP(true),
@@ -508,51 +514,82 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
         ])
       }
 
-      if (waitForSelector) {
-        await run({
-          fn: page.waitForSelector(waitForSelector),
-          timeout: gotoTimeout,
-          debug: { waitForSelector }
+      let actionCaptures
+
+      if (hasActions) {
+        const ignored = Object.entries({
+          click,
+          modules,
+          scripts,
+          scroll,
+          styles,
+          waitForFunction,
+          waitForSelector,
+          waitForTimeout
         })
-      }
+          .filter(([, value]) => castArray(value).length > 0)
+          .map(([name]) => name)
 
-      if (waitForFunction) {
-        await run({
-          fn: page.waitForFunction(waitForFunction),
-          timeout: gotoTimeout,
-          debug: { waitForFunction }
+        if (ignored.length > 0) debug('actions:ignoring', { ignored })
+
+        await inject(page, {
+          timeout: actionTimeout,
+          mediaType,
+          animations
         })
-      }
 
-      if (waitForTimeout) {
-        await setTimeout(waitForTimeout)
-      }
-
-      await inject(page, {
-        timeout: actionTimeout,
-        mediaType,
-        animations,
-        modules,
-        scripts,
-        styles
-      })
-
-      if (click) {
-        for (const selector of castArray(click)) {
+        actionCaptures = await runActions(page, actions, {
+          inject,
+          run,
+          timeout: actionsTimeout
+        })
+      } else {
+        if (waitForSelector) {
           await run({
-            fn: page.click(selector),
-            timeout: actionTimeout,
-            debug: { click: selector }
+            fn: page.waitForSelector(waitForSelector),
+            timeout: gotoTimeout,
+            debug: { waitForSelector }
           })
         }
-      }
 
-      if (scroll) {
-        await run({
-          fn: page.$eval(scroll, el => el.scrollIntoView()),
+        if (waitForFunction) {
+          await run({
+            fn: page.waitForFunction(waitForFunction),
+            timeout: gotoTimeout,
+            debug: { waitForFunction }
+          })
+        }
+
+        if (waitForTimeout) {
+          await setTimeout(waitForTimeout)
+        }
+
+        await inject(page, {
           timeout: actionTimeout,
-          debug: { scroll }
+          mediaType,
+          animations,
+          modules,
+          scripts,
+          styles
         })
+
+        if (click) {
+          for (const selector of castArray(click)) {
+            await run({
+              fn: page.click(selector),
+              timeout: actionTimeout,
+              debug: { click: selector }
+            })
+          }
+        }
+
+        if (scroll) {
+          await run({
+            fn: page.$eval(scroll, el => el.scrollIntoView()),
+            timeout: actionTimeout,
+            debug: { scroll }
+          })
+        }
       }
 
       if (isWaitUntilAuto) {
@@ -618,7 +655,9 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
         if (isRejected) error = error || flattenError || new Error('flattenShadowDOM failed')
       }
 
-      return { response, device, error }
+      return actionCaptures
+        ? { response, device, error, actionCaptures }
+        : { response, device, error }
     } finally {
       if (abortTypesHandler) page.off('request', abortTypesHandler)
       if (disableInterceptionForAbortTypes) {
@@ -642,3 +681,5 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
 
 module.exports.parseCookies = parseCookies
 module.exports.inject = inject
+module.exports.runActions = runActions
+module.exports.actions = require('./actions')

--- a/packages/goto/test/unit/actions/batch.js
+++ b/packages/goto/test/unit/actions/batch.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const test = require('ava')
+
+const { batchActions, batchKey } = require('../../../src/actions/batch')
+
+test('batchKey marks inject and screenshot groups', t => {
+  t.is(batchKey('inject'), 'inject')
+  t.is(batchKey('screenshot'), 'screenshot')
+  t.is(batchKey('click'), null)
+  t.is(batchKey('wait'), null)
+})
+
+test('batchKey treats pdf as a barrier', t => {
+  t.is(batchKey('pdf'), null)
+})
+
+test('batchActions groups consecutive injects', t => {
+  const waves = batchActions([
+    { type: 'inject', styles: ['a'] },
+    { type: 'inject', modules: ['b'] },
+    { type: 'click', selector: '#x' }
+  ])
+  t.is(waves.length, 2)
+  t.is(waves[0].key, 'inject')
+  t.is(waves[0].actions.length, 2)
+  t.is(waves[0].startIndex, 0)
+  t.is(waves[1].key, null)
+  t.is(waves[1].actions[0].type, 'click')
+})
+
+test('batchActions groups consecutive screenshots', t => {
+  const waves = batchActions([
+    { type: 'wait', timeout: 1 },
+    { type: 'screenshot', fullPage: true },
+    { type: 'screenshot', selector: '#hero' }
+  ])
+  t.is(waves.length, 2)
+  t.is(waves[1].key, 'screenshot')
+  t.is(waves[1].actions.length, 2)
+  t.is(waves[1].startIndex, 1)
+})
+
+test('batchActions never runs pdf beside a screenshot', t => {
+  const waves = batchActions([
+    { type: 'screenshot', fullPage: true },
+    { type: 'pdf', format: 'A4' }
+  ])
+  t.is(waves.length, 2)
+  t.true(waves.every(wave => wave.actions.length === 1))
+  t.is(waves[1].key, null)
+})
+
+test('batchActions treats barriers as singleton waves', t => {
+  const waves = batchActions([
+    { type: 'click', selector: '#a' },
+    { type: 'fill', selector: '#b', value: 'x' },
+    { type: 'wait', timeout: 10 }
+  ])
+  t.is(waves.length, 3)
+  t.true(waves.every(wave => wave.key === null && wave.actions.length === 1))
+})

--- a/packages/goto/test/unit/actions/handlers.js
+++ b/packages/goto/test/unit/actions/handlers.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const test = require('ava')
+
+const { clampTimeout, globToRegExp } = require('../../../src/actions/handlers')
+
+test('clampTimeout keeps budget when unset', t => {
+  t.is(clampTimeout(undefined, 5000), 5000)
+  t.is(clampTimeout(null, 5000), 5000)
+})
+
+test('clampTimeout parses humanized durations', t => {
+  t.is(clampTimeout('3s', 10000), 3000)
+  t.is(clampTimeout('500ms', 10000), 500)
+  t.is(clampTimeout(2000, 10000), 2000)
+})
+
+test('clampTimeout never exceeds budget', t => {
+  t.is(clampTimeout('30s', 1000), 1000)
+  t.is(clampTimeout(5000, 1000), 1000)
+})
+
+test('clampTimeout falls back to budget on invalid input', t => {
+  t.is(clampTimeout('nope', 1000), 1000)
+  t.is(clampTimeout(-1, 1000), 1000)
+})
+
+test('globToRegExp matches request patterns', t => {
+  const re = globToRegExp('*api.example.com/user*')
+  t.true(re.test('https://api.example.com/user/1'))
+  t.false(re.test('https://other.example.com/user/1'))
+})
+
+test('globToRegExp treats ? as a literal', t => {
+  const re = globToRegExp('*/user?id=*')
+  t.true(re.test('https://api.example.com/user?id=1'))
+  t.false(re.test('https://api.example.com/useid=1'))
+})
+
+test('globToRegExp escapes regex metacharacters', t => {
+  const re = globToRegExp('https://example.com/a+b(c)')
+  t.true(re.test('https://example.com/a+b(c)'))
+  t.false(re.test('https://example.com/aab(c)'))
+})
+
+test('globToRegExp rejects over-long patterns', t => {
+  t.throws(() => globToRegExp('*'.repeat(513)), {
+    message: /pattern exceeds 512 characters/
+  })
+})

--- a/packages/goto/test/unit/actions/index.js
+++ b/packages/goto/test/unit/actions/index.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const pReflect = require('p-reflect')
+const pTimeout = require('p-timeout')
+const test = require('ava')
+
+const { runActions, waitMode } = require('../../../src/actions')
+
+const run = async ({ fn, timeout }) => pReflect(timeout ? pTimeout(fn, timeout) : fn)
+
+const createPage = () => {
+  const listeners = { response: [] }
+  const pending = []
+
+  return {
+    listeners,
+    emitResponse: url => {
+      const response = { url: () => url }
+      listeners.response.forEach(fn => fn(response))
+      for (const { match, resolve } of pending.splice(0)) {
+        if (match(response)) resolve(response)
+        else pending.push({ match, resolve })
+      }
+    },
+    on: (event, fn) => listeners[event].push(fn),
+    off: (event, fn) => {
+      listeners[event] = listeners[event].filter(listener => listener !== fn)
+    },
+    waitForResponse: match => new Promise(resolve => pending.push({ match, resolve }))
+  }
+}
+
+test('waitMode classifies every wait target', t => {
+  t.is(waitMode({ type: 'wait', selector: '#a' }), 'element')
+  t.is(waitMode({ type: 'wait', role: 'button' }), 'element')
+  t.is(waitMode({ type: 'wait', text: 'Done' }), 'text')
+  t.is(waitMode({ type: 'wait', request: '*/api/*' }), 'request')
+  t.is(waitMode({ type: 'wait', timeout: '1s' }), 'timeout')
+  t.is(waitMode({ type: 'wait' }), 'unknown')
+})
+
+test('runActions rejects an unknown action type', async t => {
+  const page = createPage()
+  await t.throwsAsync(runActions(page, [{ type: 'teleport' }], { run, timeout: 1000 }), {
+    message: 'actions[0]: unknown type "teleport"'
+  })
+})
+
+test('runActions detaches the response listener when an action throws', async t => {
+  const page = createPage()
+  await t.throwsAsync(runActions(page, [{ type: 'teleport' }], { run, timeout: 1000 }))
+  t.is(page.listeners.response.length, 0)
+})
+
+test('runActions consumes a buffered response only once', async t => {
+  const page = createPage()
+  const actions = [
+    { type: 'wait', request: '*/api/*', timeout: 50 },
+    { type: 'wait', request: '*/api/*', timeout: 50 }
+  ]
+
+  const promise = runActions(page, actions, { run, timeout: 1000 })
+  page.emitResponse('https://example.com/api/one')
+
+  await t.throwsAsync(promise, {
+    message: /^actions\[1\] \(wait:request\) failed:/
+  })
+})
+
+test('runActions bounds the response buffer', async t => {
+  const page = createPage()
+  const promise = runActions(page, [{ type: 'wait', request: '*/first*', timeout: 50 }], {
+    run,
+    timeout: 1000
+  })
+
+  for (let i = 0; i < 150; i++) page.emitResponse(`https://example.com/${i}`)
+  t.is(page.listeners.response.length, 1)
+
+  await t.throwsAsync(promise)
+})
+
+test('runActions refuses to run an action on an exhausted budget', async t => {
+  const page = createPage()
+  const actions = [
+    { type: 'wait', timeout: '10s' },
+    { type: 'wait', timeout: '10s' }
+  ]
+
+  await t.throwsAsync(runActions(page, actions, { run, timeout: 0 }), {
+    message: 'actions[0] (wait:timeout): budget exhausted'
+  })
+})
+
+test('runActions shares one deadline across the whole list', async t => {
+  const page = createPage()
+  const actions = [
+    { type: 'wait', timeout: '10s' },
+    { type: 'wait', timeout: '10s' }
+  ]
+
+  const startedAt = Date.now()
+  await t.throwsAsync(runActions(page, actions, { run, timeout: 200 }), {
+    message: 'actions[1] (wait:timeout): budget exhausted'
+  })
+  t.true(Date.now() - startedAt < 400)
+})

--- a/packages/goto/test/unit/actions/locator.js
+++ b/packages/goto/test/unit/actions/locator.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const test = require('ava')
+
+const {
+  toSelector,
+  hasElementLocator,
+  escape,
+  escapeText
+} = require('../../../src/actions/locator')
+
+test('toSelector compiles CSS selector pass-through', t => {
+  t.is(toSelector({ selector: '#checkout' }), '#checkout')
+})
+
+test('toSelector compiles role + name to P-aria', t => {
+  t.is(toSelector({ role: 'button', name: 'Submit' }), '::-p-aria([role="button"][name="Submit"])')
+})
+
+test('toSelector compiles role without name', t => {
+  t.is(toSelector({ role: 'textbox' }), '::-p-aria([role="textbox"])')
+})
+
+test('toSelector compiles text / label / placeholder / testId / alt', t => {
+  t.is(toSelector({ text: 'Sign in' }), '::-p-text(Sign in)')
+  t.is(toSelector({ label: 'Email' }), '::-p-aria([name="Email"])')
+  t.is(toSelector({ placeholder: 'Search…' }), '[placeholder="Search…"]')
+  t.is(toSelector({ testId: 'submit-btn' }), '[data-testid="submit-btn"]')
+  t.is(toSelector({ alt: 'Logo' }), '[alt="Logo"]')
+})
+
+test('toSelector escapes quotes in role name', t => {
+  t.is(
+    toSelector({ role: 'button', name: 'Say "hi"' }),
+    '::-p-aria([role="button"][name="Say \\"hi\\""])'
+  )
+})
+
+test('toSelector throws without strategy', t => {
+  t.throws(() => toSelector({ type: 'click' }), { message: 'locator: no strategy' })
+})
+
+test('hasElementLocator treats wait text as page-text mode', t => {
+  t.false(hasElementLocator({ type: 'wait', text: 'Dashboard' }))
+  t.true(hasElementLocator({ type: 'wait', role: 'button', name: 'Submit' }))
+  t.true(hasElementLocator({ type: 'click', text: 'Accept' }))
+})
+
+test('escape quotes double quotes', t => {
+  t.is(escape('a"b'), 'a\\"b')
+})
+
+test('escape escapes backslashes before quotes', t => {
+  t.is(escape('a\\"b'), 'a\\\\\\"b')
+  t.is(escape('a\\b'), 'a\\\\b')
+})
+
+test('escapeText escapes backslashes and parentheses', t => {
+  t.is(escapeText('Save (draft)'), 'Save \\(draft\\)')
+  t.is(escapeText('a\\b'), 'a\\\\b')
+})
+
+test('toSelector escapes text with parentheses', t => {
+  t.is(toSelector({ text: 'Save (draft)' }), '::-p-text(Save \\(draft\\))')
+})
+
+test('hasElementLocator ignores empty locator values', t => {
+  t.false(hasElementLocator({ type: 'click', selector: '' }))
+  t.false(hasElementLocator({ type: 'wait', selector: null }))
+})

--- a/packages/pdf/src/index.js
+++ b/packages/pdf/src/index.js
@@ -73,19 +73,29 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       ...rest
     } = opts
 
+    const hasActionPdf =
+      Array.isArray(rest.actions) && rest.actions.some(action => action.type === 'pdf')
+
     if (waitUntil !== 'auto') {
-      await goto(page, { ...rest, url, waitUntil })
-      await prepareFullDocument(page, { goto, timeout: rest.timeout })
-      return
+      const { actionCaptures } = await goto(page, { ...rest, url, waitUntil })
+      if (!hasActionPdf) {
+        await prepareFullDocument(page, { goto, timeout: rest.timeout })
+      }
+      return { actionCaptures, hasActionPdf }
     }
 
     let readiness
     let isReady = false
     let didHydrateScroll = false
 
-    await goto(page, { ...rest, url, waitUntil, waitUntilAuto })
+    const { actionCaptures } = await goto(page, {
+      ...rest,
+      url,
+      waitUntil,
+      waitUntilAuto
+    })
 
-    if (isReady) {
+    if (isReady && !hasActionPdf) {
       const prep = await prepareFullDocument(page, {
         goto,
         timeout: rest.timeout,
@@ -94,9 +104,10 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
       readiness = { ...readiness, ...prep }
     }
 
-    return readiness
+    return { readiness, actionCaptures, hasActionPdf }
 
     async function waitUntilAuto (page, { response, timeout: autoTimeout } = {}) {
+      if (hasActionPdf) return
       const timeout = autoTimeout ?? goto.timeouts.action(rest.timeout)
       let didHydrateAttempt = false
 
@@ -165,7 +176,14 @@ module.exports = ({ goto, ...gotoOpts } = {}) => {
   const pdf =
     page =>
       async (url, opts = {}) => {
-        await prepare(page, url, opts)
+        const prepared = await prepare(page, url, opts)
+        if (prepared?.hasActionPdf) {
+          const last = prepared.actionCaptures?.pdfs?.at(-1)
+          if (!last?.buffer) {
+            throw new Error('actions: pdf action produced no buffer')
+          }
+          return last.buffer
+        }
         return render(page, opts)
       }
 

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -241,22 +241,33 @@ module.exports = ({ goto, ...gotoOpts }) => {
 
       try {
         const timeScreenshot = prettyTimeSpan()
+        const hasActionScreenshot =
+          Array.isArray(opts.actions) && opts.actions.some(action => action.type === 'screenshot')
+        let actionCaptures
 
         if (waitUntil !== 'auto') {
-          ;({ response } = await goto(page, { ...opts, url, waitUntil }))
-          const screenshotOpts = await beforeScreenshot(page, response, opts)
-          if (opts.fullPage) {
-            await prepareFullDocument(page, { goto, timeout: opts.timeout })
+          ;({ response, actionCaptures } = await goto(page, { ...opts, url, waitUntil }))
+          if (!hasActionScreenshot) {
+            const screenshotOpts = await beforeScreenshot(page, response, opts)
+            if (opts.fullPage) {
+              await prepareFullDocument(page, { goto, timeout: opts.timeout })
+            }
+            screenshot = await captureExpanded(
+              opts.fullPage,
+              { ...opts, ...screenshotOpts },
+              goto.timeouts.action(opts.timeout)
+            )
           }
-          screenshot = await captureExpanded(
-            opts.fullPage,
-            { ...opts, ...screenshotOpts },
-            goto.timeouts.action(opts.timeout)
-          )
           debug('screenshot', { waitUntil, duration: timeScreenshot() })
         } else {
-          ;({ response } = await goto(page, { ...opts, url, waitUntil, waitUntilAuto }))
+          ;({ response, actionCaptures } = await goto(page, {
+            ...opts,
+            url,
+            waitUntil,
+            waitUntilAuto
+          }))
           async function waitUntilAuto (page, { response }) {
+            if (hasActionScreenshot) return
             const screenshotOpts = await beforeScreenshot(page, response, opts)
             const { isWhite, isReady, retry } = await takeScreenshot({
               ...opts,
@@ -272,6 +283,14 @@ module.exports = ({ goto, ...gotoOpts }) => {
               duration: timeScreenshot()
             })
           }
+        }
+
+        if (hasActionScreenshot) {
+          const last = actionCaptures?.screenshots?.at(-1)
+          if (!last?.buffer) {
+            throw new Error('actions: screenshot action produced no buffer')
+          }
+          screenshot = last.buffer
         }
 
         return Object.keys(overlayOpts).length === 0


### PR DESCRIPTION
## Summary
- Restore #877 after it was dropped in #884.
- Add `@browserless/goto` `actions/` runner: `toSelector` P-selector compiler, unified `wait`, response buffer for `wait request`, auto-batching (`inject`+`inject`, `screenshot`+`screenshot`), timeout clamp.
- Wire post-adblock: when `actions` is present, skip legacy click/scroll/wait/inject path; return `actionCaptures` for mid-flow screenshot/pdf buffers.
- `@browserless/screenshot` / `@browserless/pdf`: when actions include a capture step, skip the redundant final capture and return the last action buffer.

## Test plan
- [ ] `ava 'test/unit/actions/**/*.js'`
- [ ] Confirm goto/screenshot/pdf unit tests still pass
- [ ] Integration: click → wait → screenshot via browserless once API parse lands


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added browser action sequences supporting injection, clicks, waits, scrolling, form filling, evaluation, screenshots, and PDF generation.
  - Added flexible element targeting using selectors, roles, text, labels, placeholders, test IDs, and alt text.
  - Added parallel execution for compatible actions while preserving action order.
  - Added action-specific timeouts, response URL waits, captured results, and shared execution deadlines.
  - Screenshot and PDF workflows now return results from configured actions.

- **Bug Fixes**
  - Improved timeout handling, response buffering, listener cleanup, and validation for unsupported or incomplete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->