### PR TITLE
feat(capture): add page.record() mode

### DIFF
--- a/packages/capture/README.md
+++ b/packages/capture/README.md
@@ -103,15 +103,17 @@ Each capture mode is a separate entry point, so you pull in only what you use
 const createCapture = require('@browserless/capture') // extension (default)
 const createCapture = require('@browserless/capture/screencast')
 const createCapture = require('@browserless/capture/screenshot')
+const createCapture = require('@browserless/capture/record')
 ```
 
-All three share the same factory signature — `createCapture({ goto })(page)(url, opts)`.
+All four share the same factory signature — `createCapture({ goto })(page)(url, opts)`.
 
 | Entry point | How | Notes |
 | --- | --- | --- |
 | `@browserless/capture` (`/extension`) | In-browser MediaRecorder via the bundled extension (`tabCapture`). | Default. Device-pixel (retina) output. Captures `audio`. |
 | `@browserless/capture/screencast` | CDP `Page.startScreencast` frames muxed into ffmpeg. | Video-only (`video: false` throws). CSS-pixel output. Requires `ffmpeg`. |
 | `@browserless/capture/screenshot` | Polled `page.screenshot` frames muxed into ffmpeg. | Video-only. The only mode that captures accelerated layers (WebGL/canvas/video). Device-pixel output, bounded by screenshot latency. Requires `ffmpeg`. |
+| `@browserless/capture/record` | Puppeteer `page.record()` (`Page.startScreenRecording`). | Video-only. MP4 only (`type: 'webm'` throws). CSS-pixel output. Requires Chrome M153+; no ffmpeg. |
 
 ## Exports
 

--- a/packages/capture/package.json
+++ b/packages/capture/package.json
@@ -9,6 +9,7 @@
     "./extension": "./src/extension/index.js",
     "./screencast": "./src/screencast/index.js",
     "./screenshot": "./src/screenshot/index.js",
+    "./record": "./src/record/index.js",
     "./package.json": "./package.json"
   },
   "author": {

--- a/packages/capture/src/create-capture.js
+++ b/packages/capture/src/create-capture.js
@@ -26,7 +26,7 @@ const prepareViewport = async (goto, page, opts) => {
 }
 
 // Build the public capture factory for a given mode. Each mode (extension /
-// screencast / screenshot) is published as its own entry point and wraps its
+// screencast / screenshot / record) is published as its own entry point and wraps its
 // runner with this shared "navigate concurrently inside the recording window"
 // flow, so the selected mode is explicit at `require` time rather than dispatched
 // from an option at call time.

--- a/packages/capture/src/create-capture.js
+++ b/packages/capture/src/create-capture.js
@@ -25,11 +25,10 @@ const prepareViewport = async (goto, page, opts) => {
   return page.viewport()
 }
 
-// Build the public capture factory for a given mode. Each mode (extension /
-// screencast / screenshot / record) is published as its own entry point and wraps its
-// runner with this shared "navigate concurrently inside the recording window"
-// flow, so the selected mode is explicit at `require` time rather than dispatched
-// from an option at call time.
+// Build the public capture factory for a given mode. Each mode is published as
+// its own entry point and wraps its runner with this shared "navigate
+// concurrently inside the recording window" flow, so the selected mode is
+// explicit at `require` time rather than dispatched from an option at call time.
 module.exports =
   (runMode, mode) =>
     ({ goto, ...gotoOpts } = {}) => {

--- a/packages/capture/src/index.js
+++ b/packages/capture/src/index.js
@@ -16,12 +16,13 @@ const { ENCODERS } = require('./recorder/ffmpeg')
 //   require('@browserless/capture')             // extension (default)
 //   require('@browserless/capture/screencast')  // CDP screencast + ffmpeg
 //   require('@browserless/capture/screenshot')  // polled screenshot + ffmpeg
+//   require('@browserless/capture/record')      // page.record() (Chrome M153+)
 module.exports = require('./extension')
 
 module.exports.extensionPath = EXTENSION_PATH
 module.exports.extensionId = EXTENSION_ID
 module.exports.TYPES = TYPES
-module.exports.MODES = ['extension', 'screencast', 'screenshot']
+module.exports.MODES = ['extension', 'screencast', 'screenshot', 'record']
 module.exports.ENCODERS = ENCODERS
 module.exports.DEFAULT = DEFAULT
 module.exports.DEFAULT_CODEC_BY_TYPE = DEFAULT_CODEC_BY_TYPE

--- a/packages/capture/src/record/index.js
+++ b/packages/capture/src/record/index.js
@@ -23,28 +23,29 @@ const runRecord = async (page, opts, viewport, { onStarted } = {}) => {
   }
 
   const { path: outputPath, duration = DEFAULT.duration, fps = DEFAULT.fps, audio = false } = opts
+  const recorder = await page.record({
+    audio: Boolean(audio),
+    frameRate: fps,
+    maxWidth: even(viewport.width),
+    maxHeight: even(viewport.height)
+  })
 
   const chunks = []
+  const recordingWindow = new AbortController()
   let captureError
   let navigation = Promise.resolve()
-  let recorder
-  const recordingWindow = new AbortController()
 
+  // Start the source, then navigate concurrently so load animations are in the
+  // clip. A goto failure aborts the window early; the first error wins.
   try {
-    recorder = await page.record({
-      audio: Boolean(audio),
-      frameRate: fps,
-      maxWidth: even(viewport.width),
-      maxHeight: even(viewport.height)
-    })
-    const sink = new Writable({
-      write (chunk, _encoding, callback) {
-        chunks.push(Buffer.from(chunk))
-        callback()
-      }
-    })
-    recorder.pipe(sink)
-
+    recorder.pipe(
+      new Writable({
+        write (chunk, _encoding, callback) {
+          chunks.push(Buffer.from(chunk))
+          callback()
+        }
+      })
+    )
     navigation = Promise.resolve(onStarted?.()).catch(error => {
       captureError = error
       recordingWindow.abort()
@@ -53,11 +54,9 @@ const runRecord = async (page, opts, viewport, { onStarted } = {}) => {
   } catch (error) {
     captureError = captureError || error
   } finally {
-    if (recorder) {
-      await recorder.stop().catch(error => {
-        captureError = captureError || error
-      })
-    }
+    await recorder.stop().catch(error => {
+      captureError = captureError || error
+    })
   }
 
   await navigation

--- a/packages/capture/src/record/index.js
+++ b/packages/capture/src/record/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { setTimeout: delay } = require('timers/promises')
+const { Writable } = require('stream')
 const fs = require('fs/promises')
 const debug = require('debug-logfmt')('browserless:capture')
 
@@ -36,13 +37,13 @@ const runRecord = async (page, opts, viewport, { onStarted } = {}) => {
       maxWidth: even(viewport.width),
       maxHeight: even(viewport.height)
     })
-    recorder.pipe({
-      write (chunk) {
+    const sink = new Writable({
+      write (chunk, _encoding, callback) {
         chunks.push(Buffer.from(chunk))
-        return true
-      },
-      end: NOOP
+        callback()
+      }
     })
+    recorder.pipe(sink)
 
     navigation = Promise.resolve(onStarted?.()).catch(error => {
       captureError = error

--- a/packages/capture/src/record/index.js
+++ b/packages/capture/src/record/index.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const { setTimeout: delay } = require('timers/promises')
+const fs = require('fs/promises')
+const debug = require('debug-logfmt')('browserless:capture')
+
+const createCapture = require('../create-capture')
+const { even } = require('../recorder')
+const { DEFAULT, NOOP } = require('../constants')
+
+const isWebm = type => String(type).trim().toLowerCase().replace(/^\./, '') === 'webm'
+
+const runRecord = async (page, opts, viewport, { onStarted } = {}) => {
+  if (opts.video === false) {
+    throw new TypeError('The record mode captures video; `video` cannot be disabled.')
+  }
+  if (opts.type !== undefined && isWebm(opts.type)) {
+    throw new TypeError('The record mode outputs mp4; `type` cannot be `webm`.')
+  }
+  if (typeof page.record !== 'function') {
+    throw new Error('page.record() requires puppeteer >= 25.10 and Chrome M153+.')
+  }
+
+  const { path: outputPath, duration = DEFAULT.duration, fps = DEFAULT.fps, audio = false } = opts
+
+  const chunks = []
+  let captureError
+  let navigation = Promise.resolve()
+  let recorder
+  const recordingWindow = new AbortController()
+
+  try {
+    recorder = await page.record({
+      audio: Boolean(audio),
+      frameRate: fps,
+      maxWidth: even(viewport.width),
+      maxHeight: even(viewport.height)
+    })
+    recorder.pipe({
+      write (chunk) {
+        chunks.push(Buffer.from(chunk))
+        return true
+      },
+      end: NOOP
+    })
+
+    navigation = Promise.resolve(onStarted?.()).catch(error => {
+      captureError = error
+      recordingWindow.abort()
+    })
+    await delay(duration, undefined, { signal: recordingWindow.signal }).catch(NOOP)
+  } catch (error) {
+    captureError = captureError || error
+  } finally {
+    if (recorder) {
+      await recorder.stop().catch(error => {
+        captureError = captureError || error
+      })
+    }
+  }
+
+  await navigation
+  if (captureError) throw captureError
+
+  const buffer = Buffer.concat(chunks)
+  if (buffer.length === 0) {
+    throw new Error('No video data was captured. Increase `duration` or verify the page renders.')
+  }
+
+  if (outputPath) {
+    await fs.writeFile(outputPath, buffer)
+    debug('record.writeFile', { outputPath, bytes: buffer.length })
+  }
+
+  return buffer
+}
+
+module.exports = createCapture(runRecord, 'record')

--- a/packages/capture/test/index.js
+++ b/packages/capture/test/index.js
@@ -522,22 +522,17 @@ test('record starts before goto', async t => {
   const createRecordCapture = require('../src/record')
   const { page } = createFixture()
   const events = []
-  page.record = async () => {
+  attachFakeRecord(page)
+  const start = page.record
+  page.record = async options => {
     events.push('record')
-    const destinations = []
-    return {
-      pipe (destination) {
-        destinations.push(destination)
-        return destination
-      },
-      async stop () {
-        events.push('stop')
-        for (const dest of destinations) {
-          dest.write(Buffer.from('mp4'))
-          dest.end?.()
-        }
-      }
+    const recorder = await start(options)
+    const { stop } = recorder
+    recorder.stop = async () => {
+      events.push('stop')
+      return stop()
     }
+    return recorder
   }
   const capture = createRecordCapture({
     goto: createGoto(() => {

--- a/packages/capture/test/index.js
+++ b/packages/capture/test/index.js
@@ -417,7 +417,7 @@ test('exports capture format defaults', t => {
 
   t.deepEqual(createCapture.TYPES, ['webm', 'mp4'])
   t.is(createCapture.DEFAULT.type, 'mp4')
-  t.deepEqual(createCapture.MODES, ['extension', 'screencast', 'screenshot'])
+  t.deepEqual(createCapture.MODES, ['extension', 'screencast', 'screenshot', 'record'])
 })
 
 test('the default entry point ignores an unknown `mode` option', async t => {
@@ -454,6 +454,98 @@ test('screenshot entry point rejects when `video` is disabled', async t => {
     instanceOf: TypeError,
     message: /video.*cannot be disabled/
   })
+})
+
+const attachFakeRecord = (page, { chunks = [Buffer.from('mp4')] } = {}) => {
+  const calls = []
+  page.record = async options => {
+    calls.push(options)
+    const destinations = []
+    return {
+      pipe (destination) {
+        destinations.push(destination)
+        return destination
+      },
+      async stop () {
+        for (const dest of destinations) {
+          for (const chunk of chunks) dest.write(chunk)
+          dest.end?.()
+        }
+      }
+    }
+  }
+  return calls
+}
+
+test('record entry point returns the recorded buffer', async t => {
+  const createRecordCapture = require('../src/record')
+  const { page } = createFixture()
+  const calls = attachFakeRecord(page, { chunks: [Buffer.from('aaa'), Buffer.from('bbb')] })
+  const capture = createRecordCapture({ goto: createGoto() })
+  const result = await capture(page)('https://example.com', { duration: 20, fps: 24 })
+  t.deepEqual(result, Buffer.from('aaabbb'))
+  t.deepEqual(calls, [{ audio: false, frameRate: 24, maxWidth: 1280, maxHeight: 800 }])
+})
+
+test('record entry point rejects when `video` is disabled', async t => {
+  const createRecordCapture = require('../src/record')
+  const { page } = createFixture()
+  attachFakeRecord(page)
+  const capture = createRecordCapture({ goto: createGoto() })
+  await t.throwsAsync(() => capture(page)('https://example.com', { video: false, duration: 20 }), {
+    instanceOf: TypeError,
+    message: /video.*cannot be disabled/
+  })
+})
+
+test('record entry point rejects `type: webm`', async t => {
+  const createRecordCapture = require('../src/record')
+  const { page } = createFixture()
+  attachFakeRecord(page)
+  const capture = createRecordCapture({ goto: createGoto() })
+  await t.throwsAsync(() => capture(page)('https://example.com', { type: 'webm', duration: 20 }), {
+    instanceOf: TypeError,
+    message: /mp4.*webm/
+  })
+})
+
+test('record entry point rejects when `page.record` is missing', async t => {
+  const createRecordCapture = require('../src/record')
+  const { page } = createFixture()
+  const capture = createRecordCapture({ goto: createGoto() })
+  await t.throwsAsync(() => capture(page)('https://example.com', { duration: 20 }), {
+    message: /puppeteer >= 25\.10 and Chrome M153/
+  })
+})
+
+test('record starts before goto', async t => {
+  const createRecordCapture = require('../src/record')
+  const { page } = createFixture()
+  const events = []
+  page.record = async () => {
+    events.push('record')
+    const destinations = []
+    return {
+      pipe (destination) {
+        destinations.push(destination)
+        return destination
+      },
+      async stop () {
+        events.push('stop')
+        for (const dest of destinations) {
+          dest.write(Buffer.from('mp4'))
+          dest.end?.()
+        }
+      }
+    }
+  }
+  const capture = createRecordCapture({
+    goto: createGoto(() => {
+      events.push('goto')
+    })
+  })
+  await capture(page)('https://example.com', { duration: 20 })
+  t.deepEqual(events, ['record', 'goto', 'stop'])
 })
 
 test('sizes constraints from the resolved device viewport', async t => {


### PR DESCRIPTION
## Summary
- Add `@browserless/capture/record`, wrapping Puppeteer `page.record()` so Chrome M153+ can emit MP4 without ffmpeg.
- Same factory as the other modes (`createCapture({ goto })(page)(url, opts) → Buffer`). `video: false` and `type: 'webm'` throw; missing `page.record` explains the Chrome requirement.
- Default entry stays extension. Do not flip API default until the fleet browser is M153+ (Puppeteer 25.10 still ships Chrome 152).

## Test plan
- [x] Unit tests with a fake `page.record()` (buffer, `video: false`, `webm`, missing API, record-before-goto)
- [ ] After publish: wire `CAPTURE_BACKENDS.record` in microlink/api and A/B via `x-animated-backend: record`
- [ ] On Chrome 153+, compare against screencast with `benchmark/animated-capture.js --backend=record`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a recording capture mode for producing MP4 video recordings.
  * Added a dedicated recording entry point with configurable audio, frame rate, dimensions, duration, and output path.
  * Recording starts before navigation and supports callback notifications when recording begins.
  * Recording output uses CSS-pixel dimensions and requires Chrome M153 or newer.

* **Documentation**
  * Updated capture mode documentation and examples, including recording requirements and supported options.
  * Documented that recording does not require ffmpeg and does not support WebM output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->