### PR TITLE
fix: restore workspace link so release CI installs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,5 +184,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
+          # lerna publishes via npm, which reads .npmrc — not pnpm config
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
           pnpm run release

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -31,7 +31,7 @@
   ],
   "devDependencies": {
     "ava": "5",
-    "browserless": "^13.9.0",
+    "browserless": "workspace:*",
     "puppeteer": "25"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- `pnpm install` on master fails because `@browserless/ai` pins `browserless@^13.9.0`, which was never published (npm is still at 13.8.3). That pin was left behind when the v13.9.0 release rewrote `workspace:*` and then died on npm publish.
- Write the expanded `NPM_TOKEN` into `.npmrc` during release so lerna-lite (npm/libnpmpublish) can authenticate. `pnpm config set` only updates pnpm's store, which is why `@browserless/devices@13.9.0` got `E404` after #893.

## Test plan
- [ ] Lint/install job resolves `browserless` from the workspace (no registry 13.9.0 lookup)
- [ ] After merge, the master release job authenticates to npm and publishes the pending bump


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the npm publishing workflow to use the configured authentication token.
  * Aligned the browserless development dependency with the workspace version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->