### PR TITLE
fix(ai): publish as a public scoped package

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -31,7 +31,7 @@
   ],
   "devDependencies": {
     "ava": "5",
-    "browserless": "^13.9.2",
+    "browserless": "workspace:*",
     "puppeteer": "25"
   },
   "peerDependencies": {
@@ -53,6 +53,9 @@
     "test": "DEBUG=browserless:ai ava"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "ava": {
     "serial": true,
     "timeout": "10m",


### PR DESCRIPTION
## Summary
- The [v13.9.2 release](https://github.com/microlinkhq/browserless/actions/runs/32660964695/job/97249213521) authenticated and published `browserless`, `@browserless/screenshot`, `@browserless/pdf`, and the rest of the existing packages. It then died on the first publish of `@browserless/ai` with `E402 You must sign up for private packages`.
- A new scoped package is restricted on npm unless `publishConfig.access` is `public`. Same pattern as [metascraper-helpers](https://github.com/microlinkhq/metascraper/blob/master/packages/metascraper-helpers/package.json).
- Also restore `browserless: workspace:*` — lerna rewrote it to `^13.9.2` in the version commit again.

## Test plan
- [ ] Confirm `@browserless/ai` is still unpublished (`npm view @browserless/ai` → 404)
- [ ] After merge, the release job publishes `@browserless/ai` (next patch) without E402
- [ ] `pnpm install` keeps resolving `browserless` from the workspace


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development setup to use the workspace version of Browserless.
  * Added configuration supporting public npm package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->