### PR TITLE
fix(browserless): stop disabling standard Web APIs

### DIFF
--- a/packages/browserless/src/driver.js
+++ b/packages/browserless/src/driver.js
@@ -15,11 +15,9 @@ const defaultArgs = [
   '--autoplay-policy=user-gesture-required', // https://source.chromium.org/search?q=lang:cpp+symbol:kAutoplayPolicy&ss=chromium
   '--disable-blink-features=PrettyPrintJSONDocument,AutomationControlled', // https://blog.m157q.tw/posts/2020/09/11/bypass-cloudflare-detection-while-using-selenium-with-chromedriver/
   '--disable-domain-reliability', // https://source.chromium.org/search?q=lang:cpp+symbol:kDisableDomainReliability&ss=chromium
-  '--disable-notifications', // https://source.chromium.org/search?q=lang%3Acpp+symbol%3AkDisablePermissionsAPI&ss=chromium
   '--disable-print-preview', // https://source.chromium.org/search?q=lang:cpp+symbol:kDisablePrintPreview&ss=chromium
   '--disable-setuid-sandbox', // https://source.chromium.org/search?q=lang:cpp+symbol:kDisableSetuidSandbox&ss=chromium
   '--disable-site-isolation-trials', // https://source.chromium.org/search?q=lang:cpp+symbol:kDisableSiteIsolation&ss=chromium
-  '--disable-speech-api', // https://source.chromium.org/search?q=lang:cpp+symbol:kDisableSpeechAPI&ss=chromium
   '--disk-cache-size=33554432', // https://source.chromium.org/search?q=lang:cpp+symbol:kDiskCacheSize&ss=chromium
   '--font-render-hinting=none', // https://github.com/puppeteer/puppeteer/issues/2410#issuecomment-2886054614
   '--ignore-gpu-blocklist', // https://source.chromium.org/search?q=lang:cpp+symbol:kIgnoreGpuBlocklist&ss=chromium
@@ -43,9 +41,7 @@ const defaultArgs = [
     'CanvasOopRasterization',
     'InterestFeedV2',
     'IsolateOrigins',
-    'PushMessaging',
-    'site-per-process', // Disables OOPIF. https://www.chromium.org/Home/chromium-security/site-isolation
-    'WebPayments'
+    'site-per-process' // Disables OOPIF. https://www.chromium.org/Home/chromium-security/site-isolation
   ].join(',')}`
 ]
 

--- a/packages/browserless/test/driver.js
+++ b/packages/browserless/test/driver.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createBrowser } = require('@browserless/test')
+const { createBrowser, getBrowserContext, runServer } = require('@browserless/test')
 const psList = require('ps-list')
 const test = require('ava')
 const browserless = require('..')
@@ -47,6 +47,32 @@ const getChromiumPs = async () => {
 
   await browserlessFactory.close()
   t.is(await getChromiumPs(), initialPs)
+})
+
+test('default args keep standard Web APIs exposed', async t => {
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end('<!doctype html><title>apis</title>')
+  })
+  const browserless = await getBrowserContext(t)
+
+  const apis = await browserless.evaluate(page =>
+    page.evaluate(() => ({
+      Notification: typeof Notification,
+      speechSynthesis: typeof speechSynthesis,
+      webkitSpeechRecognition: typeof webkitSpeechRecognition,
+      PushManager: typeof PushManager,
+      PaymentRequest: typeof PaymentRequest
+    }))
+  )(url)
+
+  t.deepEqual(apis, {
+    Notification: 'function',
+    speechSynthesis: 'object',
+    webkitSpeechRecognition: 'function',
+    PushManager: 'function',
+    PaymentRequest: 'function'
+  })
 })
 
 test('.close() disconnect in connect mode', async t => {


### PR DESCRIPTION
## Summary

`driver.defaultArgs` removed five standard Web APIs from every page:

| Flag | Removes |
|---|---|
| `--disable-notifications` | `Notification` |
| `--disable-speech-api` | `speechSynthesis`, `webkitSpeechRecognition` |
| `--disable-features=PushMessaging` | `PushManager` |
| `--disable-features=WebPayments` | `PaymentRequest` |

Stock Chrome exposes all of them. Pages can also spot the contradiction: `navigator.permissions.query({ name: 'notifications' })` still answers `prompt` while `Notification` is `undefined`. Git history gives no reason for these flags (`02bb5c57`, #624). Every other default flag is untouched.

## Evidence

Puppeteer 25.1.0, Chrome 149 headless, macOS arm64. Same `defaultArgs`, with and without the four removed switches, loading a local page:

| API | before | after | stock headless Chrome |
|---|---|---|---|
| `Notification` | undefined | function | function |
| `speechSynthesis` | undefined | object | object |
| `webkitSpeechRecognition` | undefined | function | function |
| `PushManager` | undefined | function | function |
| `PaymentRequest` | undefined | function | function |

Cost, 5 interleaved runs each:

| | before | after |
|---|---|---|
| browser tree RSS, page reads the 5 APIs | 608 MB median (603–608) | 618 MB median (616–622), **+10 MB / +1.6%** |
| browser tree RSS, `about:blank` (each switch toggled alone) | 594–596 MB median | 596 MB median, no difference |
| launch time | 396 ms median | 362 ms median, within noise (174–682 ms spread) |

RSS doesn't grow while the APIs sit unused. The +10 MB appears only when a page touches them and Chrome instantiates the objects (for example `speechSynthesis`).

## Tests

- New `default args keep standard Web APIs exposed` in `packages/browserless/test/driver.js`. It fails on `origin/master` (all five `undefined`) and passes here.
- `pnpm --filter browserless test`: 6 local failures (`.screenshot` png/jpeg/device pixel diffs, `report()` WebGL support, `report({ benchmark })`, `.close() is idempotency`). All 6 fail the same way on `origin/master`'s `driver.js`: identical 244/815/244 pixel diffs, and the process count picks up other Chrome instances on the host. They are environmental on macOS; CI (Linux + Xvfb + Mesa) is the gate.
- `pnpm --filter @browserless/screenshot test`: `graphics features` fails locally, and fails the same way on `origin/master`'s `driver.js`.
- `standard` clean.

## Outcome

Pages see the same Web API surface as stock Chrome. The five `typeof` checks now match an unautomated headless Chrome, as asserted by the regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116zka7w2WKPSi3kqHyVAET

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launch-flag-only change that broadens page API exposure to match stock Chrome; no auth or data-path changes, with a small possible memory bump when pages touch those APIs.
> 
> **Overview**
> **Restores stock Chrome Web API surface** in browserless launches by dropping Chromium flags that stripped `Notification`, speech APIs, `PushManager`, and `PaymentRequest` from every page.
> 
> `driver.defaultArgs` no longer passes `--disable-notifications`, `--disable-speech-api`, or `--disable-features` entries for `PushMessaging` and `WebPayments`; `site-per-process` stays disabled as before. A new driver test loads a local page and asserts all five APIs have the same `typeof` values as unmodified headless Chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ac83ae55e035d6889efab0eaaded31655194c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standard browser capabilities are now available by default, including notifications, speech recognition and synthesis, push messaging, and web payments.
  - Websites running in the browser environment can access these Web APIs without additional configuration.

- **Tests**
  - Added coverage confirming that the supported browser APIs are exposed and available at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->