### PR TITLE
fix(devices): sync Chrome UA with Puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ Used to set a specific device type, this method sets the device properties.
 browserless.getDevice({ device: 'Macbook Pro 15' })
 
 // => {
-//   userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36',
+//   userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/<chromium> Safari/537.36',
 //   viewport: {
 //     width: 1440,
 //     height: 900,

--- a/packages/devices/README.md
+++ b/packages/devices/README.md
@@ -49,7 +49,7 @@ Each device descriptor includes:
 
 ### Custom Devices
 
-This package extends [Puppeteer's KnownDevices](https://pptr.dev/api/puppeteer.knowndevices/) with additional desktop devices:
+This package extends [Puppeteer's KnownDevices](https://pptr.dev/api/puppeteer.knowndevices/) with additional desktop devices. Chrome user agents (including Puppeteer's Android descriptors) are rewritten at runtime to `puppeteer.PUPPETEER_REVISIONS.chrome`. Safari/iOS descriptors are left unchanged.
 
 | Device | Resolution | Scale |
 |--------|------------|-------|

--- a/packages/devices/src/devices.json
+++ b/packages/devices/src/devices.json
@@ -1,7 +1,6 @@
 {
   "Macbook Pro 13": {
     "name": "Macbook Pro 13",
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36",
     "viewport": {
       "width": 1280,
       "height": 800,
@@ -13,7 +12,6 @@
   },
   "Macbook Pro 15": {
     "name": "Macbook Pro 15",
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36",
     "viewport": {
       "width": 1440,
       "height": 900,
@@ -25,7 +23,6 @@
   },
   "Macbook Pro 16": {
     "name": "Macbook Pro 16",
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36",
     "viewport": {
       "width": 1536,
       "height": 960,
@@ -37,7 +34,6 @@
   },
   "iMac 21": {
     "name": "iMac 21",
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36",
     "viewport": {
       "width": 1980,
       "height": 1080,
@@ -49,7 +45,6 @@
   },
   "iMac 21 4K": {
     "name": "iMac 21 4K",
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36",
     "viewport": {
       "width": 2048,
       "height": 1152,
@@ -61,7 +56,6 @@
   },
   "iMac 24 4.5K": {
     "name": "iMac 24 4.5K",
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36",
     "viewport": {
       "width": 4480,
       "height": 2520,
@@ -73,7 +67,6 @@
   },
   "iMac 27": {
     "name": "iMac 27",
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36",
     "viewport": {
       "width": 2560,
       "height": 1440,
@@ -85,7 +78,6 @@
   },
   "iMac 27 5K": {
     "name": "iMac 27 5K",
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.89 Safari/537.36",
     "viewport": {
       "width": 2560,
       "height": 1440,

--- a/packages/devices/src/index.js
+++ b/packages/devices/src/index.js
@@ -6,12 +6,35 @@ const memoizeOne = require('memoize-one')
 
 const customDevices = require('./devices.json')
 
-module.exports = ({
+const desktopUserAgent = chromeVersion =>
+  `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`
+
+const syncChromeVersion = (userAgent, chromeVersion) =>
+  chromeVersion ? userAgent.replace(/Chrome\/[\d.]+/g, `Chrome/${chromeVersion}`) : userAgent
+
+const withChromeVersion = (source, chromeVersion) => {
+  const devices = {}
+
+  for (const [name, device] of Object.entries(source)) {
+    const userAgent = device.userAgent
+      ? syncChromeVersion(device.userAgent, chromeVersion)
+      : chromeVersion
+        ? desktopUserAgent(chromeVersion)
+        : device.userAgent
+
+    devices[name] = userAgent === device.userAgent ? device : { ...device, userAgent }
+  }
+
+  return devices
+}
+
+const createGetDevice = ({
   puppeteer = requireOneOf(['puppeteer', 'puppeteer-core', 'puppeteer-firefox']),
   lossyDeviceName = true
 } = {}) => {
   const { KnownDevices: puppeteerDevices } = puppeteer
-  const devices = { ...puppeteerDevices, ...customDevices }
+  const chromeVersion = puppeteer.PUPPETEER_REVISIONS?.chrome
+  const devices = withChromeVersion({ ...puppeteerDevices, ...customDevices }, chromeVersion)
   const deviceDescriptors = Object.keys(devices)
 
   const findDevice = memoizeOne((deviceDescriptor, lossyEnabled) => {
@@ -41,6 +64,11 @@ module.exports = ({
   getDevices.devices = devices
   getDevices.findDevice = findDevice
   getDevices.deviceDescriptors = deviceDescriptors
+  getDevices.chromeVersion = chromeVersion
 
   return getDevices
 }
+
+createGetDevice.syncChromeVersion = syncChromeVersion
+
+module.exports = createGetDevice

--- a/packages/devices/test/index.js
+++ b/packages/devices/test/index.js
@@ -42,3 +42,43 @@ test('support lossy device name', t => {
   t.deepEqual(getDevice({ device: 'macbook pro' }), device)
   t.deepEqual(getDevice({ device: 'macboo pro' }), device)
 })
+
+test('aligns Chrome user agents with the installed Puppeteer', t => {
+  const chromeVersion = '149.0.7827.22'
+  const getDevice = createGetDevice({
+    puppeteer: {
+      PUPPETEER_REVISIONS: { chrome: chromeVersion },
+      KnownDevices: {
+        'Galaxy S8': {
+          name: 'Galaxy S8',
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 7.0; SM-G950U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36',
+          viewport: { width: 360, height: 740 }
+        },
+        'iPhone 13': {
+          name: 'iPhone 13',
+          userAgent:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
+          viewport: { width: 390, height: 844 }
+        }
+      }
+    }
+  })
+
+  t.is(getDevice.chromeVersion, chromeVersion)
+  t.is(
+    getDevice({ device: 'Macbook Pro 13' }).userAgent,
+    `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`
+  )
+  t.true(getDevice({ device: 'Galaxy S8' }).userAgent.includes(`Chrome/${chromeVersion}`))
+  t.false(getDevice({ device: 'iPhone 13' }).userAgent.includes('Chrome/'))
+})
+
+test('does not ship a frozen Chrome 62 user agent', t => {
+  const getDevice = createGetDevice()
+  const { userAgent } = getDevice({ device: 'Macbook Pro 13' })
+
+  t.true(userAgent.includes(`Chrome/${getDevice.chromeVersion}`))
+  t.false(userAgent.includes('Chrome/62'))
+  t.false(userAgent.includes('10_12_6'))
+})

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -30,7 +30,7 @@ const chromeVersionFromBrowser = async page => {
     if (chromeVersionCache.has(browser)) return chromeVersionCache.get(browser)
     const raw = await browser.version().catch(() => {})
     const version = raw?.match(/^(?:Headless)?Chrome\/([\d.]+)/)?.[1]
-    chromeVersionCache.set(browser, version)
+    if (version) chromeVersionCache.set(browser, version)
     return version
   } catch {
     return undefined
@@ -389,7 +389,7 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
     })
 
     if (device.userAgent && !rawHeaders['user-agent']) {
-      rawHeaders['user-agent'] = syncChromeVersion(
+      device.userAgent = rawHeaders['user-agent'] = syncChromeVersion(
         device.userAgent,
         (await chromeVersionFromBrowser(page)) || getDevice.chromeVersion
       )

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -3,6 +3,7 @@
 const { shallowEqualObjects } = require('shallow-equal')
 const { setTimeout } = require('node:timers/promises')
 const createDevices = require('@browserless/devices')
+const { syncChromeVersion } = createDevices
 const toughCookie = require('tough-cookie')
 const pReflect = require('p-reflect')
 const pTimeout = require('p-timeout')
@@ -20,6 +21,21 @@ debug.abort = require('debug-logfmt')('browserless:goto:abort')
 const truncate = (str, n = 80) => (str.length > n ? str.substr(0, n - 1) + '…' : str)
 
 const isEmpty = val => val == null || !(Object.keys(val) || val).length
+
+const chromeVersionCache = new WeakMap()
+
+const chromeVersionFromBrowser = async page => {
+  try {
+    const browser = page.browser()
+    if (chromeVersionCache.has(browser)) return chromeVersionCache.get(browser)
+    const raw = await browser.version().catch(() => {})
+    const version = raw?.includes('/') ? raw.split('/')[1] : undefined
+    chromeVersionCache.set(browser, version)
+    return version
+  } catch {
+    return undefined
+  }
+}
 
 const castArray = value => [].concat(value).filter(Boolean)
 
@@ -373,7 +389,10 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
     })
 
     if (device.userAgent && !rawHeaders['user-agent']) {
-      rawHeaders['user-agent'] = device.userAgent
+      rawHeaders['user-agent'] = syncChromeVersion(
+        device.userAgent,
+        (await chromeVersionFromBrowser(page)) || getDevice.chromeVersion
+      )
     }
 
     if (!isEmpty(device.viewport) && !shallowEqualObjects(defaultViewport, device.viewport)) {

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -29,7 +29,7 @@ const chromeVersionFromBrowser = async page => {
     const browser = page.browser()
     if (chromeVersionCache.has(browser)) return chromeVersionCache.get(browser)
     const raw = await browser.version().catch(() => {})
-    const version = raw?.includes('/') ? raw.split('/')[1] : undefined
+    const version = raw?.match(/^(?:Headless)?Chrome\/([\d.]+)/)?.[1]
     chromeVersionCache.set(browser, version)
     return version
   } catch {


### PR DESCRIPTION
## Summary
- Stop shipping frozen Chrome 62 user agents in `devices.json`. Desktop descriptors are viewport-only; Chrome UAs are built at runtime from `puppeteer.PUPPETEER_REVISIONS.chrome`.
- Rewrite Puppeteer's Android Chrome UAs the same way. Safari/iOS descriptors are left unchanged.
- `goto` rewrites once more from the live `browser.version()` so a cached or custom binary cannot drift from the UA the page sends.

## Test plan
- [x] `pnpm --filter @browserless/devices test`
- [ ] Confirm a default `Macbook Pro 13` navigation no longer logs `Chrome/62`
- [ ] Confirm an explicit `iPhone 13` device still uses a Safari UA


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device profiles now use the current Chrome version instead of a fixed legacy version.
  * Browser navigation user-agent headers stay synchronized with the running browser version.
  * Safari and iOS device user agents remain unchanged.

* **Documentation**
  * Updated examples and custom device guidance to explain dynamic Chrome user-agent versioning.

* **Tests**
  * Added coverage confirming current Chrome versions are used and non-Chromium devices do not receive Chrome user-agent tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->