### PR TITLE
chore: update dependencies

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -62,6 +62,6 @@
     "workerThreads": false
   },
   "dependencies": {
-    "debug-logfmt": "~1.4.12"
+    "debug-logfmt": "~1.4.15"
   }
 }

--- a/packages/browserless/package.json
+++ b/packages/browserless/package.json
@@ -39,13 +39,13 @@
     "@browserless/goto": "workspace:*",
     "@browserless/pdf": "workspace:*",
     "@browserless/screenshot": "workspace:*",
-    "debug-logfmt": "~1.4.10",
-    "kill-process-group": "~1.0.13",
     "p-reflect": "~2.1.0",
     "p-retry": "~4.6.1",
     "p-timeout": "~4.1.0",
-    "require-one-of": "~1.0.24",
-    "superlock": "~1.3.1"
+    "debug-logfmt": "~1.4.15",
+    "kill-process-group": "~1.0.16",
+    "require-one-of": "~1.0.25",
+    "superlock": "~1.3.5"
   },
   "devDependencies": {
     "ava": "5",

--- a/packages/capture/package.json
+++ b/packages/capture/package.json
@@ -39,8 +39,8 @@
   "dependencies": {
     "@browserless/goto": "workspace:*",
     "@browserless/screencast": "workspace:*",
-    "debug-logfmt": "~1.4.10",
-    "ws": "~8.21.0"
+    "debug-logfmt": "~1.4.15",
+    "ws": "~8.21.3"
   },
   "devDependencies": {
     "ava": "5"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@browserless/capture": "workspace:*",
-    "beauty-error": "~1.2.22",
+    "beauty-error": "~1.2.23",
     "browserless": "workspace:*",
     "dark-mode": "~3.0.0",
     "dset": "~3.1.4",

--- a/packages/devices/package.json
+++ b/packages/devices/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "didyoumean3": "~1.2.5",
     "memoize-one": "~6.0.0",
-    "require-one-of": "~1.0.24"
+    "require-one-of": "~1.0.25"
   },
   "devDependencies": {
     "ava": "5",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -29,10 +29,10 @@
     "puppeteer"
   ],
   "dependencies": {
-    "debug-logfmt": "~1.4.10",
     "ensure-error": "~3.0.1",
     "serialize-error": "~8.1.0",
-    "whoops": "~5.1.1"
+    "debug-logfmt": "~1.4.15",
+    "whoops": "~5.1.4"
   },
   "devDependencies": {
     "ava": "5"

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -35,8 +35,8 @@
     "@cloudflare/puppeteer": "~1.4.0",
     "acorn": "~8.18.0",
     "acorn-walk": "~8.3.5",
-    "isolated-function": "~0.2.0",
-    "require-one-of": "~1.0.24"
+    "isolated-function": "~0.2.3",
+    "require-one-of": "~1.0.25"
   },
   "devDependencies": {
     "ava": "5",

--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -39,7 +39,7 @@
     "p-reflect": "~2.1.0",
     "p-timeout": "~4.1.0",
     "shallow-equal": "~3.1.0",
-    "tough-cookie": "~6.0.1"
+    "tough-cookie": "~6.0.2"
   },
   "devDependencies": {
     "ava": "5"

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "@browserless/errors": "workspace:*",
-    "lighthouse": "~13.4.0"
+    "lighthouse": "~13.4.1"
   },
   "devDependencies": {
     "ava": "5"

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -32,10 +32,10 @@
   "dependencies": {
     "@browserless/goto": "workspace:*",
     "@browserless/screenshot": "workspace:*",
-    "@kikobeats/time-span": "~1.0.12",
-    "debug-logfmt": "~1.4.10",
     "p-reflect": "~2.1.0",
     "pretty-ms": "~7.0.1"
+    "@kikobeats/time-span": "~1.0.13",
+    "debug-logfmt": "~1.4.15",
   },
   "engines": {
     "node": ">= 24"

--- a/packages/screencast/package.json
+++ b/packages/screencast/package.json
@@ -32,7 +32,7 @@
     "video"
   ],
   "dependencies": {
-    "null-prototype-object": "~1.2.6"
+    "null-prototype-object": "~1.2.7"
   },
   "devDependencies": {
     "@kikobeats/time-span": "latest",

--- a/packages/screenshot/package.json
+++ b/packages/screenshot/package.json
@@ -35,21 +35,21 @@
     "@browserless/errors": "workspace:*",
     "@browserless/goto": "workspace:*",
     "@kikobeats/content-type": "~1.0.4",
-    "@kikobeats/time-span": "~1.0.12",
-    "automad-prism-themes": "~0.3.7",
-    "debug-logfmt": "~1.4.10",
     "got": "~11.8.6",
+    "@kikobeats/time-span": "~1.0.13",
+    "automad-prism-themes": "~0.3.8",
+    "debug-logfmt": "~1.4.15",
     "is-html-content": "~1.0.0",
     "is-url-http": "~2.3.13",
     "lodash": "~4.18.1",
     "map-values-deep": "~1.0.2",
     "mime": "~3.0.0",
-    "null-prototype-object": "~1.2.6",
     "p-reflect": "~2.1.0",
     "pretty-ms": "~7.0.1",
+    "null-prototype-object": "~1.2.7",
     "prism-themes": "~1.9.0",
-    "sharp": "~0.35.1",
-    "svg-gradient": "~1.0.4"
+    "sharp": "~0.35.4",
+    "svg-gradient": "~1.0.5"
   },
   "devDependencies": {
     "ava": "5"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Routine dependency pin bumps with no logic changes; residual risk is limited to transitive behavior changes in logging, image processing (sharp), and process/WebSocket utilities.
> 
> **Overview**
> Bumps **patch/minor** third-party dependency ranges in multiple monorepo `package.json` files. There is **no application or test source** in the diff—only version constraint updates (and minor dependency list reordering in a few packages).
> 
> **Shared bumps** include `debug-logfmt` to `~1.4.15` (ai, browserless, capture, errors, pdf, screenshot), `require-one-of` to `~1.0.25` (browserless, devices, function), and `null-prototype-object` to `~1.2.7` (screencast, screenshot).
> 
> **Package-specific** updates: core `browserless` (`kill-process-group`, `superlock`), `capture` (`ws`), `cli` (`beauty-error`), `errors` (`whoops`), `function` (`isolated-function`), `goto` (`tough-cookie`), `lighthouse` (`lighthouse` patch), `pdf` / `screenshot` (`@kikobeats/time-span`, `sharp`, `svg-gradient`, `automad-prism-themes` on screenshot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc855edd9997714ea0941e92d87734f686906359. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->