### PR TITLE
docs: tighten README copy across packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ Optional name for the page, used in debug logs.
 
 ### ai
 
-The [`@browserless/ai`](https://npm.im/@browserless/ai) package runs [Chrome Built-in AI](https://developer.chrome.com/docs/ai/built-in-apis) APIs from Node:
+The [`@browserless/ai`](https://npm.im/@browserless/ai) package runs [Chrome Built-in AI](https://developer.chrome.com/docs/ai/built-in-apis) APIs from Node.js:
 
 ```js
 const createAi = require('@browserless/ai')

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Changes the default maximum navigation time.
 type: `Puppeteer`<br/>
 default: `puppeteer`|`puppeteer-core`|`puppeteer-firefox`
 
-By default, it automatically detects which libary is installed (thus either [puppeteer](https://www.npmjs.com/package/puppeteer) or [puppeteer-core](https://www.npmjs.com/package/puppeteer-core) based on your installed dependecies.
+By default, it automatically detects which library is installed — either [puppeteer](https://www.npmjs.com/package/puppeteer) or [puppeteer-core](https://www.npmjs.com/package/puppeteer-core) — based on your installed dependencies.
 
 ### .createContext(options)
 
@@ -415,7 +415,7 @@ default: `'atom-dark'`
 
 Whenever the incoming response `'Content-Type'` is set to `'json'`, the JSON payload will be presented as a formatted JSON string, beautified using the provided `codeScheme` theme or by default `atom-dark`. 
 
-The color schemes is based on the [Prism library](https://prismjs.com).
+The color scheme is based on the [Prism library](https://prismjs.com).
 
 ![](https://i.imgur.com/uFfviX7.png)
 
@@ -813,7 +813,7 @@ console.log(browserContext.id)
 
 ### .withPage(fn, [options])
 
-Returns a higher-order function as convenient way to interact with a page:
+Returns a higher-order function as a convenient way to interact with a page:
 
 ```js
 const getTitle = browserless.withPage((page, goto) => async opts => {
@@ -961,7 +961,7 @@ The [Lighthouse configuration](https://github.com/GoogleChrome/lighthouse/blob/m
 
 ```js
 const report = await lighthouse(url, {
-  onlyAudits: ['accessibility']
+  onlyCategories: ['accessibility']
 })
 ```
 
@@ -970,7 +970,7 @@ Also, you can extend from a different preset of settings:
 ```js
 const report = await lighthouse(url, {
   preset: 'desktop',
-  onlyAudits: ['accessibility']
+  onlyCategories: ['accessibility']
 })
 ```
 
@@ -1085,7 +1085,7 @@ Headless navigation is expensive compared to just fetching the content from a we
 
 To speed up the process, we block ad scripts by default because most of them are resource-intensive.
 
-**Q: My output is different from the expected**
+**Q: My output is different from what I expected**
 
 **Browserless** might have been too smart and blocked a request that you need.
 
@@ -1093,7 +1093,7 @@ You can activate debug mode using `DEBUG=browserless` environment variable in or
 
 Consider opening an [issue](https://github.com/microlinkhq/browserless/issues/new) with the debug trace.
 
-**Q: I want to use `browserless` with my AWS Lambda like project**
+**Q: I want to use `browserless` on AWS Lambda**
 
 Yes, check [chrome-aws-lambda](https://github.com/alixaxel/chrome-aws-lambda) to setup AWS Lambda with a binary compatible.
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Changes the default maximum navigation time.
 type: `Puppeteer`<br/>
 default: `puppeteer`|`puppeteer-core`|`puppeteer-firefox`
 
-By default, it automatically detects which library is installed — either [puppeteer](https://www.npmjs.com/package/puppeteer) or [puppeteer-core](https://www.npmjs.com/package/puppeteer-core) — based on your installed dependencies.
+By default, it automatically detects which library is installed — [puppeteer](https://www.npmjs.com/package/puppeteer), [puppeteer-core](https://www.npmjs.com/package/puppeteer-core), or [puppeteer-firefox](https://www.npmjs.com/package/puppeteer-firefox) — based on your installed dependencies.
 
 ### .createContext(options)
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -27,7 +27,7 @@ Requires Node.js 24+ and a [browserless](https://www.npmjs.com/package/browserle
 
 This package runs [Chrome Built-in AI](https://developer.chrome.com/docs/ai/built-in-apis) from Node.js. It evaluates Prompt, Summarizer, Translator, and Language Detector on a browserless page, so you can call those APIs from a script instead of a visible Chrome window.
 
-Chrome for Testing cannot download Gemini Nano. Pack a model on a machine that already has it, unpack it into one directory, then pass that `dir` to `createAi` / `launch`.
+Chrome for Testing does not download Gemini Nano for you. Pack a model on a machine that already has it, unpack it into one directory, then pass that `dir` to `createAi` / `launch`.
 
 Chrome’s docs allow the foundation model on **GPU (>4 GB VRAM) or CPU (16 GB RAM, 4+ cores)**.
 
@@ -65,7 +65,7 @@ const ai = createAi(async teardown => {
 })
 ```
 
-Each method is `(url, options)`. Pass `options.text` to use your own input; otherwise the package reads `document.body.innerText` after navigation.
+Each page-processing method is `(url, options)`. Pass `options.text` to use your own input; otherwise the package reads `document.body.innerText` after navigation. `capabilities` accepts `{ timeout, url }` and supplies defaults.
 
 | Method | Create options |
 |--------|----------------|
@@ -112,7 +112,7 @@ pnpm --filter @browserless/ai start https://example.com
 | `translate` | `Translator` | 138 |
 | `capabilities` | feature detect | — |
 
-`extract` requires `schema`. `translate` requires `sourceLanguage` and `targetLanguage`. Language Detector and Translator download separately from Gemini Nano. Prompt and Summarizer use Nano.
+`extract` requires `schema` or `responseConstraint`. `translate` requires `sourceLanguage` and `targetLanguage`. Language Detector and Translator download separately from Gemini Nano. Prompt and Summarizer use Nano.
 
 ### How it fits in the monorepo
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -9,7 +9,7 @@
   <br><br>
 </div>
 
-> @browserless/ai: Run Chrome Built-in AI from Node.
+> @browserless/ai: Run Chrome Built-in AI from Node.js.
 
 See the [ai section](https://browserless.js.org/#/?id=ai) on our website for more information.
 
@@ -25,7 +25,7 @@ Requires Node.js 24+ and a [browserless](https://www.npmjs.com/package/browserle
 
 ## About
 
-This package runs [Chrome Built-in AI](https://developer.chrome.com/docs/ai/built-in-apis) from Node. It evaluates Prompt, Summarizer, Translator, and Language Detector on a browserless page, so you can call those APIs from a script instead of a visible Chrome window.
+This package runs [Chrome Built-in AI](https://developer.chrome.com/docs/ai/built-in-apis) from Node.js. It evaluates Prompt, Summarizer, Translator, and Language Detector on a browserless page, so you can call those APIs from a script instead of a visible Chrome window.
 
 Chrome for Testing cannot download Gemini Nano. Pack a model on a machine that already has it, unpack it into one directory, then pass that `dir` to `createAi` / `launch`.
 
@@ -116,7 +116,7 @@ pnpm --filter @browserless/ai start https://example.com
 
 ### How it fits in the monorepo
 
-This is an **extended functionality package**. It is not wired into `browserless` core — install `@browserless/ai` when you need Chrome Built-in AI from Node.
+This is an **extended functionality package**. It is not wired into `browserless` core — install `@browserless/ai` when you need Chrome Built-in AI from Node.js.
 
 ## License
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -9,7 +9,7 @@
   <br><br>
 </div>
 
-> @browserless/ai: Chrome Built-in AI via browserless (Chrome for Testing, headless; GPU or CPU).
+> @browserless/ai: Run Chrome Built-in AI from Node.
 
 See the [ai section](https://browserless.js.org/#/?id=ai) on our website for more information.
 
@@ -21,11 +21,15 @@ Using npm:
 npm install @browserless/ai --save
 ```
 
+Requires Node.js 24+ and a [browserless](https://www.npmjs.com/package/browserless) peer.
+
 ## About
 
-This package runs [Chrome Built-in AI](https://developer.chrome.com/docs/ai/built-in-apis) from Node by evaluating the APIs on a browserless page.
+This package runs [Chrome Built-in AI](https://developer.chrome.com/docs/ai/built-in-apis) from Node. It evaluates Prompt, Summarizer, Translator, and Language Detector on a browserless page, so you can call those APIs from a script instead of a visible Chrome window.
 
-Chrome for Testing cannot download Gemini Nano. Unpack a packed model into one directory, then pass that `dir` to `createAi` / `launch`. Chrome’s docs allow the foundation model on **GPU (>4 GB VRAM) or CPU (16 GB RAM, 4+ cores)**.
+Chrome for Testing cannot download Gemini Nano. Pack a model on a machine that already has it, unpack it into one directory, then pass that `dir` to `createAi` / `launch`.
+
+Chrome’s docs allow the foundation model on **GPU (>4 GB VRAM) or CPU (16 GB RAM, 4+ cores)**.
 
 ### Usage
 
@@ -45,9 +49,9 @@ await ai.translate('https://example.com', { text: 'Hello', sourceLanguage: 'en',
 await ai.close()
 ```
 
-`unpack` accepts a local zip path or a download function. The function can return a path, `Buffer`, stream, or S3 `GetObject` result, or write to the `dest` path it receives. Already-unpacked trees are reused unless `{ force: true }`.
+`unpack` accepts a local zip path or a download function. The function can return a path, `Buffer`, stream, or S3 `GetObject` result, or write to the `dest` path it receives. If the directory is already unpacked, `unpack` reuses it unless you pass `{ force: true }`.
 
-If you already own the browser (lighthouse-style):
+If you already have a browserless instance:
 
 ```js
 const createBrowser = require('browserless')
@@ -61,7 +65,14 @@ const ai = createAi(async teardown => {
 })
 ```
 
-Each method is `(url, options)`. Input text is `options.text` when provided, otherwise `document.body.innerText` after navigation. Supported create options are `temperature` / `topK` / `initialPrompts` / `expectedInputs` / `expectedOutputs` for prompt, `type` / `format` / `length` / `sharedContext` / `expectedInputLanguages` / `outputLanguage` / `expectedContextLanguages` for summarize, `sourceLanguage` / `targetLanguage` for translate, and `expectedInputLanguages` for detectLanguage.
+Each method is `(url, options)`. Pass `options.text` to use your own input; otherwise the package reads `document.body.innerText` after navigation.
+
+| Method | Create options |
+|--------|----------------|
+| `prompt` / `extract` | `temperature`, `topK`, `initialPrompts`, `expectedInputs`, `expectedOutputs` |
+| `summarize` | `type`, `format`, `length`, `sharedContext`, `expectedInputLanguages`, `outputLanguage`, `expectedContextLanguages` |
+| `translate` | `sourceLanguage`, `targetLanguage` (required) |
+| `detectLanguage` | `expectedInputLanguages` |
 
 ### Options
 
@@ -70,7 +81,7 @@ Each method is `(url, options)`. Input text is `options.text` when provided, oth
 | `dir` | `string` | `BROWSERLESS_AI_DIR` | Unpacked model tree (`nano/`, `prompt/`, `summarize/`, `detect/`) |
 | `timeout` | `number` | `120000` | Launch and evaluate timeout (ms). `protocolTimeout` follows it |
 
-`unpack(source, { dir, force })` writes to `dir` when given, otherwise `BROWSERLESS_AI_DIR` or `~/.cache/browserless-ai`.
+`unpack(source, { dir, force })` writes to `dir` when you pass one. Otherwise it uses `BROWSERLESS_AI_DIR`, or `~/.cache/browserless-ai`.
 
 ### Pack a model
 
@@ -101,11 +112,11 @@ pnpm --filter @browserless/ai start https://example.com
 | `translate` | `Translator` | 138 |
 | `capabilities` | feature detect | — |
 
-`extract` requires `schema`. `translate` requires `sourceLanguage` and `targetLanguage`. Language Detector and Translator are expert models. Prompt / Summarizer use Gemini Nano.
+`extract` requires `schema`. `translate` requires `sourceLanguage` and `targetLanguage`. Language Detector and Translator download separately from Gemini Nano. Prompt and Summarizer use Nano.
 
 ### How it fits in the monorepo
 
-This is an **extended functionality package**. It is not wired into `browserless` core.
+This is an **extended functionality package**. It is not wired into `browserless` core — install `@browserless/ai` when you need Chrome Built-in AI from Node.
 
 ## License
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -29,7 +29,7 @@ This package runs [Chrome Built-in AI](https://developer.chrome.com/docs/ai/buil
 
 Chrome for Testing does not download Gemini Nano for you. Pack a model on a machine that already has it, unpack it into one directory, then pass that `dir` to `createAi` / `launch`.
 
-Chrome’s docs allow the foundation model on **GPU (>4 GB VRAM) or CPU (16 GB RAM, 4+ cores)**.
+Chrome’s docs allow the foundation model on **GPU (>4 GB VRAM) or CPU (16 GB RAM, 4+ cores)** at runtime. The 22 GB profile-volume space and unmetered connection apply only when desktop Chrome first downloads Nano, not when you launch with a packed `dir`.
 
 ### Usage
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -106,7 +106,7 @@ pnpm --filter @browserless/ai start https://example.com
 | Method | Chrome API | Chrome |
 |--------|------------|--------|
 | `prompt` | `LanguageModel` | 148 |
-| `extract` | `LanguageModel` + schema | 148 |
+| `extract` | `LanguageModel` + `schema` / `responseConstraint` | 148 |
 | `summarize` | `Summarizer` | 138 |
 | `detectLanguage` | `LanguageDetector` | 138 |
 | `translate` | `Translator` | 138 |

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserless/ai",
-  "description": "Run Chrome Built-in AI APIs (Prompt, Summarizer, Translator, Language Detector) from Node using browserless.",
+  "description": "Run Chrome Built-in AI APIs (Prompt, Summarizer, Translator, Language Detector) from Node.js using browserless.",
   "homepage": "https://browserless.js.org",
   "version": "13.8.3",
   "main": "src",

--- a/packages/browserless/README.md
+++ b/packages/browserless/README.md
@@ -9,6 +9,10 @@
   <br><br>
 </div>
 
+> browserless: The headless Chrome/Chromium driver on top of Puppeteer.
+
+See the [website](https://browserless.js.org) for the full API.
+
 ## Install
 
 Using npm:

--- a/packages/capture/README.md
+++ b/packages/capture/README.md
@@ -119,24 +119,25 @@ All three share the same factory signature — `createCapture({ goto })(page)(ur
 - `capture.extensionId`: Extension ID used by the package.
 - `capture.MODES`: Names of the available capture modes (entry points).
 - `capture.types`: Supported values for `type`.
-`capture` uses `goto(...).device.viewport` as the capture viewport source.
-When `video` is `true` or omitted, video constraints are inferred from that viewport to keep capture framing aligned with screenshot/pdf rendering.
-When `video` is an object, that object is used as the video constraints.
-When `audio` is an object, that object is used as the audio constraints.
-The inferred constraints also account for `deviceScaleFactor`, so output video pixels match screenshot pixel density.
-`type` is mapped internally to the MediaRecorder mime type, and `codec` is appended as `;codecs=...`.
-Default codecs are `vp9` for `webm` and `avc1.4D401F` for `mp4`.
-You can override codec per request using `opts.codec`.
-For example:
+
+`capture` uses `goto(...).device.viewport` as the capture viewport. When `video` is `true` or omitted, video constraints are inferred from that viewport so framing matches screenshot and PDF. Pass an object for `video` or `audio` to set those constraints yourself.
+
+Inferred constraints include `deviceScaleFactor`, so output pixels match screenshot density.
+
+`type` maps to a MediaRecorder mime type. `codec` is appended as `;codecs=...`. Defaults are `vp9` for `webm` and `avc1.4D401F` for `mp4`. Override per request with `opts.codec`:
 
 ```js
 await capture(page)(url, { type: 'webm', codec: 'vp8' })
 await capture(page)(url, { type: 'mp4', codec: 'avc1.640033' })
 ```
 
-When `type` is `'mp4'`, the running Chromium build must support MP4 MediaRecorder output.
-For strict screenshot/poster parity in headless mode, launch Chrome with matching `--screen-info`.
+When `type` is `'mp4'`, Chromium must support MP4 MediaRecorder output. For screenshot/poster parity in headless mode, launch Chrome with matching `--screen-info`.
 
 ## License
 
-**@browserless/capture** © [Microlink](https://microlink.io), released under the [MIT](https://github.com/microlinkhq/browserless/blob/master/LICENSE.md) License.
+**@browserless/capture** © [Microlink](https://microlink.io), released under the [MIT](https://github.com/microlinkhq/browserless/blob/master/LICENSE.md) License.<br>
+Authored and maintained by [Microlink](https://microlink.io) with help from [contributors](https://github.com/microlinkhq/browserless/contributors).
+
+The [logo](https://thenounproject.com/term/browser/288309/) has been designed by [xinh studio](https://xinh.studio).
+
+> [microlink.io](https://microlink.io) · GitHub [microlinkhq](https://github.com/microlinkhq) · X [@microlinkhq](https://x.com/microlinkhq)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -11,7 +11,7 @@
 
 > @browserless/cli: CLI to interact with Browserless capabilities.
 
-See [CLI section](https://browserless.js.org/#/?id=cli) our website for more information.
+See the [CLI section](https://browserless.js.org/#/?id=cli) on our website for more information.
 
 ## Install
 
@@ -68,6 +68,7 @@ browserless capture https://example.com --type=webm --path=./capture.webm
 > <kbd>npm install -g @browserless/lighthouse</kbd>
 
 ### How it fits in the monorepo
+
 This package depends on:
 
 | Dependency                | Purpose                                                 |

--- a/packages/devices/README.md
+++ b/packages/devices/README.md
@@ -11,7 +11,7 @@
 
 > @browserless/devices: A collection of different devices for emulation purposes.
 
-See [devices section](https://browserless.js.org/#/?id=getdeviceoptions) our website for more information.
+See the [devices section](https://browserless.js.org/#/?id=getdeviceoptions) on our website for more information.
 
 ## Install
 

--- a/packages/function/README.md
+++ b/packages/function/README.md
@@ -9,9 +9,9 @@
   <br><br>
 </div>
 
-> @browserless/function: Run abritrary JavaScript inside a browser sandbox.
+> @browserless/function: Run arbitrary JavaScript inside a browser sandbox.
 
-See [function section](https://browserless.js.org/#/?id=function) our website for more information.
+See the [function section](https://browserless.js.org/#/?id=function) on our website for more information.
 
 ## Install
 
@@ -222,7 +222,7 @@ console.log(result.value.message) // => 'Something went wrong'
 
 ### How it fits in the monorepo
 
-This is an **extended functionality package** for advanced use cases. It makes the repository more extensible and customizable for any edge case you may encounter.
+This is an **extended functionality package**. It is not wired into `browserless` core — install it when you need a sandbox that can touch a page.
 
 ### Dependencies
 
@@ -235,7 +235,7 @@ This is an **extended functionality package** for advanced use cases. It makes t
 
 ## License
 
-**@browserless/functions** © [Microlink](https://microlink.io), released under the [MIT](https://github.com/microlinkhq/browserless/blob/master/LICENSE.md) License.<br>
+**@browserless/function** © [Microlink](https://microlink.io), released under the [MIT](https://github.com/microlinkhq/browserless/blob/master/LICENSE.md) License.<br>
 Authored and maintained by [Microlink](https://microlink.io) with help from [contributors](https://github.com/microlinkhq/browserless/contributors).
 
 The [logo](https://thenounproject.com/term/browser/288309/) has been designed by [xinh studio](https://xinh.studio).

--- a/packages/goto/README.md
+++ b/packages/goto/README.md
@@ -34,7 +34,7 @@ The `@browserless/goto` package allows you to:
 - **Inject scripts, modules, and styles** into pages
 - **Emulate devices** with viewport, user agent, and media features
 - **Intercept and abort requests** by resource type
-- **Handle cookies and authentication** seamlessly
+- **Handle cookies and HTTP authentication**
 
 ### Usage
 

--- a/packages/lighthouse/README.md
+++ b/packages/lighthouse/README.md
@@ -33,7 +33,7 @@ The `@browserless/lighthouse` package allows you to:
 - **Generate reports** in JSON, HTML, or CSV formats
 - **Use Lighthouse presets** for desktop or mobile configurations
 - **Customize audits** by selecting specific categories or skipping certain checks
-- **Integrate seamlessly** with your existing browserless browser instance
+- **Reuse your existing browserless instance** for the audit
 
 ### Usage
 
@@ -98,9 +98,9 @@ const report = await lighthouse(url, { preset: 'lr-mobile' })
 ### Customizing audits
 
 ```js
-// Run only accessibility audits
+// Run only specific audits
 const report = await lighthouse(url, {
-  onlyAudits: ['accessibility']
+  onlyAudits: ['first-contentful-paint', 'largest-contentful-paint']
 })
 
 // Run only specific categories
@@ -145,7 +145,6 @@ This is an **extended functionality package** for performance auditing:
 | Consumer | Purpose |
 |----------|---------|
 | `@browserless/cli` | Powers the `browserless lighthouse` command |
-| User applications | Performance monitoring, CI/CD quality gates |
 
 ### Dependencies
 

--- a/packages/pdf/README.md
+++ b/packages/pdf/README.md
@@ -178,7 +178,7 @@ This is a **core functionality package** for PDF generation:
 | Package | Purpose |
 |---------|---------|
 | `@browserless/goto` | Page navigation with ad blocking |
-| `@browserless/screenshot` | White screen detection for content verification |
+| `@browserless/screenshot` | Readiness and blank-screen checks |
 | `@kikobeats/time-span` | Timing measurements for retry logic |
 | `debug-logfmt` | Structured debug logging |
 | `pretty-ms` | Human-readable time formatting |

--- a/packages/pdf/README.md
+++ b/packages/pdf/README.md
@@ -30,7 +30,7 @@ This package provides **PDF generation** from web pages with sensible defaults a
 The `@browserless/pdf` package allows you to:
 
 - **Generate PDFs** from any URL with production-ready defaults
-- **Auto-detect content rendering** using white screenshot detection
+- **Wait until the page is ready** before printing, including blank-screen checks
 - **Customize margins** with a simple string or per-side configuration
 - **Scale content** to fit pages optimally
 - **Use all Puppeteer PDF options** for advanced customization

--- a/packages/screencast/README.md
+++ b/packages/screencast/README.md
@@ -25,7 +25,7 @@ npm install @browserless/screencast --save
 
 This package provides **frame-by-frame video capture** from browser page navigation using the Chrome DevTools Protocol. It allows you to capture individual frames during page interactions for creating GIFs, videos, or frame-by-frame analysis.
 
-### What This Package Does
+### What this package does
 
 The `@browserless/screencast` package allows you to:
 
@@ -38,13 +38,6 @@ The `@browserless/screencast` package allows you to:
 ### Usage
 
 ```js
-const createScreencast = require('@browserless/screencast')
-const createBrowser = require('browserless')
-
-const browser = createBrowser()
-const browserless = await browser.createContext()
-const page = await browserless.page()
-
 const createScreencast = require('@browserless/screencast')
 const createBrowser = require('browserless')
 

--- a/packages/screenshot/README.md
+++ b/packages/screenshot/README.md
@@ -331,7 +331,7 @@ This is a **core functionality package** for screenshot capture:
 | -------------------- | ---------------------------------------------- |
 | `browserless` (core) | Provides the `.screenshot()` method            |
 | `@browserless/cli`   | Powers the `browserless screenshot` command    |
-| `@browserless/pdf`   | Uses `isWhiteScreenshot` for content detection |
+| `@browserless/pdf`   | Uses `waitForReady` and `isWhiteScreenshot` |
 
 ### Dependencies
 

--- a/packages/screenshot/README.md
+++ b/packages/screenshot/README.md
@@ -25,7 +25,7 @@ npm install @browserless/screenshot --save
 
 This package provides **advanced screenshot capture** with smart defaults, browser frame overlays, gradient backgrounds, and automatic code syntax highlighting. It wraps Puppeteer's `page.screenshot()` with features optimized for production use.
 
-### What This Package Does
+### What this package does
 
 The `@browserless/screenshot` package allows you to:
 
@@ -323,7 +323,7 @@ const buffer = await browserless.screenshot('https://example.com', {
     └── index.js            → Tests
 ```
 
-### How It Fits in the Monorepo
+### How it fits in the monorepo
 
 This is a **core functionality package** for screenshot capture:
 

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -9,7 +9,7 @@
   <br><br>
 </div>
 
-> A test suite for the **browserless** api
+> @browserless/test: Shared helpers for the browserless test suite.
 
 ## Install
 
@@ -18,6 +18,12 @@ Using npm:
 ```sh
 npm install @browserless/test --save-dev
 ```
+
+## About
+
+Internal helpers used by the monorepo tests: spin up a browserless instance, serve a fixture page, and compare screenshot or PDF output.
+
+This package is not a public product API.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Clarify package READMEs (especially `@browserless/ai`) so setup, options, and why you would use each package are readable.
- Fix copy bugs: typos, missing “on our website,” a duplicated screencast example, a wrong Lighthouse `onlyAudits` example, and the `@browserless/functions` license name.

## Test plan
- [ ] Skim the root README and package READMEs for tone/consistency
- [ ] Confirm Lighthouse examples use real audit ids / `onlyCategories`
- [ ] Confirm `@browserless/ai` install + unpack path still matches the code


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified setup requirements, supported environments, AI model preparation, and package integration guidance.
  - Improved examples for Lighthouse audit selection, PDF readiness checks, and capture video/audio settings.
  - Added or updated links to API, CLI, and package documentation.
  - Refined descriptions for navigation, testing utilities, browser automation, media features, and shared testing helpers.
  - Corrected terminology, licensing references, headings, package descriptions, and general wording throughout the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->