### PR TITLE
fix: republish versions that never reached npm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,6 +180,7 @@ jobs:
           DEBUG: browserless:ai
         run: xvfb-run -a pnpm --recursive --sequential test
       - name: Release
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -187,9 +188,10 @@ jobs:
           pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
           pnpm run release
       - name: Publish unpublished versions
-        if: success() || failure()
+        if: ${{ !cancelled() && (steps.release.outcome == 'success' || steps.release.outcome == 'failure') }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
+          git restore --source=HEAD --worktree --staged -- .
           pnpm exec lerna publish from-package --yes --sort

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,3 +186,10 @@ jobs:
         run: |
           pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
           pnpm run release
+      - name: Publish unpublished versions
+        if: success() || failure()
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
+          pnpm exec lerna publish from-package --yes --sort

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,10 @@
   "packages": [
     "packages/*"
   ],
-  "version": "13.9.4"
+  "version": "13.9.4",
+  "command": {
+    "publish": {
+      "access": "public"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- v13.9.0 tagged 13 packages, then `@browserless/devices` 404'd and aborted the rest. `@browserless/goto@13.9.0` (and devices, capture, lighthouse, screencast) never reached npm, so `browserless@latest` cannot install.
- Later releases only publish packages with new commits, so those tagged versions stay missing.
- After `lerna publish`, always run `from-package` so any version already in git but absent from npm is retried. Also set `publish.access=public` so a first scoped publish cannot die with E402 the way `@browserless/ai` did.

## Test plan
- [ ] Merge to master so release CI runs `from-package`
- [ ] Confirm `@browserless/goto@13.9.0` and `@browserless/devices@13.9.0` exist on npm
- [ ] `pnpm add browserless@13.9.2` succeeds (html-get CI install)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Management**
  * Improved package publishing during releases by automatically publishing previously unpublished versions.
  * Added safeguards to ensure publishing runs only after the release process completes and the repository is restored to a clean state.
  * Configured published packages for public npm access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->