### PR TITLE
ci: drop auth token from project .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -11,4 +11,3 @@ strict-peer-dependencies=false
 unsafe-perm=true
 link-workspace-packages=true
 block-exotic-subdeps=false
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
## Summary
- pnpm no longer expands `${NPM_TOKEN}` from a committed project `.npmrc`, so every CI `pnpm` invocation warns and ignores that line.
- Remove the auth setting from `.npmrc`. The release job already writes the token to the runner user config with `pnpm config set`.

## Test plan
- [ ] Confirm CI logs no longer show `Ignored project-level auth setting`
- [ ] Confirm the release job still has `pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"` before `pnpm run release`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the npm registry authentication token configuration.
  * All other npm settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->