### PR TITLE
fix: pin changelog preset to 10.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "browser-sync": "latest",
     "c8": "latest",
     "concurrently": "latest",
+    "conventional-changelog-conventionalcommits": "10.2.1",
     "cssnano": "latest",
     "cssnano-preset-advanced": "latest",
     "finepack": "latest",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,7 @@
 dangerouslyAllowAllBuilds: true
 minimumReleaseAge: 0
+# 10.3+ drops the CJS export commitlint resolves; 10.4+ trips lerna-lite's writer shim
+overrides:
+  conventional-changelog-conventionalcommits: 10.2.1
 packages:
   - 'packages/*'


### PR DESCRIPTION
## Summary
- Release failed on `lerna publish` because `conventional-changelog-conventionalcommits@10.4.0` sets a Handlebars `mainTemplate` guard that lerna-lite 5.6 compiles instead of the function template ([run](https://github.com/microlinkhq/browserless/actions/runs/32459510944/job/96704560963)).
- 10.3+ also drops the `exports.default` entry `@commitlint/config-conventional` resolves, so the pin is `10.2.1` (last version that works for both).
- Forced via `pnpm.overrides` because `resolution-mode=highest` and no lockfile would otherwise hoist 10.4 again.

## Test plan
- [x] `commitlint` loads with the pinned preset
- [x] Preset exposes `writer.template` as a function and no `mainTemplate`
- [ ] Merge to master so the release workflow retries


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling for conventional commit changelog generation.
  * Added compatibility pinning to ensure consistent changelog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->