### PR TITLE
test(screencast): force paints in capture frames

### DIFF
--- a/packages/screencast/test/index.js
+++ b/packages/screencast/test/index.js
@@ -80,28 +80,15 @@ test('capture frames', async t => {
 
   await screencast.start()
 
-  // Local animated page: no network, and a continuous CSS animation forces
-  // compositor commits under the GL/xvfb backend (a static page often does not).
-  await page.setContent(
-    `<!doctype html>
-<style>
-  html, body { margin: 0; height: 100%; }
-  body {
-    background: linear-gradient(90deg, #f00, #00f);
-    background-size: 200% 100%;
-    animation: slide 0.2s linear infinite;
-  }
-  @keyframes slide {
-    from { background-position: 0 0; }
-    to { background-position: 100% 0; }
-  }
-</style>
-<body></body>`,
-    { waitUntil: 'load' }
-  )
+  // Local page: no network. CSS animation alone often does not commit under
+  // GL/xvfb; mutate a style each tick so Page.startScreencast emits a frame.
+  await page.setContent('<!doctype html><body></body>', { waitUntil: 'load' })
 
   const deadline = Date.now() + 10000
   while (frames.length === 0 && Date.now() < deadline) {
+    await page.evaluate(() => {
+      document.body.style.background = `hsl(${Date.now() % 360}, 50%, 50%)`
+    })
     await new Promise(resolve => setTimeout(resolve, 50))
   }
 


### PR DESCRIPTION
## Summary
- `capture frames` failed on [PR #887 CI](https://github.com/microlinkhq/browserless/actions/runs/32409679387/job/96556982502?pr=887) with `frames.length === 0` — unrelated to the AI package.
- CSS animation does not force compositor commits under GL/xvfb. Restore a per-tick style mutation so `Page.startScreencast` emits a frame.

## Test plan
- [x] `pnpm --filter @browserless/screencast test` (11 passed)
- [ ] CI `Test @browserless/screencast` green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved screencast capture coverage with a simpler local test page.
  * Added repeated visual updates to better verify that captured frames are produced correctly.
  * Reduced reliance on CSS animations during capture validation, helping make test results more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->