### PR TITLE
fix(goto): flatten shadow DOM in an isolated world

### DIFF
--- a/packages/browserless/test/shadow-dom.js
+++ b/packages/browserless/test/shadow-dom.js
@@ -276,6 +276,46 @@ test('slots with fallback content use the fallback when no nodes are assigned', 
   t.true(withoutScripts.includes('<span class="default-label">Default</span>'))
 })
 
+const getHookedUrl = t =>
+  runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(`<!DOCTYPE html>
+<html>
+<head>
+  <script>
+    for (const proto of [Document.prototype, Element.prototype, DocumentFragment.prototype]) {
+      const querySelectorAll = proto.querySelectorAll
+      proto.querySelectorAll = function (...args) {
+        document.documentElement.setAttribute('data-main-world-query', 'true')
+        return querySelectorAll.apply(this, args)
+      }
+    }
+    class MyRow extends HTMLElement {
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' })
+        shadow.innerHTML = '<div class="row"><span>' + this.getAttribute('name') + '</span></div>'
+      }
+    }
+    customElements.define('my-row', MyRow)
+  </script>
+</head>
+<body>
+  <my-row name="Alice"></my-row>
+</body>
+</html>`)
+  })
+
+test('shadow DOM flattening is invisible to main-world page scripts', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getHookedUrl(t)
+
+  const html = await browserless.html(url, { adblock: false })
+  const withoutScripts = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+
+  t.true(withoutScripts.includes('<div class="row"><span>Alice</span></div>'))
+  t.false(withoutScripts.includes('data-main-world-query'))
+})
+
 test('custom element attributes are preserved after flattening', async t => {
   const browserless = await getBrowserContext(t)
   const url = await getUrl(t)

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -579,8 +579,9 @@ module.exports = ({ defaultDevice = 'Macbook Pro 13', timeout: globalTimeout, ..
       }
 
       if (flattenShadowDOM) {
+        const isolatedRealm = page.mainFrame().isolatedRealm()
         const { isRejected, reason: flattenError } = await run({
-          fn: page.evaluate(() => {
+          fn: isolatedRealm.evaluate(() => {
             ;(function flatten (root) {
               const replaceSlot = (slot, nodes) => {
                 const parent = slot.parentNode


### PR DESCRIPTION
## Summary
- `flattenShadowDOM` (on by default for `browserless.html()`) ran its walker with `page.evaluate`, i.e. in the page's **main world**. Any page that hooks DOM methods saw it, with a stack that names Puppeteer and our local source path.
- It now runs through `page.mainFrame().isolatedRealm().evaluate(...)`. Isolated worlds share the DOM, so flattening output is identical, but page scripts cannot observe the calls.
- No extra round trip: Puppeteer already creates this utility world for every frame.

## Evidence (main-world `querySelectorAll` hook during `browserless.html(url, { adblock: false })`)
Before (origin/master):
```
"mainWorldQuerySelectorAllCalls": "[\"at flattenChildren (pptr:evaluate;goto (…/packages/goto/src/index.js:583:20):17:39)\", …] total=2"
```
After:
```
"flattened": true,
"mainWorldQuerySelectorAllCalls": "none"
```

## Note
`Frame.isolatedRealm()` is marked `@internal` in puppeteer-core typings, but Puppeteer uses it itself for `Page.waitForSelector` and friends. The public alternative (`createCDPSession` + `Page.createIsolatedWorld` + `Runtime.evaluate`) costs extra CDP round trips per call.

## Test plan
- [x] New regression test `shadow DOM flattening is invisible to main-world page scripts` (packages/browserless/test/shadow-dom.js): fails on origin/master (`data-main-world-query` present), passes with the fix.
- [x] `pnpm --filter browserless exec ava test/shadow-dom.js`: 11 passed.
- [x] `pnpm --filter @browserless/goto test`: all pass except 3 `unit/evasions` WebGL tests that also fail on origin/master locally (macOS, Chrome 152 `getContext('webgl')` returns null); CI runs them on Linux + Mesa.
- [x] `standard` on touched files.

## Outcome
One fewer automation signal: shadow DOM flattening no longer exposes a `pptr:evaluate` frame to page scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116zka7w2WKPSi3kqHyVAET

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how HTML is produced for a default code path and relies on Puppeteer’s internal `isolatedRealm()` API, though behavior is intended to be identical aside from reduced detectability.
> 
> **Overview**
> **Shadow DOM flattening** (default for `browserless.html()`) no longer runs in the page’s main JavaScript world. The flatten walker in `@browserless/goto` now uses `page.mainFrame().isolatedRealm().evaluate(...)` instead of `page.evaluate(...)`, so the DOM is still flattened the same way but **main-world scripts cannot observe** hooked APIs like `querySelectorAll` or Puppeteer stack frames during serialization.
> 
> A regression test adds a page that patches `querySelectorAll` on `Document`/`Element`/`DocumentFragment` and asserts flattened markup appears while `data-main-world-query` is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b00db4eae8e7638eaf88cb37061d13c002de7afa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Shadow DOM flattening now runs in an isolated context, preventing page-level scripts from observing or interfering with the operation.
  - Flattened output continues to include shadow content without adding instrumentation artifacts from page scripts.

- **Tests**
  - Added coverage verifying isolated shadow DOM flattening and the resulting HTML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->