### PR TITLE
fix(screenshot): run page helpers in an isolated world

### DIFF
--- a/packages/screenshot/src/evaluate-isolated.js
+++ b/packages/screenshot/src/evaluate-isolated.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const isolatedRealm = page =>
+  typeof page.mainFrame === 'function' ? page.mainFrame().isolatedRealm() : page
+
+const evaluateIsolated = (page, pageFunction, ...args) =>
+  isolatedRealm(page).evaluate(pageFunction, ...args)
+
+module.exports = { evaluateIsolated }

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -93,18 +93,12 @@ const readElementClip = async (page, element) => {
   }
 }
 
-const waitForElement = async (page, element) => {
-  const screenshotOpts = {}
-  if (element) {
-    let clip = null
-    for (let attempt = 0; attempt < ELEMENT_CLIP_ATTEMPTS && clip === null; attempt++) {
-      clip = await readElementClip(page, element)
-    }
-    screenshotOpts.clip = clip
-    screenshotOpts.fullPage = false
-    return screenshotOpts
+const waitForElement = async (page, element, screenshotOpts) => {
+  for (let attempt = 0; attempt < ELEMENT_CLIP_ATTEMPTS; attempt++) {
+    screenshotOpts.clip = await readElementClip(page, element)
+    if (screenshotOpts.clip !== null) break
   }
-  return screenshotOpts
+  screenshotOpts.fullPage = false
 }
 
 const SCREENSHOT_DEFAULT_OPTS = {
@@ -153,7 +147,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
       const beforeScreenshot = async (page, response, { element, fullPage = false } = {}) => {
         const timeout = goto.timeouts.action(opts.timeout)
 
-        let screenshotOpts = {}
+        const screenshotOpts = {}
         const tasks = [
           {
             fn: () => evaluateIsolated(page, 'document.fonts.ready'),
@@ -174,9 +168,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
 
         if (element && !fullPage) {
           tasks.push({
-            fn: async () => {
-              screenshotOpts = await waitForElement(page, element)
-            },
+            fn: () => waitForElement(page, element, screenshotOpts),
             debug: 'beforeScreenshot:waitForElement'
           })
         }

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -23,6 +23,8 @@ const {
 
 const timeSpan = require('@kikobeats/time-span')()
 
+const ELEMENT_CLIP_ATTEMPTS = 2
+
 // No pacing here on purpose: `waitUntilAuto` is a network-idle wait, which on a
 // live page costs at least its idle window (~500ms) and at most what is left of
 // the budget. The runaway case was never a fast loop — it was retrying a page
@@ -82,15 +84,23 @@ const waitForImagesOnViewport = page =>
     )
   )
 
+const readElementClip = async (page, element) => {
+  const handle = await page.waitForSelector(element, { visible: true })
+  try {
+    return await handle.boundingBox()
+  } finally {
+    await handle.dispose()
+  }
+}
+
 const waitForElement = async (page, element) => {
   const screenshotOpts = {}
   if (element) {
-    const handle = await page.waitForSelector(element, { visible: true })
-    try {
-      screenshotOpts.clip = await handle.boundingBox()
-    } finally {
-      await handle.dispose()
+    let clip = null
+    for (let attempt = 0; attempt < ELEMENT_CLIP_ATTEMPTS && clip === null; attempt++) {
+      clip = await readElementClip(page, element)
     }
+    screenshotOpts.clip = clip
     screenshotOpts.fullPage = false
     return screenshotOpts
   }
@@ -180,6 +190,10 @@ module.exports = ({ goto, ...gotoOpts }) => {
             })
           )
         )
+
+        if (screenshotOpts.clip === null) {
+          throw new Error(`Element \`${element}\` detached before its clip could be read`)
+        }
 
         return screenshotOpts
       }

--- a/packages/screenshot/src/index.js
+++ b/packages/screenshot/src/index.js
@@ -7,6 +7,7 @@ const pReflect = require('p-reflect')
 
 const isTransientContextLoss = require('./is-transient-context-loss')
 const isWhiteScreenshot = require('./is-white-screenshot')
+const { evaluateIsolated } = require('./evaluate-isolated')
 const waitForPrism = require('./pretty')
 const prettyTimeSpan = require('./time-span')
 const overlay = require('./overlay')
@@ -43,7 +44,7 @@ const captureWithNavigationRetry = async (capture, { page, goto, timeout }) => {
 }
 
 const getPageMeta = page =>
-  page.evaluate(() => ({
+  evaluateIsolated(page, () => ({
     title: document.title || '',
     bodyText: document.body ? document.body.innerText || '' : '',
     url: window.location.href || ''
@@ -63,15 +64,10 @@ const checkPageReady = async (page, { isPageReady, response, screenshot, isWhite
   return !pageReadyResult.isRejected && !!pageReadyResult.value
 }
 
-const getBoundingClientRect = element => {
-  const { top, left, height, width, x, y } = element.getBoundingClientRect()
-  return { top, left, height, width, x, y }
-}
-
 const waitForImagesOnViewport = page =>
-  page.$$eval('img[src]:not([aria-hidden="true"])', elements =>
+  evaluateIsolated(page, () =>
     Promise.all(
-      elements
+      Array.from(document.querySelectorAll('img[src]:not([aria-hidden="true"])'))
         .filter(el => {
           if (el.naturalHeight === 0 || el.naturalWidth === 0) return false
           const { top, left, bottom, right } = el.getBoundingClientRect()
@@ -89,8 +85,12 @@ const waitForImagesOnViewport = page =>
 const waitForElement = async (page, element) => {
   const screenshotOpts = {}
   if (element) {
-    await page.waitForSelector(element, { visible: true })
-    screenshotOpts.clip = await page.$eval(element, getBoundingClientRect)
+    const handle = await page.waitForSelector(element, { visible: true })
+    try {
+      screenshotOpts.clip = await handle.boundingBox()
+    } finally {
+      await handle.dispose()
+    }
     screenshotOpts.fullPage = false
     return screenshotOpts
   }
@@ -146,7 +146,7 @@ module.exports = ({ goto, ...gotoOpts }) => {
         let screenshotOpts = {}
         const tasks = [
           {
-            fn: () => page.evaluate('document.fonts.ready'),
+            fn: () => evaluateIsolated(page, 'document.fonts.ready'),
             debug: 'beforeScreenshot:fontsReady'
           },
           {

--- a/packages/screenshot/src/prepare-full-document.js
+++ b/packages/screenshot/src/prepare-full-document.js
@@ -4,6 +4,7 @@ const debug = require('debug-logfmt')('browserless:prepare')
 const pReflect = require('p-reflect')
 
 const { waitForDomStability } = require('./wait-for-dom')
+const { evaluateIsolated } = require('./evaluate-isolated')
 
 const SCROLL_STEP_MS = 50
 const OVERFLOW_MIN_PX = 200
@@ -25,14 +26,14 @@ function findTallestOverflowScroller (minPx) {
   return best
 }
 
-// page.evaluate only serializes the function it is given, so an in-page helper
+// An evaluate only serializes the function it is given, so an in-page helper
 // can't be shared across evaluates by reference. Compose the scanner source in
 // front of `fn` on the Node side (no in-page eval, so page CSP is untouched) to
 // give every caller the same scanner.
 const evaluateInPage = (page, fn, ...args) => {
   const source = `${findTallestOverflowScroller}\nreturn (${fn}).apply(null, arguments)`
   // eslint-disable-next-line no-new-func
-  return page.evaluate(new Function(source), ...args)
+  return evaluateIsolated(page, new Function(source), ...args)
 }
 
 const waitForOverflowHeight = (page, timeout = OVERFLOW_WAIT_MS) =>
@@ -91,7 +92,7 @@ const expandOverflow = (page, minPx = OVERFLOW_MIN_PX) =>
 
 const settleDom = async (page, { idle, timeout }, label) => {
   const started = Date.now()
-  const result = await page.evaluate(waitForDomStability, { idle, timeout })
+  const result = await evaluateIsolated(page, waitForDomStability, { idle, timeout })
   debug(label, { ...result, duration: Date.now() - started })
 }
 

--- a/packages/screenshot/src/wait-for-ready.js
+++ b/packages/screenshot/src/wait-for-ready.js
@@ -2,6 +2,7 @@
 
 const { setTimeout: sleep } = require('node:timers/promises')
 const isTransientContextLoss = require('./is-transient-context-loss')
+const { evaluateIsolated } = require('./evaluate-isolated')
 
 const DEFAULT_QUIET_MS = 300
 const DEFAULT_POLL_MS = 150
@@ -191,7 +192,7 @@ const waitForReady = async (
   while (Date.now() < deadline) {
     let signals
     try {
-      signals = await page.evaluate(paintSignals)
+      signals = await evaluateIsolated(page, paintSignals)
     } catch (error) {
       if (!isTransientContextLoss(page, error)) throw error
       resets++

--- a/packages/screenshot/test/isolated-world.js
+++ b/packages/screenshot/test/isolated-world.js
@@ -1,0 +1,126 @@
+'use strict'
+
+const { getBrowserContext, runServer } = require('@browserless/test')
+const test = require('ava')
+
+const createScreenshot = require('..')
+const { waitForReady } = require('..')
+
+const hooks = `
+(() => {
+  const calls = (window.__automationCalls = [])
+  const record = name => {
+    const frames = (new Error().stack || '').split('\\n').slice(3)
+    if (frames.length && !frames.some(frame => frame.includes(location.origin))) calls.push(name)
+  }
+  const hookMethod = (target, name) => {
+    const original = target[name]
+    target[name] = function (...args) {
+      record(name)
+      return original.apply(this, args)
+    }
+  }
+  const hookGetter = (target, name) => {
+    let owner = target
+    while (!Object.getOwnPropertyDescriptor(owner, name)) owner = Object.getPrototypeOf(owner)
+    const descriptor = Object.getOwnPropertyDescriptor(owner, name)
+    Object.defineProperty(owner, name, {
+      ...descriptor,
+      get () {
+        record(name)
+        return descriptor.get.call(this)
+      }
+    })
+  }
+  hookMethod(Document.prototype, 'querySelectorAll')
+  hookMethod(window, 'getComputedStyle')
+  hookMethod(window, 'scrollBy')
+  hookMethod(window, 'requestAnimationFrame')
+  hookMethod(Element.prototype, 'getBoundingClientRect')
+  hookMethod(Document.prototype, 'elementFromPoint')
+  hookGetter(window, 'innerHeight')
+  hookGetter(Document.prototype, 'fonts')
+  hookGetter(Document.prototype, 'title')
+  hookGetter(HTMLElement.prototype, 'innerText')
+})()
+`
+
+const PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC'
+
+const html = `<!doctype html><html><head><title>hooked</title><script>${hooks}</script></head>
+<body style="margin:0"><h1 id="title">hooked</h1><p>${'lorem ipsum '.repeat(40)}</p>
+<img src="${PIXEL}" width="300" height="300"><div style="height:3000px"></div></body></html>`
+
+const serve = t =>
+  runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(html)
+  })
+
+const automationCalls = (browserless, url, capture) =>
+  browserless.withPage((page, goto) => async () => {
+    await capture({ page, goto, url })
+    const calls = await page.evaluate(() => window.__automationCalls)
+    await page.close()
+    return calls
+  })()
+
+const screenshotWith =
+  opts =>
+    ({ page, goto, url }) =>
+      createScreenshot({ goto })(page)(url, { adblock: false, codeScheme: false, ...opts })
+
+test('viewport screenshot helpers are invisible to page hooks', async t => {
+  const browserless = await getBrowserContext(t)
+  t.deepEqual(await automationCalls(browserless, await serve(t), screenshotWith({})), [])
+})
+
+test('fullPage screenshot helpers are invisible to page hooks', async t => {
+  const browserless = await getBrowserContext(t)
+  const capture = screenshotWith({ fullPage: true })
+  t.deepEqual(await automationCalls(browserless, await serve(t), capture), [])
+})
+
+test('element screenshot helpers are invisible to page hooks', async t => {
+  const browserless = await getBrowserContext(t)
+  const capture = screenshotWith({ element: '#title' })
+  t.deepEqual(await automationCalls(browserless, await serve(t), capture), [])
+})
+
+test('isPageReady page metadata is read invisibly to page hooks', async t => {
+  const browserless = await getBrowserContext(t)
+  const capture = screenshotWith({ isPageReady: ({ title }) => title === 'hooked' })
+  t.deepEqual(await automationCalls(browserless, await serve(t), capture), [])
+})
+
+test('waitForReady paint signals are invisible to page hooks', async t => {
+  const browserless = await getBrowserContext(t)
+  const capture = async ({ page, goto, url }) => {
+    await goto(page, { url, waitUntil: 'load', adblock: false })
+    const signals = await waitForReady(page, { timeout: 3000, quietMs: 100, poll: 50 })
+    t.true(signals.text >= 200)
+  }
+  t.deepEqual(await automationCalls(browserless, await serve(t), capture), [])
+})
+
+test('an isolated world observes DOM mutations made by the page', async t => {
+  const { evaluateIsolated } = require('../src/evaluate-isolated')
+  const { waitForDomStability } = require('..')
+  const browserless = await getBrowserContext(t)
+  const url = await serve(t)
+
+  const status = await browserless.withPage((page, goto) => async () => {
+    await goto(page, { url, waitUntil: 'load', adblock: false })
+    await page.evaluate(() => {
+      const timer = setInterval(() => document.body.appendChild(document.createElement('i')), 20)
+      setTimeout(() => clearInterval(timer), 400)
+    })
+    const busy = await evaluateIsolated(page, waitForDomStability, { idle: 150, timeout: 200 })
+    const settled = await evaluateIsolated(page, waitForDomStability, { idle: 150, timeout: 2000 })
+    await page.close()
+    return { busy: busy.status, settled: settled.status }
+  })()
+
+  t.deepEqual(status, { busy: 'timeout', settled: 'idle' })
+})

--- a/packages/screenshot/test/wait-for-element.js
+++ b/packages/screenshot/test/wait-for-element.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const pReflect = require('p-reflect')
+const test = require('ava')
+
+const createScreenshot = require('..')
+
+const BOX = { x: 10, y: 20, width: 320, height: 120 }
+
+const createGoto = () => {
+  const goto = async () => ({ response: { headers: () => ({}) } })
+  goto.run = ({ fn }) => pReflect(fn)
+  goto.timeouts = { action: () => 1000, goto: () => 1000 }
+  goto.waitUntilAuto = async () => {}
+  return goto
+}
+
+const createPage = boxes => {
+  const page = {
+    waitForSelectorCalls: 0,
+    screenshots: [],
+    on: () => {},
+    off: () => {},
+    isClosed: () => false,
+    evaluate: async () => undefined,
+    waitForSelector: async () => {
+      const box = boxes[Math.min(page.waitForSelectorCalls++, boxes.length - 1)]
+      return { boundingBox: async () => box, dispose: async () => {} }
+    },
+    screenshot: async opts => {
+      page.screenshots.push(opts)
+      return Buffer.from('shot')
+    }
+  }
+  return page
+}
+
+const capture = page =>
+  createScreenshot({ goto: createGoto() })(page)('https://example.com', {
+    waitUntil: 'load',
+    element: '#card',
+    codeScheme: false
+  })
+
+test('element clip is read once when the matched node is stable', async t => {
+  const page = createPage([BOX])
+  await capture(page)
+  t.is(page.waitForSelectorCalls, 1)
+  t.deepEqual(page.screenshots[0].clip, BOX)
+})
+
+test('element clip re-queries when the matched node is replaced before it is measured', async t => {
+  const page = createPage([null, BOX])
+  await capture(page)
+  t.is(page.waitForSelectorCalls, 2)
+  t.is(page.screenshots.length, 1)
+  t.deepEqual(page.screenshots[0].clip, BOX)
+})
+
+test('element screenshot throws instead of capturing the viewport when the node keeps detaching', async t => {
+  const page = createPage([null])
+  await t.throwsAsync(capture(page), { message: /#card/ })
+  t.is(page.screenshots.length, 0)
+})

--- a/packages/screenshot/test/wait-for-element.js
+++ b/packages/screenshot/test/wait-for-element.js
@@ -25,6 +25,7 @@ const createPage = boxes => {
     evaluate: async () => undefined,
     waitForSelector: async () => {
       const box = boxes[Math.min(page.waitForSelectorCalls++, boxes.length - 1)]
+      if (box instanceof Error) throw box
       return { boundingBox: async () => box, dispose: async () => {} }
     },
     screenshot: async opts => {
@@ -60,5 +61,12 @@ test('element clip re-queries when the matched node is replaced before it is mea
 test('element screenshot throws instead of capturing the viewport when the node keeps detaching', async t => {
   const page = createPage([null])
   await t.throwsAsync(capture(page), { message: /#card/ })
+  t.is(page.screenshots.length, 0)
+})
+
+test('element screenshot throws when the re-query fails after the node detached', async t => {
+  const timedOut = new Error('Waiting for selector `#card` failed: Waiting failed: 1000ms exceeded')
+  const page = createPage([null, timedOut])
+  await t.throwsAsync(capture(page), { message: /detached/ })
   t.is(page.screenshots.length, 0)
 })


### PR DESCRIPTION
## Summary

`@browserless/screenshot` evaluated its **own helpers** in the page's main world. Any page script that wraps DOM APIs (a common bot-detection technique) saw those calls, with `pptr:evaluate` in the stack. This PR runs them in Puppeteer's isolated utility world. That world shares the DOM, computed styles, window metrics, scrolling and `document.fonts`, but page scripts can't see what runs there.

| Call site | Before | After |
|---|---|---|
| `getPageMeta` (`src/index.js`) | `page.evaluate` | isolated evaluate |
| `waitForImagesOnViewport` (`src/index.js`) | `page.$$eval` (main world) | one isolated evaluate over `document.querySelectorAll` |
| `waitForElement` clip (`src/index.js`) | `page.$eval(getBoundingClientRect)` | `ElementHandle.boundingBox()` (evaluates in the isolated world), re-queried once if the node detached |
| `document.fonts.ready` (`src/index.js`) | `page.evaluate` | isolated evaluate |
| `paintSignals` (`src/wait-for-ready.js`) | `page.evaluate` | isolated evaluate |
| `evaluateInPage` + `settleDom` (`src/prepare-full-document.js`) | `page.evaluate` | isolated evaluate |

I checked every helper for page-defined JS globals: none read any, so nothing had to stay in the main world. The new `src/evaluate-isolated.js` evaluates through `page.mainFrame().isolatedRealm()`. That's the realm Puppeteer itself uses for `waitForSelector`, `boundingBox` and `content()`. I picked it over raw `Page.createIsolatedWorld` + `Runtime.evaluate` because the utility world already exists for every document, and its context tracking and "Execution context was destroyed" errors behave exactly like the main realm. So `isTransientContextLoss` and every navigation retry path are unchanged. Page-like objects without `mainFrame` (the unit-test fakes in this package and in `browserless/test/pdf.js`) still get `page.evaluate`. `isolatedRealm()` is not in Puppeteer's public typings; the live tests below fail loudly if a Puppeteer bump renames it.

### Scope: what this does not fix

This PR closes the channel **for the screenshot package's own helpers only**. With goto's default `adblock: true`, a capture still leaks main-world calls that do not come from this package:
- 36 calls on a viewport capture, 134 on fullPage (cold critic run).
- Sources: Ghostery's `extractFeaturesFromDOM` (evaluated through `pptr:`), autoconsent (`AutoConsent.*`, `DomActions.querySingleReplySelector`), and goto's overlay dismissal.
- Tracking: autoconsent and dismissal in #926; Ghostery cosmetic filtering needs a follow-up in `@browserless/goto`.

The evidence and tests below pass `adblock: false` to isolate this package's own calls.

### Intentional behavior change

The helpers now call the browser's **native** DOM methods instead of whatever the page patched onto `window`/prototypes in its main world. Pixels do not change for pages that leave those APIs alone (see identity below). Pages that override them now get the native behavior:
- **Overridden scroll:** a page that overrides `window.scrollBy` to append content on each call used to grow during our fullPage scroll. It no longer does: a fullPage capture is 2560×1600 now versus 2560×2788 on master.
- **Lying `getBoundingClientRect`:** an override that offsets element rects no longer mis-crops `element` captures; the crop now matches the element's real box.

That is the intended trade: our measurements reflect what is rendered, not what page JS claims, and page JS can no longer steer them.

### Element clip race (fixed in this PR)

`boundingBox()` returns `null` when the node matched by `waitForSelector` is replaced before it is measured. The first commit then passed `clip: null` and **silently captured the full viewport**. The fix:
- The clip is re-queried once. The capture throws `` Element `<selector>` detached before its clip could be read `` if it is still unreadable.
- Each read is recorded on the shared screenshot options before the re-query, so a re-query that fails or times out inside `goto.run`'s `pReflect` still reaches the throw (Bugbot's finding on `5fa702ca`).
- The throw happens after `pReflect`, so it cannot be swallowed.
- Unchanged: an element that never appears keeps the existing behavior.

Page replacing `#card` every 4 ms, 40 trials each:

| | element crop | silent full viewport | error |
|---|---|---|---|
| origin/master | 28 | 0 | 12 (`'width' in 'clip' must be positive.`) |
| first commit (`30bdd683`) | 26 | **14** | 0 |
| this PR | **36** | **0** | 4 (detached error) |

## Evidence

**Page-visible helper calls** (`adblock: false`): the probe page hooks `querySelectorAll`, `getComputedStyle`, `scrollBy`/`scrollTo`, `requestAnimationFrame`, `getBoundingClientRect`, `elementFromPoint`, `createTreeWalker`, `MutationObserver`, and the `innerHeight`/`document.fonts`/`document.images`/`document.title`/`innerText` getters. It counts every call whose stack does not come from the page itself.

| Scenario | origin/master | this PR |
|---|---|---|
| viewport | 3 | 0 |
| fullPage | 177 | 0 |
| element | 4 | 0 |
| isPageReady (custom) | 5 | 0 |
| waitUntil: 'load' + fullPage | 176 | 0 |
| `waitForReady` | 88 | 0 |
| **total** | **453** | **0** |

A cold critic run with a wider hook set (setters, `checkVisibility`, `decode`, `Range`, `contains`, …) also measured 0 helper calls in every mode, against 5–1080 per mode on master.

A sample of what master exposed:
```
getComputedStyle <- at pptr:evaluate;evaluateInPage (…/src/prepare-full-document.js:35:15)
requestAnimationFrame <- at pptr:evaluate;settleDom (…/src/prepare-full-document.js:94)
elementFromPoint <- at coveredAt (pptr:evaluate;waitForReady (…/src/wait-for-ready.js:194:28))
```

**Cost:**
- **Timing:** fullPage capture of a local 3000px fixture, 7 runs each: master median 1116 ms, this PR 1121 ms. The difference is within noise.
- **CDP calls per capture** (critic run): viewport 35 → 11, fullPage 42 → 18, element 49 → 29. `waitForImagesOnViewport` drops query + evaluate + handle disposal for a single evaluate. The clip re-query adds calls only when a node detaches.

**Pixel identity:**
- sha256 of master vs this PR matches for viewport, fullPage, `element`, fullPage with `waitUntil: 'load'`, and a fixed `overflow:auto` app shell.
- The critic's 14-fixture run also matched: fonts, lazy images, iframes, fixed header, dark mode, JPEG, `omitBackground`, CSP sandbox, pretty JSON.
- The only differences are the intentional override cases above.

## Tests

- New `test/isolated-world.js` (live browser):
  - Five tests assert that a hooked page records **zero** automation calls during viewport, fullPage, `element` and custom-`isPageReady` captures, and during `waitForReady`. All five fail on origin/master with the leaked call lists.
  - One test proves a `MutationObserver` created in the isolated world observes DOM mutations made by page scripts (`waitForDomStability` reports `timeout` while the page mutates, `idle` once it stops).
- New `test/wait-for-element.js` (deterministic fakes, `goto.run` with the real `pReflect` semantics):
  - The clip is read once for a stable node.
  - It is re-queried when the first `boundingBox()` is `null`.
  - The capture throws instead of screenshotting when the node keeps detaching.
  - The capture throws when the re-query itself fails after the node detached.

  Tests 2–4 fail on `30bdd683`; test 4 also fails on `5fa702ca`.
- `pnpm --filter @browserless/screenshot test`:
  - **67 passed** in total, including the 10 new tests above.
  - **1 failure:** `index › graphics features`, an environmental failure on this macOS host that is unrelated to this change. It only calls `page.evaluate` to create a WebGL context, and raw Puppeteer with `driver.defaultArgs` (`--use-angle=gl`, which needs Mesa/Xvfb as on CI) returns `null` there with no screenshot code involved. CI passes it.
- `packages/browserless/test/pdf.js`: 11 passed. It reuses these helpers through fake pages.
- `standard` passes clean.

## Outcome

The screenshot package's readiness, scroll, overflow and element-clip machinery is invisible to page DOM hooks. Pixels, timing and navigation-retry behavior are unchanged. Element captures on rerendering pages now fail loudly instead of returning a silently wrong full-viewport image. The remaining main-world leaks come from adblock/autoconsent in `@browserless/goto` (see Scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116zka7w2WKPSi3kqHyVAET
