### PR TITLE
fix(browserless): read text() in an isolated world

### DIFF
--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -205,7 +205,12 @@ module.exports = ({ timeout: globalTimeout = 30000, ...launchOpts } = {}) => {
       page: createPage,
       pdf: withPage(createPdf({ goto })),
       screenshot: withPage(createScreenshot({ goto })),
-      text: evaluate(page => page.evaluate(() => document.body.innerText)),
+      text: evaluate(page =>
+        page
+          .mainFrame()
+          .isolatedRealm()
+          .evaluate(() => document.body.innerText)
+      ),
       getDevice: goto.getDevice,
       destroyContext,
       withPage

--- a/packages/browserless/test/text.js
+++ b/packages/browserless/test/text.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const test = require('ava')
+
+const { runServer, getBrowserContext } = require('@browserless/test')
+
+const getInnerTextSpyUrl = async t => {
+  const foreignReads = []
+
+  const url = await runServer(t, ({ req, res }) => {
+    if (req.method === 'POST') {
+      let body = ''
+      req.on('data', chunk => {
+        body += chunk
+      })
+      req.on('end', () => {
+        foreignReads.push(body)
+        res.end()
+      })
+      return
+    }
+
+    res.setHeader('content-type', 'text/html')
+    res.end(`<!DOCTYPE html>
+<html>
+<head>
+  <script>
+    const descriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'innerText')
+    Object.defineProperty(HTMLElement.prototype, 'innerText', {
+      ...descriptor,
+      get () {
+        const callers = new Error().stack.split('\\n').slice(2)
+        if (!callers.some(line => line.includes(location.origin))) {
+          const request = new XMLHttpRequest()
+          request.open('POST', '/foreign-read', false)
+          request.send(callers.join('\\n'))
+        }
+        return descriptor.get.call(this)
+      }
+    })
+  </script>
+</head>
+<body>
+  <p>hello world</p>
+</body>
+</html>`)
+  })
+
+  return { url, foreignReads }
+}
+
+test('page hook detects innerText reads from the main world', async t => {
+  const browserless = await getBrowserContext(t)
+  const { url, foreignReads } = await getInnerTextSpyUrl(t)
+
+  const text = await browserless.evaluate(page => page.evaluate(() => document.body.innerText))(
+    url,
+    { adblock: false }
+  )
+
+  t.is(text, 'hello world')
+  t.true(foreignReads.length > 0)
+})
+
+test('text() is invisible to main world innerText hooks', async t => {
+  const browserless = await getBrowserContext(t)
+  const { url, foreignReads } = await getInnerTextSpyUrl(t)
+
+  const text = await browserless.text(url, { adblock: false })
+
+  t.is(text, 'hello world')
+  t.deepEqual(foreignReads, [])
+})


### PR DESCRIPTION
## Summary

`browserless.text()` read `document.body.innerText` in the page's main world. A page that hooks the `HTMLElement.prototype.innerText` getter sees the call, and the stack names the automation framework:

```
at pptr:evaluate;%2F...%2Fpackages%2Fbrowserless%2Fsrc%2Findex.js%3A208%3A35:1:22
```

This PR reads `innerText` from Puppeteer's isolated world. That world shares the DOM, but page JavaScript can't hook or observe it.

## Why `frame.isolatedRealm()`

- **Round trips:** it costs one, the same as today, because Puppeteer already creates the utility world on page init.
- **Stability:** it's marked `@internal` in puppeteer-core 25.1.0 (`src/api/Frame.ts:418`). But Puppeteer's own public `Frame` methods use it internally (`Frame.ts:452`, `Frame.ts:941`), so it can't be removed without rewriting those.
- **Public alternative:** a CDP session plus `Page.createIsolatedWorld` plus `Runtime.evaluate` with a `contextId` is 3–4 round trips per call. That trades latency for API purity, which isn't worth it on a hot path.
- **Breakage guard:** if a Puppeteer bump ever removes it, `test/text.js` fails right away.

## Evidence

Page with a main-world `innerText` getter hook that reports non-origin callers over a synchronous XHR. 5 `text()` calls, adblock off, so only `text()` itself is measured:

| | origin/master | this PR |
|---|---|---|
| foreign `innerText` reads | **5** | **0** |
| foreign stack | `at pptr:evaluate;…packages/browserless/src/index.js:208` | none |
| text returned | `hello probe` | `hello probe` |
| `text()` median | 607 ms | 591 ms |

With adblock on (the default), the remaining foreign reads come from autoconsent (`hideElements`, `AutoConsent.detectHeuristics`). That's out of scope here and tracked separately.

## Tests

- **New `test/text.js`**, two tests:
  - A positive control: the fixture hook catches a main-world `page.evaluate` read, so the test can't pass vacuously.
  - `text()` returns `hello world` while the hook records nothing.
- **Fails on origin/master** with exactly the `index.js:208` `pptr:evaluate` stack. Passes with this change.
- **`standard` and `prettier-standard`** are clean.
- **Full `browserless` suite on macOS: 52/57 pass.** The 5 failures reproduce when run alone and are local-environment issues unrelated to `text()`:
  - 3 `.screenshot` pixel-diff comparisons (244–815 px) against the Linux snapshots
  - 2 `report()` WebGL assertions (`--use-angle=gl` needs Mesa/Xvfb, as set up in CI)

  CI on Linux is the gate for those.

## Outcome

`text()` no longer leaves a Puppeteer-branded stack trace or any main-world footprint that page scripts can detect, with no added latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116zka7w2WKPSi3kqHyVAET

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how visible page text is extracted on a hot path and relies on Puppeteer’s internal `isolatedRealm()` API, though behavior and latency are intended to stay the same.
> 
> **Overview**
> **`browserless.text()`** no longer reads `document.body.innerText` via main-world `page.evaluate`, which let hostile pages hook `HTMLElement.prototype.innerText` and see Puppeteer-branded stack traces.
> 
> It now evaluates in Puppeteer’s **isolated realm** on the main frame (`mainFrame().isolatedRealm().evaluate(...)`), so the DOM text is unchanged but page scripts cannot observe the read.
> 
> New **`test/text.js`** adds a page that reports foreign `innerText` access: a control proves main-world reads are detected, and **`text()`** is asserted to return the same content with zero foreign reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98e1b5a2492c81cb7daff0cf13205411e63999eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `text()` API so page body text is read without triggering page-level interception or detection mechanisms.

* **Tests**
  * Added coverage verifying that `text()` returns the expected page content while avoiding unintended cross-context reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->