### PR TITLE
fix(errors): treat Target closed as context disconnect

### DIFF
--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -55,7 +55,7 @@ const timeoutError = errors.browserTimeout({ timeout: 30000 })
 
 // Create a protocol error
 const protocolError = errors.protocolError({ message: 'Printing failed' })
-// => BrowserlessError: EPROTOCOL, Printing failed.
+// => BrowserlessError: EPROTOCOL, Printing failed
 
 // Create an evaluation error
 const evalError = errors.evaluationFailed({ message: 'foo is not defined' })

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -54,17 +54,17 @@ const timeoutError = errors.browserTimeout({ timeout: 30000 })
 // => BrowserlessError: EBRWSRTIMEOUT, Promise timed out after 30000 milliseconds
 
 // Create a protocol error
-const protocolError = errors.protocolError({ message: 'Target closed.' })
-// => BrowserlessError: EPROTOCOL, Target closed.
+const protocolError = errors.protocolError({ message: 'Printing failed' })
+// => BrowserlessError: EPROTOCOL, Printing failed.
 
 // Create an evaluation error
 const evalError = errors.evaluationFailed({ message: 'foo is not defined' })
 // => BrowserlessError: EINVALEVAL, foo is not defined
 
-// Normalize a raw error from Puppeteer
-const rawError = { message: 'Protocol error (Runtime.callFunctionOn): Target closed.' }
+// Normalize a raw error from Puppeteer (page target gone mid-evaluate)
+const rawError = { message: 'Protocol error (Runtime.evaluate): Target closed' }
 const normalizedError = errors.ensureError(rawError)
-// => BrowserlessError: EPROTOCOL, Target closed.
+// => BrowserlessError: EBRWSRCONTEXTCONNRESET, The browser context is not connected.
 
 // Normalize a page range Chrome cannot satisfy
 const rangeError = errors.ensureError({

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -63,11 +63,12 @@ const getErrorMessage = rawError => {
 const isContextDestroyed = rawError => {
   const errorMessage = getErrorMessage(rawError)
   return (
-    [
-      'Protocol error (Target.createTarget): Failed to find browser context with id',
-      'Protocol error (Target.createTarget): Target closed',
-      'Protocol error (Target.createBrowserContext): Target closed'
-    ].some(message => errorMessage.startsWith(message)) ||
+    errorMessage.startsWith(
+      'Protocol error (Target.createTarget): Failed to find browser context with id'
+    ) ||
+    // Page or browser target gone: Runtime.evaluate, Runtime.callFunctionOn,
+    // Target.createTarget, Target.createBrowserContext, Page.createIsolatedWorld.
+    errorMessage.includes('Target closed') ||
     errorMessage.includes('Session closed') ||
     errorMessage.includes('Attempted to use detached Frame') ||
     // Chrome's other phrasing of a frame detaching mid-operation (a navigation

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -66,9 +66,11 @@ const isContextDestroyed = rawError => {
     errorMessage.startsWith(
       'Protocol error (Target.createTarget): Failed to find browser context with id'
     ) ||
-    // Page or browser target gone: Runtime.evaluate, Runtime.callFunctionOn,
-    // Target.createTarget, Target.createBrowserContext, Page.createIsolatedWorld.
-    errorMessage.includes('Target closed') ||
+    // Page or browser target gone mid-CDP (Runtime.evaluate, callFunctionOn,
+    // createTarget, createBrowserContext, createIsolatedWorld). Require the
+    // protocol prefix so a page exception `Evaluation failed: Target closed`
+    // still maps to EINVALEVAL.
+    (errorMessage.includes('Protocol error') && errorMessage.includes('Target closed')) ||
     errorMessage.includes('Session closed') ||
     errorMessage.includes('Attempted to use detached Frame') ||
     // Chrome's other phrasing of a frame detaching mid-operation (a navigation

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -12,19 +12,19 @@ test('avoid parse ensureError twice', t => {
 
 test('protocolError', t => {
   const parsedError = errors.ensureError({
-    message: 'Protocol error (Runtime.callFunctionOn): Target closed.'
+    message: 'Protocol error (Page.printToPDF): Printing failed'
   })
 
   t.true(parsedError instanceof Error)
   t.is(parsedError.name, 'BrowserlessError')
   t.is(parsedError.code, 'EPROTOCOL')
-  t.is(parsedError.message, 'EPROTOCOL, Target closed.')
+  t.is(parsedError.message, 'EPROTOCOL, Printing failed')
 
-  const error = errors.protocolError({ message: 'Target closed.' })
+  const error = errors.protocolError({ message: 'Printing failed' })
   t.true(error instanceof Error)
   t.is(error.name, 'BrowserlessError')
   t.is(error.code, 'EPROTOCOL')
-  t.is(error.message, 'EPROTOCOL, Target closed.')
+  t.is(error.message, 'EPROTOCOL, Printing failed')
 })
 
 test('browserTimeout', t => {
@@ -92,6 +92,26 @@ test('evaluationFailed', t => {
   }
 })
 
+test('contextDisconnected from Runtime.evaluate Target closed', t => {
+  const error = errors.ensureError({
+    message: 'Protocol error (Runtime.evaluate): Protocol error (Runtime.evaluate): Target closed'
+  })
+
+  t.true(error instanceof Error)
+  t.is(error.name, 'BrowserlessError')
+  t.is(error.code, 'EBRWSRCONTEXTCONNRESET')
+})
+
+test('contextDisconnected from Runtime.callFunctionOn Target closed', t => {
+  const error = errors.ensureError({
+    message: 'Protocol error (Runtime.callFunctionOn): Target closed.'
+  })
+
+  t.true(error instanceof Error)
+  t.is(error.name, 'BrowserlessError')
+  t.is(error.code, 'EBRWSRCONTEXTCONNRESET')
+})
+
 test('contextDisconnected from "Session closed"', t => {
   const error = errors.ensureError({
     message: 'Session closed. Most likely the page has been closed.'
@@ -135,6 +155,16 @@ test('isContextDestroyed', t => {
   t.true(
     errors.isContextDestroyed({
       message: 'Protocol error (Target.createTarget): Target closed'
+    })
+  )
+  t.true(
+    errors.isContextDestroyed({
+      message: 'Protocol error (Runtime.evaluate): Protocol error (Runtime.evaluate): Target closed'
+    })
+  )
+  t.true(
+    errors.isContextDestroyed({
+      message: 'Protocol error (Runtime.callFunctionOn): Target closed.'
     })
   )
   t.true(

--- a/packages/errors/test/index.js
+++ b/packages/errors/test/index.js
@@ -102,6 +102,14 @@ test('contextDisconnected from Runtime.evaluate Target closed', t => {
   t.is(error.code, 'EBRWSRCONTEXTCONNRESET')
 })
 
+test('Evaluation failed: Target closed stays EINVALEVAL', t => {
+  const error = errors.ensureError({
+    message: 'Evaluation failed: Target closed'
+  })
+
+  t.is(error.code, 'EINVALEVAL')
+})
+
 test('contextDisconnected from Runtime.callFunctionOn Target closed', t => {
   const error = errors.ensureError({
     message: 'Protocol error (Runtime.callFunctionOn): Target closed.'
@@ -184,6 +192,7 @@ test('isContextDestroyed', t => {
   // The inverse race: an operation ran before the main frame attached.
   t.true(errors.isContextDestroyed({ message: 'Requesting main frame too early!' }))
 
+  t.false(errors.isContextDestroyed({ message: 'Evaluation failed: Target closed' }))
   t.false(errors.isContextDestroyed({ message: 'Evaluation failed: boom' }))
   t.false(errors.isContextDestroyed({ message: 'Navigation timeout of 30000 ms exceeded' }))
   t.false(errors.isContextDestroyed('boom'))

--- a/packages/screenshot/src/is-transient-context-loss.js
+++ b/packages/screenshot/src/is-transient-context-loss.js
@@ -11,7 +11,10 @@ const { isContextDestroyed } = require('@browserless/errors')
 // (`CdpSession.send` raises it the moment `detached` is set). Ask it as well as
 // the page: the session flips first, so between the two there is a window where
 // every call throws yet `isClosed()` still answers false.
+const isDeadTarget = error =>
+  error?.name === 'TargetCloseError' || (error?.message || '').includes('Target closed')
+
 const isTransientContextLoss = (page, error) =>
-  isContextDestroyed(error) && error?.name !== 'TargetCloseError' && !page.isClosed()
+  isContextDestroyed(error) && !isDeadTarget(error) && !page.isClosed()
 
 module.exports = isTransientContextLoss

--- a/packages/screenshot/test/capture-navigation-retry.js
+++ b/packages/screenshot/test/capture-navigation-retry.js
@@ -47,6 +47,35 @@ test('a closed page is terminal even for an otherwise transient error', async t 
   t.is(waits, 0)
 })
 
+test('a protocol Target closed is terminal even without TargetCloseError', async t => {
+  let attempts = 0
+  let waits = 0
+
+  const error = await t.throwsAsync(
+    captureWithNavigationRetry(
+      () => {
+        attempts++
+        throw new Error(
+          'Protocol error (Runtime.evaluate): Protocol error (Runtime.evaluate): Target closed'
+        )
+      },
+      {
+        page: createPage({ isClosed: false }),
+        goto: {
+          waitUntilAuto: async () => {
+            waits++
+          }
+        },
+        timeout: 5000
+      }
+    )
+  )
+
+  t.true(error.message.includes('Target closed'))
+  t.is(attempts, 1, 'a gone target is never retried in place')
+  t.is(waits, 0)
+})
+
 test('a detached session is terminal even while the page still reports open', async t => {
   let attempts = 0
   let waits = 0


### PR DESCRIPTION
## Summary

- `Runtime.evaluate` / `Runtime.callFunctionOn` `Target closed` is the same page teardown as `Session closed`, not a bad CDP payload.
- `ensureError` now maps any `Target closed` to `EBRWSRCONTEXTCONNRESET` so `withPage` retries a dead page as context loss.
- Q7M (`performance mark has not been set`) already maps to `contextDisconnected` in `@browserless/lighthouse`. Soft-null of `insights.lighthouse` stays in microlink-api.

Companion: https://gitlab.com/microlink/api/-/merge_requests/1824

## Test plan

- [x] `pnpm --filter @browserless/errors test` (14 passed)
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification of browser context disconnection errors from runtime operations.
  * Prevented evaluation failures that mention “Target closed” from being incorrectly classified as context disconnections.
  * Prevented terminal “Target closed” errors from triggering unnecessary screenshot retries or navigation waits.
  * Standardized protocol error handling and messaging for printing failures.
* **Documentation**
  * Updated error-handling examples to reflect current protocol and browser context disconnection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->