### PR TITLE
fix(goto): run autoconsent in an isolated world

### DIFF
--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -100,13 +100,23 @@ const RECEIVE_MESSAGE = `function (message) {
   return window.autoconsentReceiveMessage && window.autoconsentReceiveMessage(message)
 }`
 
-/* Top frame only. autoconsent sends objects through `autoconsentSendMessage`,
-   while the CDP binding takes a string under its own name: Chrome re-installs
-   bindings on a back/forward cache restore, which must not replace the wrapper. */
-const toContentScript = autoconsentScript => `if (window.self === window.top) {
-  window.autoconsentSendMessage = message => window.${AUTOCONSENT_BINDING}(JSON.stringify(message))
-  ${autoconsentScript}
-}`
+/* autoconsent sends objects through `autoconsentSendMessage`, while the CDP
+   binding takes a string under its own name: Chrome re-installs bindings on a
+   back/forward cache restore, which must not replace the wrapper. */
+const toContentScript =
+  autoconsentScript => `window.autoconsentSendMessage = message => window.${AUTOCONSENT_BINDING}(JSON.stringify(message))
+${autoconsentScript}`
+
+const injectContentScript = async (client, frameId, contentScript) => {
+  const { executionContextId } = await client.send('Page.createIsolatedWorld', {
+    frameId,
+    worldName: AUTOCONSENT_WORLD
+  })
+  return client.send('Runtime.evaluate', {
+    expression: contentScript,
+    contextId: executionContextId
+  })
+}
 
 const parseMessage = payload => {
   try {
@@ -180,8 +190,22 @@ const createAutoConsent = async (page, timeout) => {
     [
       'Runtime.executionContextCreated',
       ({ context }) => {
-        if (context.name !== AUTOCONSENT_WORLD) return
-        if (context.auxData?.frameId === page.mainFrame()._id) topFrameContexts.add(context.id)
+        const isTopFrame = context.auxData?.frameId === page.mainFrame()._id
+        if (context.name === AUTOCONSENT_WORLD) {
+          if (isTopFrame) topFrameContexts.add(context.id)
+        } else if (context.auxData?.isDefault && isTopFrame && page._autoconsentScript) {
+          page._autoconsentInjection = injectContentScript(
+            client,
+            context.auxData.frameId,
+            page._autoconsentScript
+          ).then(
+            ({ exceptionDetails }) => !exceptionDetails,
+            error => {
+              debug('autoconsent:inject:error', { message: error.message })
+              return false
+            }
+          )
+        }
       }
     ],
     [
@@ -189,6 +213,7 @@ const createAutoConsent = async (page, timeout) => {
       () => {
         topFrameContexts.clear()
         page._autoconsentInitDone = false
+        page._autoconsentInjection = undefined
       }
     ],
     [
@@ -207,16 +232,10 @@ const createAutoConsent = async (page, timeout) => {
 
   try {
     const contentScript = toContentScript(await getAutoconsentPlaywrightScript())
-    await Promise.all([
-      client.send('Runtime.addBinding', {
-        name: AUTOCONSENT_BINDING,
-        executionContextName: AUTOCONSENT_WORLD
-      }),
-      client.send('Page.addScriptToEvaluateOnNewDocument', {
-        source: contentScript,
-        worldName: AUTOCONSENT_WORLD
-      })
-    ])
+    await client.send('Runtime.addBinding', {
+      name: AUTOCONSENT_BINDING,
+      executionContextName: AUTOCONSENT_WORLD
+    })
     page._autoconsentScript = contentScript
   } catch (error) {
     detach()
@@ -230,20 +249,13 @@ const setupAutoConsent = (page, timeout) =>
     throw error
   }))
 
-/* Fallback for documents where the new-document injection did not run.
+/* Fallback for documents where the injection did not run or failed.
    `Page.createIsolatedWorld` returns the document's existing autoconsent world
    when there is one, where autoconsent's own guard skips a second instance. */
 const runAutoConsent = async page => {
   if (page._autoconsentInitDone || !page._autoconsentScript) return
-  const client = page._client()
-  const { executionContextId } = await client.send('Page.createIsolatedWorld', {
-    frameId: page.mainFrame()._id,
-    worldName: AUTOCONSENT_WORLD
-  })
-  return client.send('Runtime.evaluate', {
-    expression: page._autoconsentScript,
-    contextId: executionContextId
-  })
+  if (await page._autoconsentInjection) return
+  return injectContentScript(page._client(), page.mainFrame()._id, page._autoconsentScript)
 }
 
 const enableBlockingInPage = (page, run, timeout) => {

--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -97,25 +97,104 @@ const AUTOCONSENT_WORLD = 'browserless_autoconsent'
 const AUTOCONSENT_BINDING = 'browserlessAutoconsentBinding'
 
 const RECEIVE_MESSAGE = `function (message) {
-  return window.autoconsentReceiveMessage && window.autoconsentReceiveMessage(message)
+  const receive = Object.prototype.hasOwnProperty.call(window, 'autoconsentReceiveMessage') && window.autoconsentReceiveMessage
+  return typeof receive === 'function' ? receive(message) : undefined
 }`
 
 /* autoconsent sends objects through `autoconsentSendMessage`, while the CDP
    binding takes a string under its own name: Chrome re-installs bindings on a
-   back/forward cache restore, which must not replace the wrapper. */
-const toContentScript =
-  autoconsentScript => `window.autoconsentSendMessage = message => window.${AUTOCONSENT_BINDING}(JSON.stringify(message));
-${autoconsentScript}`
+   back/forward cache restore, which must not replace the wrapper.
+   The injection runs after the document exists, so `window.<id>` can already
+   resolve to a page element: an own `autoconsentReceiveMessage` property keeps
+   autoconsent's startup guard from reading `<div id="autoconsentReceiveMessage">`.
+   The first run in a world delivers `initResp` in the same evaluation, so
+   prehide does not wait for an init round trip; its `init` is marked
+   `preinitialized` for Node to skip the reply. */
+const toContentScript = (autoconsentScript, initResp) => `{
+  if (!Object.prototype.hasOwnProperty.call(window, 'autoconsentReceiveMessage')) {
+    Object.defineProperty(window, 'autoconsentReceiveMessage', { value: undefined, writable: true, configurable: true });
+  }
+  const firstRun = typeof window.autoconsentReceiveMessage !== 'function';
+  let bootstrapping = firstRun;
+  window.autoconsentSendMessage = message => window.${AUTOCONSENT_BINDING}(JSON.stringify(
+    bootstrapping && message && message.type === 'init' ? Object.assign({}, message, { preinitialized: true }) : message
+  ));
+  ${autoconsentScript}
+  ;bootstrapping = false;
+  if (firstRun && typeof window.autoconsentReceiveMessage === 'function') {
+    window.autoconsentReceiveMessage(JSON.parse(${JSON.stringify(JSON.stringify(initResp))}));
+  }
+}`
 
-const injectContentScript = async (client, frameId, contentScript) => {
+const getContentScript = lazy(() =>
+  Promise.all([getAutoconsentPlaywrightScript(), getAutoconsentRules()]).then(
+    ([autoconsentScript, rules]) =>
+      toContentScript(autoconsentScript, { type: 'initResp', config: autoconsentConfig, rules })
+  )
+)
+
+const AUTOCONSENT_PREHIDE_ID = 'autoconsent-prehide'
+const AUTOCONSENT_GLOBAL_PREHIDE =
+  '#didomi-popup,.didomi-popup-container,.didomi-popup-notice,.didomi-consent-popup-preferences,#didomi-notice,.didomi-popup-backdrop,.didomi-screen-medium'
+
+/* Mirrors autoconsent's own prehide (`style#autoconsent-prehide`, opacity rule)
+   so it lands before the bundle is compiled; autoconsent appends to the same
+   element and removes it, and an unclaimed prehide removes itself. */
+const toPrehideScript = (selectors, patterned) => `{
+  try {
+    const receive = Object.prototype.hasOwnProperty.call(window, 'autoconsentReceiveMessage') && window.autoconsentReceiveMessage;
+    if (typeof receive !== 'function' && !document.getElementById('${AUTOCONSENT_PREHIDE_ID}')) {
+      const selector = [${JSON.stringify(selectors)}]
+        .concat(${JSON.stringify(
+          patterned
+        )}.filter(([pattern]) => window.location.href.match(pattern)).map(([, patternSelectors]) => patternSelectors))
+        .join(',');
+      const css = selector + ' { opacity: 0 !important; z-index: -1 !important; pointer-events: none !important; } ';
+      const style = document.createElement('style');
+      style.id = '${AUTOCONSENT_PREHIDE_ID}';
+      style.innerText = css;
+      const append = () => (document.head || document.documentElement).appendChild(style);
+      if (document.head || document.documentElement) append();
+      else document.addEventListener('DOMContentLoaded', append, { once: true });
+      setTimeout(() => { if (style.innerText === css) style.remove(); }, ${
+        autoconsentConfig.prehideTimeout
+      });
+    }
+  } catch {}
+}`
+
+const getPrehideScript = lazy(() =>
+  getAutoconsentRules().then(compactRules => {
+    const { decodeRules } = require('@duckduckgo/autoconsent')
+    const topFrameRules = decodeRules(compactRules).filter(
+      rule => rule.prehideSelectors?.length && rule.runContext?.main !== false
+    )
+    const selectors = topFrameRules
+      .filter(rule => !rule.runContext?.urlPattern)
+      .flatMap(rule => rule.prehideSelectors)
+    const patterned = topFrameRules
+      .filter(rule => rule.runContext?.urlPattern)
+      .map(rule => [rule.runContext.urlPattern, rule.prehideSelectors.join(',')])
+    return toPrehideScript([AUTOCONSENT_GLOBAL_PREHIDE, ...selectors].join(','), patterned)
+  })
+)
+
+const injectContentScript = async (client, frameId, contentScript, prehideScript) => {
   const { executionContextId } = await client.send('Page.createIsolatedWorld', {
     frameId,
     worldName: AUTOCONSENT_WORLD
   })
-  return client.send('Runtime.evaluate', {
+  const prehide =
+    prehideScript &&
+    client
+      .send('Runtime.evaluate', { expression: prehideScript, contextId: executionContextId })
+      .catch(() => {})
+  const result = await client.send('Runtime.evaluate', {
     expression: contentScript,
     contextId: executionContextId
   })
+  await prehide
+  return result
 }
 
 const parseMessage = payload => {
@@ -140,6 +219,7 @@ const onMessage = async ({ page, client, executionContextId, message, timeout })
   switch (message.type) {
     case 'init': {
       page._autoconsentInitDone = true
+      if (message.preinitialized) return
       const rules = await getAutoconsentRules()
       return sendMessage(client, executionContextId, {
         type: 'initResp',
@@ -182,8 +262,7 @@ const listenUntilClose = (page, client, listeners) => {
   return detach
 }
 
-const createAutoConsent = async (page, timeout) => {
-  const client = page._client()
+const createAutoConsent = async (page, client, timeout) => {
   const topFrameContexts = (page._autoconsentContextIds = new Set())
 
   const detach = listenUntilClose(page, client, [
@@ -197,7 +276,8 @@ const createAutoConsent = async (page, timeout) => {
           page._autoconsentInjection = injectContentScript(
             client,
             context.auxData.frameId,
-            page._autoconsentScript
+            page._autoconsentScript,
+            page._autoconsentPrehideScript
           ).then(
             ({ exceptionDetails }) => !exceptionDetails,
             error => {
@@ -230,8 +310,16 @@ const createAutoConsent = async (page, timeout) => {
     ]
   ])
 
+  page._autoconsentDetach = detach
+
   try {
-    const contentScript = toContentScript(await getAutoconsentPlaywrightScript())
+    const [contentScript, prehideScript] = await Promise.all([
+      getContentScript(),
+      getPrehideScript().catch(error => {
+        debug('autoconsent:prehide:error', { message: error.message })
+      })
+    ])
+    page._autoconsentPrehideScript = prehideScript
     await client.send('Runtime.addBinding', {
       name: AUTOCONSENT_BINDING,
       executionContextName: AUTOCONSENT_WORLD
@@ -243,11 +331,23 @@ const createAutoConsent = async (page, timeout) => {
   }
 }
 
-const setupAutoConsent = (page, timeout) =>
-  (page._autoconsentSetup ??= createAutoConsent(page, timeout).catch(error => {
-    page._autoconsentSetup = undefined
-    throw error
-  }))
+/* Puppeteer swaps the page to a new CDP session when a prerendered page is
+   activated, so listeners and the binding follow the session, not the page. */
+const setupAutoConsent = (page, timeout) => {
+  const client = page._client()
+  if (page._autoconsentSession !== client) {
+    page._autoconsentDetach?.()
+    page._autoconsentSession = client
+    page._autoconsentSetup = createAutoConsent(page, client, timeout).catch(error => {
+      if (page._autoconsentSession === client) {
+        page._autoconsentSession = undefined
+        page._autoconsentSetup = undefined
+      }
+      throw error
+    })
+  }
+  return page._autoconsentSetup
+}
 
 /* Fallback for documents where the injection did not run or failed.
    `Page.createIsolatedWorld` returns the document's existing autoconsent world

--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -264,6 +264,8 @@ const listenUntilClose = (page, client, listeners) => {
 
 const createAutoConsent = async (page, client, timeout) => {
   const topFrameContexts = (page._autoconsentContextIds = new Set())
+  page._autoconsentInitDone = false
+  page._autoconsentInjection = undefined
 
   const detach = listenUntilClose(page, client, [
     [
@@ -335,6 +337,7 @@ const createAutoConsent = async (page, client, timeout) => {
    activated, so listeners and the binding follow the session, not the page. */
 const setupAutoConsent = (page, timeout) => {
   const client = page._client()
+  page._autoconsentTimeout = timeout
   if (page._autoconsentSession !== client) {
     page._autoconsentDetach?.()
     page._autoconsentSession = client
@@ -353,9 +356,17 @@ const setupAutoConsent = (page, timeout) => {
    `Page.createIsolatedWorld` returns the document's existing autoconsent world
    when there is one, where autoconsent's own guard skips a second instance. */
 const runAutoConsent = async page => {
+  if (page._autoconsentSetup && page._client() !== page._autoconsentSession) {
+    await setupAutoConsent(page, page._autoconsentTimeout)
+  }
   if (page._autoconsentInitDone || !page._autoconsentScript) return
   if (await page._autoconsentInjection) return
-  return injectContentScript(page._client(), page.mainFrame()._id, page._autoconsentScript)
+  return injectContentScript(
+    page._client(),
+    page.mainFrame()._id,
+    page._autoconsentScript,
+    page._autoconsentPrehideScript
+  )
 }
 
 const enableBlockingInPage = (page, run, timeout) => {

--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -104,7 +104,7 @@ const RECEIVE_MESSAGE = `function (message) {
    binding takes a string under its own name: Chrome re-installs bindings on a
    back/forward cache restore, which must not replace the wrapper. */
 const toContentScript =
-  autoconsentScript => `window.autoconsentSendMessage = message => window.${AUTOCONSENT_BINDING}(JSON.stringify(message))
+  autoconsentScript => `window.autoconsentSendMessage = message => window.${AUTOCONSENT_BINDING}(JSON.stringify(message));
 ${autoconsentScript}`
 
 const injectContentScript = async (client, frameId, contentScript) => {

--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -94,18 +94,17 @@ const autoconsentConfig = Object.freeze({
 })
 
 const AUTOCONSENT_WORLD = 'browserless_autoconsent'
-const AUTOCONSENT_BINDING = 'autoconsentSendMessage'
+const AUTOCONSENT_BINDING = 'browserlessAutoconsentBinding'
 
 const RECEIVE_MESSAGE = `function (message) {
   return window.autoconsentReceiveMessage && window.autoconsentReceiveMessage(message)
 }`
 
-/* Top frame only, once per document: the CDP binding takes a string, so the
-   wrapper serializes every message before autoconsent captures it. */
-const toContentScript =
-  autoconsentScript => `if (window.self === window.top && !window.autoconsentReceiveMessage) {
-  const sendMessage = window.${AUTOCONSENT_BINDING}
-  window.${AUTOCONSENT_BINDING} = message => sendMessage(JSON.stringify(message))
+/* Top frame only. autoconsent sends objects through `autoconsentSendMessage`,
+   while the CDP binding takes a string under its own name: Chrome re-installs
+   bindings on a back/forward cache restore, which must not replace the wrapper. */
+const toContentScript = autoconsentScript => `if (window.self === window.top) {
+  window.autoconsentSendMessage = message => window.${AUTOCONSENT_BINDING}(JSON.stringify(message))
   ${autoconsentScript}
 }`
 
@@ -163,49 +162,67 @@ const onMessage = async ({ page, client, executionContextId, message, timeout })
   }
 }
 
-const trackTopFrameContexts = (page, client) => {
-  const contextIds = new Set()
-  client.on('Runtime.executionContextCreated', ({ context }) => {
-    if (context.name === AUTOCONSENT_WORLD && context.auxData?.frameId === page.mainFrame()._id) {
-      contextIds.add(context.id)
-    }
-  })
-  client.on('Runtime.executionContextDestroyed', ({ executionContextId }) =>
-    contextIds.delete(executionContextId)
-  )
-  client.on('Runtime.executionContextsCleared', () => contextIds.clear())
-  return contextIds
+const listenUntilClose = (page, client, listeners) => {
+  const detach = () => {
+    page.off('close', detach)
+    for (const [event, handler] of listeners) client.off(event, handler)
+  }
+  for (const [event, handler] of listeners) client.on(event, handler)
+  page.on('close', detach)
+  return detach
 }
 
-const setupAutoConsent = async (page, timeout) => {
-  if (page._autoconsentSetup) return
+const createAutoConsent = async (page, timeout) => {
   const client = page._client()
-  const contentScript = toContentScript(await getAutoconsentPlaywrightScript())
-  const topFrameContexts = trackTopFrameContexts(page, client)
+  const topFrameContexts = (page._autoconsentContextIds = new Set())
 
-  client.on('Runtime.bindingCalled', ({ name, payload, executionContextId }) => {
-    if (name !== AUTOCONSENT_BINDING || !topFrameContexts.has(executionContextId)) return
-    const message = parseMessage(payload)
-    if (message) onMessage({ page, client, executionContextId, message, timeout })
-  })
-
-  await Promise.all([
-    client.send('Runtime.addBinding', {
-      name: AUTOCONSENT_BINDING,
-      executionContextName: AUTOCONSENT_WORLD
-    }),
-    client.send('Page.addScriptToEvaluateOnNewDocument', {
-      source: contentScript,
-      worldName: AUTOCONSENT_WORLD
-    })
+  const detach = listenUntilClose(page, client, [
+    [
+      'Runtime.executionContextCreated',
+      ({ context }) => {
+        if (context.name !== AUTOCONSENT_WORLD) return
+        if (context.auxData?.frameId === page.mainFrame()._id) topFrameContexts.add(context.id)
+      }
+    ],
+    ['Runtime.executionContextsCleared', () => topFrameContexts.clear()],
+    [
+      'Runtime.bindingCalled',
+      ({ name, payload, executionContextId }) => {
+        if (name !== AUTOCONSENT_BINDING || !topFrameContexts.has(executionContextId)) return
+        const message = parseMessage(payload)
+        if (message) onMessage({ page, client, executionContextId, message, timeout })
+      }
+    ]
   ])
-  page._autoconsentScript = contentScript
-  page._autoconsentSetup = true
+
+  try {
+    const contentScript = toContentScript(await getAutoconsentPlaywrightScript())
+    await Promise.all([
+      client.send('Runtime.addBinding', {
+        name: AUTOCONSENT_BINDING,
+        executionContextName: AUTOCONSENT_WORLD
+      }),
+      client.send('Page.addScriptToEvaluateOnNewDocument', {
+        source: contentScript,
+        worldName: AUTOCONSENT_WORLD
+      })
+    ])
+    page._autoconsentScript = contentScript
+  } catch (error) {
+    detach()
+    throw error
+  }
 }
+
+const setupAutoConsent = (page, timeout) =>
+  (page._autoconsentSetup ??= createAutoConsent(page, timeout).catch(error => {
+    page._autoconsentSetup = undefined
+    throw error
+  }))
 
 /* Fallback for documents where the new-document injection did not run.
    `Page.createIsolatedWorld` returns the document's existing autoconsent world
-   when there is one, where the content script guard skips a second instance. */
+   when there is one, where autoconsent's own guard skips a second instance. */
 const runAutoConsent = async page => {
   if (page._autoconsentInitDone || !page._autoconsentScript) return
   const client = page._client()
@@ -242,4 +259,4 @@ const enableBlockingInPage = (page, run, timeout) => {
   ]
 }
 
-module.exports = { enableBlockingInPage, runAutoConsent, AUTOCONSENT_WORLD }
+module.exports = { enableBlockingInPage, runAutoConsent, AUTOCONSENT_WORLD, AUTOCONSENT_BINDING }

--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -9,7 +9,11 @@ const debug = require('debug-logfmt')('browserless:goto:adblock')
 
 const lazy = fn => {
   let p
-  return () => (p ??= fn())
+  return () =>
+    (p ??= fn().catch(error => {
+      p = undefined
+      throw error
+    }))
 }
 
 const autoconsentDir = path.dirname(require.resolve('@duckduckgo/autoconsent'))
@@ -101,16 +105,25 @@ const RECEIVE_MESSAGE = `function (message) {
   return typeof receive === 'function' ? receive(message) : undefined
 }`
 
+const AUTOCONSENT_PENDING_INIT_RESP = 'browserlessAutoconsentPendingInitResp'
+
+const DELIVER_INIT_RESP = `function (initResp) {
+  if (!Object.prototype.hasOwnProperty.call(window, '${AUTOCONSENT_PENDING_INIT_RESP}')) return;
+  delete window.${AUTOCONSENT_PENDING_INIT_RESP};
+  return window.autoconsentReceiveMessage(initResp);
+}`
+
 /* autoconsent sends objects through `autoconsentSendMessage`, while the CDP
    binding takes a string under its own name: Chrome re-installs bindings on a
    back/forward cache restore, which must not replace the wrapper.
    The injection runs after the document exists, so `window.<id>` can already
    resolve to a page element: an own `autoconsentReceiveMessage` property keeps
    autoconsent's startup guard from reading `<div id="autoconsentReceiveMessage">`.
-   The first run in a world delivers `initResp` in the same evaluation, so
-   prehide does not wait for an init round trip; its `init` is marked
-   `preinitialized` for Node to skip the reply. */
-const toContentScript = (autoconsentScript, initResp) => `{
+   The first run in a world marks `initResp` as pending; it arrives in the
+   `Runtime.callFunctionOn` queued right behind this evaluation, so prehide does
+   not wait for an init round trip and the rules are not part of the script.
+   Its `init` is marked `preinitialized` for Node to skip the reply. */
+const toContentScript = autoconsentScript => `{
   if (!Object.prototype.hasOwnProperty.call(window, 'autoconsentReceiveMessage')) {
     Object.defineProperty(window, 'autoconsentReceiveMessage', { value: undefined, writable: true, configurable: true });
   }
@@ -122,15 +135,14 @@ const toContentScript = (autoconsentScript, initResp) => `{
   ${autoconsentScript}
   ;bootstrapping = false;
   if (firstRun && typeof window.autoconsentReceiveMessage === 'function') {
-    window.autoconsentReceiveMessage(JSON.parse(${JSON.stringify(JSON.stringify(initResp))}));
+    window.${AUTOCONSENT_PENDING_INIT_RESP} = true;
   }
 }`
 
-const getContentScript = lazy(() =>
-  Promise.all([getAutoconsentPlaywrightScript(), getAutoconsentRules()]).then(
-    ([autoconsentScript, rules]) =>
-      toContentScript(autoconsentScript, { type: 'initResp', config: autoconsentConfig, rules })
-  )
+const getContentScript = lazy(() => getAutoconsentPlaywrightScript().then(toContentScript))
+
+const getInitResp = lazy(() =>
+  getAutoconsentRules().then(rules => ({ type: 'initResp', config: autoconsentConfig, rules }))
 )
 
 const AUTOCONSENT_PREHIDE_ID = 'autoconsent-prehide'
@@ -180,20 +192,27 @@ const getPrehideScript = lazy(() =>
 )
 
 const injectContentScript = async (client, frameId, contentScript, prehideScript) => {
-  const { executionContextId } = await client.send('Page.createIsolatedWorld', {
-    frameId,
-    worldName: AUTOCONSENT_WORLD
-  })
+  const [{ executionContextId }, initResp] = await Promise.all([
+    client.send('Page.createIsolatedWorld', { frameId, worldName: AUTOCONSENT_WORLD }),
+    getInitResp()
+  ])
   const prehide =
     prehideScript &&
     client
       .send('Runtime.evaluate', { expression: prehideScript, contextId: executionContextId })
       .catch(() => {})
-  const result = await client.send('Runtime.evaluate', {
+  const evaluation = client.send('Runtime.evaluate', {
     expression: contentScript,
     contextId: executionContextId
   })
-  await prehide
+  const initialization = client
+    .send('Runtime.callFunctionOn', {
+      functionDeclaration: DELIVER_INIT_RESP,
+      executionContextId,
+      arguments: [{ value: initResp }]
+    })
+    .catch(() => {})
+  const [result] = await Promise.all([evaluation, prehide, initialization])
   return result
 }
 
@@ -319,7 +338,8 @@ const createAutoConsent = async (page, client, timeout) => {
       getContentScript(),
       getPrehideScript().catch(error => {
         debug('autoconsent:prehide:error', { message: error.message })
-      })
+      }),
+      getInitResp()
     ])
     page._autoconsentPrehideScript = prehideScript
     await client.send('Runtime.addBinding', {

--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -184,13 +184,23 @@ const createAutoConsent = async (page, timeout) => {
         if (context.auxData?.frameId === page.mainFrame()._id) topFrameContexts.add(context.id)
       }
     ],
-    ['Runtime.executionContextsCleared', () => topFrameContexts.clear()],
+    [
+      'Runtime.executionContextsCleared',
+      () => {
+        topFrameContexts.clear()
+        page._autoconsentInitDone = false
+      }
+    ],
     [
       'Runtime.bindingCalled',
       ({ name, payload, executionContextId }) => {
         if (name !== AUTOCONSENT_BINDING || !topFrameContexts.has(executionContextId)) return
         const message = parseMessage(payload)
-        if (message) onMessage({ page, client, executionContextId, message, timeout })
+        if (message) {
+          onMessage({ page, client, executionContextId, message, timeout }).catch(error =>
+            debug('autoconsent:error', { message: error.message })
+          )
+        }
       }
     ]
   ])

--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { PuppeteerBlocker } = require('@ghostery/adblocker-puppeteer')
-const { randomUUID } = require('crypto')
 const pTimeout = require('p-timeout')
 const fs = require('fs/promises')
 const path = require('path')
@@ -94,73 +93,130 @@ const autoconsentConfig = Object.freeze({
   }
 })
 
-const sendMessage = (page, message) =>
-  page
-    .evaluate(msg => {
-      if (window.autoconsentReceiveMessage) {
-        return window.autoconsentReceiveMessage(msg)
-      }
-    }, message)
+const AUTOCONSENT_WORLD = 'browserless_autoconsent'
+const AUTOCONSENT_BINDING = 'autoconsentSendMessage'
+
+const RECEIVE_MESSAGE = `function (message) {
+  return window.autoconsentReceiveMessage && window.autoconsentReceiveMessage(message)
+}`
+
+/* Top frame only, once per document: the CDP binding takes a string, so the
+   wrapper serializes every message before autoconsent captures it. */
+const toContentScript =
+  autoconsentScript => `if (window.self === window.top && !window.autoconsentReceiveMessage) {
+  const sendMessage = window.${AUTOCONSENT_BINDING}
+  window.${AUTOCONSENT_BINDING} = message => sendMessage(JSON.stringify(message))
+  ${autoconsentScript}
+}`
+
+const parseMessage = payload => {
+  try {
+    const message = JSON.parse(payload)
+    return message && typeof message === 'object' ? message : undefined
+  } catch {}
+}
+
+const sendMessage = (client, executionContextId, message) =>
+  client
+    .send('Runtime.callFunctionOn', {
+      functionDeclaration: RECEIVE_MESSAGE,
+      executionContextId,
+      arguments: [{ value: message }],
+      awaitPromise: true,
+      returnByValue: true
+    })
     .catch(() => {})
+
+const onMessage = async ({ page, client, executionContextId, message, timeout }) => {
+  switch (message.type) {
+    case 'init': {
+      page._autoconsentInitDone = true
+      const rules = await getAutoconsentRules()
+      return sendMessage(client, executionContextId, {
+        type: 'initResp',
+        config: autoconsentConfig,
+        rules
+      })
+    }
+
+    case 'eval': {
+      let result = false
+      try {
+        result = await pTimeout(page.evaluate(message.code), timeout)
+      } catch {}
+      return sendMessage(client, executionContextId, { type: 'evalResp', id: message.id, result })
+    }
+
+    case 'cmpDetected':
+    case 'popupFound':
+    case 'autoconsentDone':
+      debug(message.type, { cmp: message.cmp })
+      break
+
+    case 'optOutResult':
+      debug(message.type, { result: message.result })
+      break
+
+    case 'autoconsentError':
+      debug(message.type, { details: message.details })
+      break
+  }
+}
+
+const trackTopFrameContexts = (page, client) => {
+  const contextIds = new Set()
+  client.on('Runtime.executionContextCreated', ({ context }) => {
+    if (context.name === AUTOCONSENT_WORLD && context.auxData?.frameId === page.mainFrame()._id) {
+      contextIds.add(context.id)
+    }
+  })
+  client.on('Runtime.executionContextDestroyed', ({ executionContextId }) =>
+    contextIds.delete(executionContextId)
+  )
+  client.on('Runtime.executionContextsCleared', () => contextIds.clear())
+  return contextIds
+}
 
 const setupAutoConsent = async (page, timeout) => {
   if (page._autoconsentSetup) return
-  const autoconsentPlaywrightScript = await getAutoconsentPlaywrightScript()
-  const nonce = randomUUID()
+  const client = page._client()
+  const contentScript = toContentScript(await getAutoconsentPlaywrightScript())
+  const topFrameContexts = trackTopFrameContexts(page, client)
 
-  await page.exposeFunction('autoconsentSendMessage', async message => {
-    if (!message || typeof message !== 'object') return
-    if (message.__nonce !== nonce) return
-
-    switch (message.type) {
-      case 'init': {
-        page._autoconsentInitDone = true
-        const rules = await getAutoconsentRules()
-        return sendMessage(page, { type: 'initResp', config: autoconsentConfig, rules })
-      }
-
-      case 'eval': {
-        let result = false
-        try {
-          result = await pTimeout(page.evaluate(message.code), timeout)
-        } catch {}
-        return sendMessage(page, { type: 'evalResp', id: message.id, result })
-      }
-
-      case 'cmpDetected':
-      case 'popupFound':
-      case 'autoconsentDone':
-        debug(message.type, { cmp: message.cmp })
-        break
-
-      case 'optOutResult':
-        debug(message.type, { result: message.result })
-        break
-
-      case 'autoconsentError':
-        debug(message.type, { details: message.details })
-        break
-    }
+  client.on('Runtime.bindingCalled', ({ name, payload, executionContextId }) => {
+    if (name !== AUTOCONSENT_BINDING || !topFrameContexts.has(executionContextId)) return
+    const message = parseMessage(payload)
+    if (message) onMessage({ page, client, executionContextId, message, timeout })
   })
 
-  /* Single injection: wrap the binding in the top frame so every outgoing
-     message carries the nonce, then run the autoconsent script. Child frames
-     keep the raw CDP binding which lacks the nonce, so their messages are
-     silently rejected. */
-  const nonceGuard = `(function(n){if(window.self!==window.top)return;var raw=window.autoconsentSendMessage;if(raw)window.autoconsentSendMessage=function(msg){return raw(Object.assign({},msg,{__nonce:n}))}})(${JSON.stringify(
-    nonce
-  )});`
-  page._autoconsentScript = nonceGuard + autoconsentPlaywrightScript
-  await page.evaluateOnNewDocument(page._autoconsentScript)
+  await Promise.all([
+    client.send('Runtime.addBinding', {
+      name: AUTOCONSENT_BINDING,
+      executionContextName: AUTOCONSENT_WORLD
+    }),
+    client.send('Page.addScriptToEvaluateOnNewDocument', {
+      source: contentScript,
+      worldName: AUTOCONSENT_WORLD
+    })
+  ])
+  page._autoconsentScript = contentScript
   page._autoconsentSetup = true
 }
 
 /* Fallback for documents where the new-document injection did not run.
-   It must re-inject the nonce guard too: without it the messages lack the
-   nonce and are silently dropped by the exposed function. */
+   `Page.createIsolatedWorld` returns the document's existing autoconsent world
+   when there is one, where the content script guard skips a second instance. */
 const runAutoConsent = async page => {
   if (page._autoconsentInitDone || !page._autoconsentScript) return
-  return page.evaluate(page._autoconsentScript)
+  const client = page._client()
+  const { executionContextId } = await client.send('Page.createIsolatedWorld', {
+    frameId: page.mainFrame()._id,
+    worldName: AUTOCONSENT_WORLD
+  })
+  return client.send('Runtime.evaluate', {
+    expression: page._autoconsentScript,
+    contextId: executionContextId
+  })
 }
 
 const enableBlockingInPage = (page, run, timeout) => {
@@ -186,4 +242,4 @@ const enableBlockingInPage = (page, run, timeout) => {
   ]
 }
 
-module.exports = { enableBlockingInPage, runAutoConsent }
+module.exports = { enableBlockingInPage, runAutoConsent, AUTOCONSENT_WORLD }

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -541,12 +541,23 @@ test('runAutoConsent fallback initializes autoconsent when injection did not run
   const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
-    suppressAutoconsentInjection(page._client())
+    const client = page._client()
+    suppressAutoconsentInjection(client)
+    let prehideEvaluations = 0
+    const send = client.send.bind(client)
+    client.send = (method, params, ...rest) => {
+      if (method === 'Runtime.evaluate' && params?.expression === page._autoconsentPrehideScript) {
+        prehideEvaluations += 1
+      }
+      return send(method, params, ...rest)
+    }
     await goto(page, { url })
-    return waitForInitDone(page)
+    return { initDone: await waitForInitDone(page), prehideEvaluations }
   })
 
-  t.true(await run(), 'fallback injection must complete the init handshake')
+  const { initDone, prehideEvaluations } = await run()
+  t.true(initDone, 'fallback injection must complete the init handshake')
+  t.true(prehideEvaluations >= 1, 'fallback injection must apply the early prehide too')
 })
 
 test('runAutoConsent fallback reuses the running autoconsent instance', async t => {
@@ -832,6 +843,50 @@ test('autoconsent keeps running after a prerendered page is activated', async t 
   t.true(activated, 'the page must be activated from a prerender')
   t.true(sessionSwapped, 'activation must swap the CDP session')
   t.is(clicked, 'reject', 'autoconsent must run on the new CDP session')
+})
+
+test('runAutoConsent re-registers on a swapped CDP session and injects with the early prehide', t => {
+  const adblockPath = path.resolve(__dirname, '../../../src/adblock.js')
+  const script = `
+    const adblock = require(${JSON.stringify(adblockPath)})
+    const createSession = () => ({
+      sent: [],
+      on: () => {},
+      off: () => {},
+      async send (method) {
+        this.sent.push(method)
+        return method === 'Page.createIsolatedWorld' ? { executionContextId: 1 } : {}
+      }
+    })
+    const hostSession = createSession()
+    const activatedSession = createSession()
+    let session = hostSession
+    const page = { _client: () => session, mainFrame: () => ({ _id: 'main' }), on: () => {}, off: () => {} }
+    const run = async ({ fn }) => ({ value: await fn.catch(() => {}) })
+    adblock.enableBlockingInPage(page, run, 5000)
+    const startedAt = Date.now()
+    const poll = setInterval(async () => {
+      if (!page._autoconsentScript && Date.now() - startedAt < 10000) return
+      clearInterval(poll)
+      page._autoconsentInitDone = true
+      session = activatedSession
+      await adblock.runAutoConsent(page)
+      process.stdout.write(JSON.stringify(activatedSession.sent))
+      process.exit(0)
+    }, 20)
+  `
+
+  const { status, stdout, stderr } = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8',
+    timeout: 15000
+  })
+
+  t.is(status, 0, stderr)
+  t.deepEqual(
+    JSON.parse(stdout),
+    ['Runtime.addBinding', 'Page.createIsolatedWorld', 'Runtime.evaluate', 'Runtime.evaluate'],
+    'the swapped session needs the binding, the world, the early prehide and the content script'
+  )
 })
 
 test('heuristic dismisses a consent banner with only an acknowledge button', async t => {

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -6,6 +6,7 @@ const test = require('ava')
 
 const { PuppeteerBlocker } = require('@ghostery/adblocker-puppeteer')
 const { runServer, getBrowserContext } = require('@browserless/test')
+const { AUTOCONSENT_WORLD, runAutoConsent } = require('../../../src/adblock')
 
 const TEST_RULES = [
   '###browserless-test-ad',
@@ -25,6 +26,39 @@ const getUrl = t =>
     res.setHeader('content-type', 'text/html')
     res.end('<html><body><h1>hello</h1></body></html>')
   })
+
+const getUrlWithFrame = t =>
+  runServer(t, ({ req, res }) => {
+    res.setHeader('content-type', 'text/html')
+    if (req.url === '/frame') return res.end('<html><body></body></html>')
+    res.end('<html><body><iframe src="/frame"></iframe></body></html>')
+  })
+
+const evaluateInAutoconsentWorld = async (page, fn, frame = page.mainFrame()) => {
+  const client = page._client()
+  const { executionContextId } = await client.send('Page.createIsolatedWorld', {
+    frameId: frame._id,
+    worldName: AUTOCONSENT_WORLD
+  })
+  const { result, exceptionDetails } = await client.send('Runtime.evaluate', {
+    expression: `(${fn})()`,
+    contextId: executionContextId,
+    awaitPromise: true,
+    returnByValue: true
+  })
+  if (exceptionDetails) throw new Error(exceptionDetails.exception?.description)
+  return result.value
+}
+
+const waitForInitDone = async page => {
+  for (let attempts = 0; attempts < 50 && !page._autoconsentInitDone; attempts++) {
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  return page._autoconsentInitDone === true
+}
+
+const autoconsentGlobals = () =>
+  Object.getOwnPropertyNames(window).filter(name => /autoconsent|puppeteer_/i.test(name))
 
 test('adblock assets are lazy loaded at require time', t => {
   const adblockPath = path.resolve(__dirname, '../../../src/adblock.js')
@@ -65,7 +99,8 @@ test('pre-warm rules failure does not crash the process', t => {
     }
     const adblock = require(${JSON.stringify(adblockPath)})
     const run = async ({ fn }) => ({ value: await fn.catch(() => {}) })
-    adblock.enableBlockingInPage({ exposeFunction: async () => {}, evaluateOnNewDocument: async () => {} }, run, 5000)
+    const client = { on: () => {}, send: async () => ({}) }
+    adblock.enableBlockingInPage({ _client: () => client, mainFrame: () => ({ _id: 'main' }) }, run, 5000)
     setTimeout(() => { process.stdout.write('ok'); process.exit(0) }, 500)
   `
 
@@ -83,21 +118,11 @@ test('setup autoconsent when `adblock` is enabled', async t => {
   const url = await getUrl(t)
 
   const run = browserless.withPage((page, goto) => async () => {
-    const calls = []
-    const originalExposeFunction = page.exposeFunction.bind(page)
-
-    page.exposeFunction = (...args) => {
-      calls.push(args[0])
-      return originalExposeFunction(...args)
-    }
-
     await goto(page, { url })
-    return calls
+    return waitForInitDone(page)
   })
 
-  const calls = await run()
-
-  t.true(calls.includes('autoconsentSendMessage'))
+  t.true(await run(), 'autoconsent must complete the init handshake')
 })
 
 test('skip autoconsent setup when `adblock` is false', async t => {
@@ -105,21 +130,35 @@ test('skip autoconsent setup when `adblock` is false', async t => {
   const url = await getUrl(t)
 
   const run = browserless.withPage((page, goto) => async () => {
-    const calls = []
-    const originalExposeFunction = page.exposeFunction.bind(page)
-
-    page.exposeFunction = (...args) => {
-      calls.push(args[0])
-      return originalExposeFunction(...args)
-    }
-
     await goto(page, { url, adblock: false })
-    return calls
+    await new Promise(resolve => setTimeout(resolve, 500))
+    return { setup: page._autoconsentSetup, initDone: page._autoconsentInitDone }
   })
 
-  const calls = await run()
+  const { setup, initDone } = await run()
+  t.falsy(setup)
+  t.falsy(initDone)
+})
 
-  t.false(calls.includes('autoconsentSendMessage'))
+test('autoconsent leaves no globals in the main world of any frame', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrlWithFrame(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url, waitUntil: 'load' })
+    const initDone = await waitForInitDone(page)
+    const iframe = await (await page.waitForSelector('iframe')).contentFrame()
+    return {
+      initDone,
+      mainFrame: await page.evaluate(autoconsentGlobals),
+      childFrame: await iframe.evaluate(autoconsentGlobals)
+    }
+  })
+
+  const { initDone, mainFrame, childFrame } = await run()
+  t.true(initDone)
+  t.deepEqual(mainFrame, [])
+  t.deepEqual(childFrame, [])
 })
 
 test('initResp includes rules', async t => {
@@ -129,7 +168,7 @@ test('initResp includes rules', async t => {
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
 
-    return page.evaluate(() => {
+    return evaluateInAutoconsentWorld(page, () => {
       return new Promise(resolve => {
         const timeout = setTimeout(() => resolve('TIMEOUT'), 5000)
         const messages = []
@@ -147,7 +186,7 @@ test('initResp includes rules', async t => {
             })
           }
         }
-        window.autoconsentSendMessage({ type: 'init' }).catch(() => {})
+        window.autoconsentSendMessage({ type: 'init' })
       })
     })
   })
@@ -175,7 +214,7 @@ test('initResp includes config with expected shape', async t => {
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
 
-    return page.evaluate(() => {
+    return evaluateInAutoconsentWorld(page, () => {
       return new Promise(resolve => {
         const timeout = setTimeout(() => resolve('TIMEOUT'), 5000)
         window.autoconsentReceiveMessage = msg => {
@@ -188,7 +227,7 @@ test('initResp includes config with expected shape', async t => {
             })
           }
         }
-        window.autoconsentSendMessage({ type: 'init' }).catch(() => {})
+        window.autoconsentSendMessage({ type: 'init' })
       })
     })
   })
@@ -220,18 +259,58 @@ test('runAutoConsent fallback initializes autoconsent when injection did not run
 
   const run = browserless.withPage((page, goto) => async () => {
     /* simulate a document where the new-document injection never ran */
-    page.evaluateOnNewDocument = async () => {}
-    await goto(page, { url })
+    const client = page._client()
+    const send = client.send.bind(client)
+    client.send = (method, params, ...rest) =>
+      method === 'Page.addScriptToEvaluateOnNewDocument' && params?.worldName === AUTOCONSENT_WORLD
+        ? Promise.resolve({ identifier: '' })
+        : send(method, params, ...rest)
 
-    /* goto already invoked the runAutoConsent fallback; the init message
-       travels page → node async, so poll for the flag */
-    for (let i = 0; i < 30 && !page._autoconsentInitDone; i++) {
-      await new Promise(resolve => setTimeout(resolve, 100))
-    }
-    return page._autoconsentInitDone === true
+    await goto(page, { url })
+    return waitForInitDone(page)
   })
 
   t.true(await run(), 'fallback injection must complete the init handshake')
+})
+
+test('runAutoConsent fallback reuses the running autoconsent instance', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const client = page._client()
+    const initContextIds = []
+    const fallbackContextIds = []
+
+    client.on('Runtime.bindingCalled', ({ payload, executionContextId }) => {
+      if (payload.includes('"type":"init"')) initContextIds.push(executionContextId)
+    })
+
+    const send = client.send.bind(client)
+    client.send = async (method, params, ...rest) => {
+      const result = await send(method, params, ...rest)
+      if (method === 'Page.createIsolatedWorld' && params?.worldName === AUTOCONSENT_WORLD) {
+        fallbackContextIds.push(result.executionContextId)
+      }
+      return result
+    }
+
+    await goto(page, { url })
+    await waitForInitDone(page)
+
+    page._autoconsentInitDone = false
+    await runAutoConsent(page)
+    await new Promise(resolve => setTimeout(resolve, 500))
+    return { initContextIds, fallbackContextIds }
+  })
+
+  const { initContextIds, fallbackContextIds } = await run()
+  t.is(initContextIds.length, 1, 'a second injection must not start another autoconsent instance')
+  t.deepEqual(
+    fallbackContextIds.slice(-1),
+    initContextIds,
+    'the fallback must evaluate in the world that already runs autoconsent'
+  )
 })
 
 const consentBanner = buttons => `<html><body>
@@ -300,7 +379,7 @@ test('eval that succeeds returns the actual result', async t => {
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
 
-    return page.evaluate(() => {
+    return evaluateInAutoconsentWorld(page, () => {
       return new Promise(resolve => {
         const timeout = setTimeout(() => resolve(null), 3000)
         window.autoconsentReceiveMessage = msg => {
@@ -309,13 +388,7 @@ test('eval that succeeds returns the actual result', async t => {
             resolve(msg)
           }
         }
-        window
-          .autoconsentSendMessage({
-            type: 'eval',
-            id: 'test-ok',
-            code: '1 + 1 === 2'
-          })
-          .catch(() => {})
+        window.autoconsentSendMessage({ type: 'eval', id: 'test-ok', code: '1 + 1 === 2' })
       })
     })
   })
@@ -327,6 +400,37 @@ test('eval that succeeds returns the actual result', async t => {
   t.is(received.result, true)
 })
 
+test('eval snippets run in the main world', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url })
+    await page.evaluate(() => {
+      window.__pageGlobal = 'visible'
+    })
+
+    return evaluateInAutoconsentWorld(page, () => {
+      return new Promise(resolve => {
+        const timeout = setTimeout(() => resolve(null), 3000)
+        window.autoconsentReceiveMessage = msg => {
+          if (msg.type === 'evalResp' && msg.id === 'test-main-world') {
+            clearTimeout(timeout)
+            resolve(msg.result)
+          }
+        }
+        window.autoconsentSendMessage({
+          type: 'eval',
+          id: 'test-main-world',
+          code: 'window.__pageGlobal'
+        })
+      })
+    })
+  })
+
+  t.is(await run(), 'visible')
+})
+
 test('invalid messages are silently ignored', async t => {
   const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
@@ -334,18 +438,24 @@ test('invalid messages are silently ignored', async t => {
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
 
-    const results = await page.evaluate(() => {
-      return Promise.allSettled([
-        window.autoconsentSendMessage(null),
-        window.autoconsentSendMessage('string'),
+    return evaluateInAutoconsentWorld(page, () => {
+      return new Promise(resolve => {
+        const timeout = setTimeout(() => resolve('TIMEOUT'), 5000)
+        window.autoconsentReceiveMessage = msg => {
+          if (msg && msg.type === 'initResp') {
+            clearTimeout(timeout)
+            resolve('initResp')
+          }
+        }
+        window.autoconsentSendMessage(null)
+        window.autoconsentSendMessage('string')
         window.autoconsentSendMessage(42)
-      ])
+        window.autoconsentSendMessage({ type: 'init' })
+      })
     })
-
-    return results.every(r => r.status === 'fulfilled')
   })
 
-  t.true(await run(), 'invalid messages must not throw')
+  t.is(await run(), 'initResp', 'invalid messages must not break later messages')
 })
 
 test('autoconsent eval that throws still sends evalResp with result false', async t => {
@@ -355,7 +465,7 @@ test('autoconsent eval that throws still sends evalResp with result false', asyn
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
 
-    return page.evaluate(() => {
+    return evaluateInAutoconsentWorld(page, () => {
       return new Promise(resolve => {
         const timeout = setTimeout(() => resolve(null), 3000)
         window.autoconsentReceiveMessage = msg => {
@@ -364,13 +474,11 @@ test('autoconsent eval that throws still sends evalResp with result false', asyn
             resolve(msg)
           }
         }
-        window
-          .autoconsentSendMessage({
-            type: 'eval',
-            id: 'test-throw',
-            code: '(() => { throw new Error("boom") })()'
-          })
-          .catch(() => {})
+        window.autoconsentSendMessage({
+          type: 'eval',
+          id: 'test-throw',
+          code: '(() => { throw new Error("boom") })()'
+        })
       })
     })
   })
@@ -389,7 +497,7 @@ test('autoconsent eval that hangs is timed out', async t => {
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
 
-    return page.evaluate(() => {
+    return evaluateInAutoconsentWorld(page, () => {
       return new Promise(resolve => {
         const timeout = setTimeout(() => resolve(null), 10000)
         window.autoconsentReceiveMessage = msg => {
@@ -398,13 +506,11 @@ test('autoconsent eval that hangs is timed out', async t => {
             resolve(msg)
           }
         }
-        window
-          .autoconsentSendMessage({
-            type: 'eval',
-            id: 'test-hang',
-            code: 'new Promise(() => {})'
-          })
-          .catch(() => {})
+        window.autoconsentSendMessage({
+          type: 'eval',
+          id: 'test-hang',
+          code: 'new Promise(() => {})'
+        })
       })
     })
   })
@@ -416,49 +522,38 @@ test('autoconsent eval that hangs is timed out', async t => {
   t.is(received.result, false)
 })
 
-test('eval triggered from child frame is rejected', async t => {
+test('autoconsent does not run in child frames and ignores their messages', async t => {
   const browserless = await getBrowserContext(t)
-
-  const url = await runServer(t, ({ req, res }) => {
-    res.setHeader('content-type', 'text/html')
-    if (req.url === '/frame') {
-      return res.end('<html><body></body></html>')
-    }
-    res.end('<html><body><iframe src="/frame"></iframe></body></html>')
-  })
+  const url = await getUrlWithFrame(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url, waitUntil: 'load' })
+    await waitForInitDone(page)
 
-    const iframeEl = await page.waitForSelector('iframe')
-    const iframe = await iframeEl.contentFrame()
-
+    const iframe = await (await page.waitForSelector('iframe')).contentFrame()
     await page.evaluate(() => {
       window.__iframeEval = false
     })
 
-    const hasBinding = await iframe
-      .evaluate(() => typeof window.autoconsentSendMessage === 'function')
-      .catch(() => false)
-
-    if (!hasBinding) return false
-
-    await iframe.evaluate(() => {
-      window
-        .autoconsentSendMessage({
-          type: 'eval',
-          id: 'frame-eval',
-          code: 'window.__iframeEval = true'
-        })
-        .catch(() => {})
-    })
+    const childWorld = await evaluateInAutoconsentWorld(
+      page,
+      () => {
+        const initialized = typeof window.autoconsentReceiveMessage === 'function'
+        window.autoconsentSendMessage(
+          JSON.stringify({ type: 'eval', id: 'frame-eval', code: 'window.__iframeEval = true' })
+        )
+        return initialized
+      },
+      iframe
+    )
 
     await new Promise(resolve => setTimeout(resolve, 1000))
-    return page.evaluate(() => window.__iframeEval)
+    return { childWorld, iframeEval: await page.evaluate(() => window.__iframeEval) }
   })
 
-  const result = await run()
-  t.is(result, false, 'eval from child frame must not execute in main frame')
+  const { childWorld, iframeEval } = await run()
+  t.false(childWorld, 'autoconsent must not initialize in child frames')
+  t.false(iframeEval, 'eval from child frame must not execute in main frame')
 })
 
 const GHOSTERY_DOM_SELECTORS = [

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -6,7 +6,7 @@ const test = require('ava')
 
 const { PuppeteerBlocker } = require('@ghostery/adblocker-puppeteer')
 const { runServer, getBrowserContext } = require('@browserless/test')
-const { AUTOCONSENT_WORLD, runAutoConsent } = require('../../../src/adblock')
+const { AUTOCONSENT_WORLD, AUTOCONSENT_BINDING, runAutoConsent } = require('../../../src/adblock')
 
 const TEST_RULES = [
   '###browserless-test-ad',
@@ -34,14 +34,14 @@ const getUrlWithFrame = t =>
     res.end('<html><body><iframe src="/frame"></iframe></body></html>')
   })
 
-const evaluateInAutoconsentWorld = async (page, fn, frame = page.mainFrame()) => {
+const evaluateInAutoconsentWorld = async (page, fn, frame = page.mainFrame(), args = []) => {
   const client = page._client()
   const { executionContextId } = await client.send('Page.createIsolatedWorld', {
     frameId: frame._id,
     worldName: AUTOCONSENT_WORLD
   })
   const { result, exceptionDetails } = await client.send('Runtime.evaluate', {
-    expression: `(${fn})()`,
+    expression: `(${fn})(...${JSON.stringify(args)})`,
     contextId: executionContextId,
     awaitPromise: true,
     returnByValue: true
@@ -99,8 +99,9 @@ test('pre-warm rules failure does not crash the process', t => {
     }
     const adblock = require(${JSON.stringify(adblockPath)})
     const run = async ({ fn }) => ({ value: await fn.catch(() => {}) })
-    const client = { on: () => {}, send: async () => ({}) }
-    adblock.enableBlockingInPage({ _client: () => client, mainFrame: () => ({ _id: 'main' }) }, run, 5000)
+    const client = { on: () => {}, off: () => {}, send: async () => ({}) }
+    const page = { _client: () => client, mainFrame: () => ({ _id: 'main' }), on: () => {}, off: () => {} }
+    adblock.enableBlockingInPage(page, run, 5000)
     setTimeout(() => { process.stdout.write('ok'); process.exit(0) }, 500)
   `
 
@@ -311,6 +312,127 @@ test('runAutoConsent fallback reuses the running autoconsent instance', async t 
     initContextIds,
     'the fallback must evaluate in the world that already runs autoconsent'
   )
+})
+
+const spyAdblockListeners = client => {
+  const added = []
+  const removed = new Set()
+  const on = client.on.bind(client)
+  const off = client.off.bind(client)
+  client.on = (event, handler) => {
+    if (new Error().stack.includes('/src/adblock.js')) added.push(handler)
+    return on(event, handler)
+  }
+  client.off = (event, handler) => {
+    removed.add(handler)
+    return off(event, handler)
+  }
+  return { added, removed }
+}
+
+test('concurrent goto calls on the same page set up autoconsent once', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const { added } = spyAdblockListeners(page._client())
+    await Promise.all([goto(page, { url: `${url}1` }), goto(page, { url: `${url}2` })])
+    return added.length
+  })
+
+  t.is(await run(), 3, 'one listener per CDP event, registered once')
+})
+
+test('autoconsent session listeners are removed when the page closes', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const { added, removed } = spyAdblockListeners(page._client())
+    await goto(page, { url })
+    await page.close()
+    return { added: added.length, detached: added.filter(handler => removed.has(handler)).length }
+  })
+
+  const { added, detached } = await run()
+  t.is(added, 3)
+  t.is(detached, 3)
+})
+
+test('autoconsent tracks only the contexts of the current document', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    for (const path of ['one', 'two', 'three']) await goto(page, { url: `${url}${path}` })
+    await waitForInitDone(page)
+    return page._autoconsentContextIds.size
+  })
+
+  t.is(await run(), 1)
+})
+
+test('autoconsent ignores messages from other worlds even when the binding reaches them', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url })
+    await waitForInitDone(page)
+    await page._client().send('Runtime.addBinding', { name: AUTOCONSENT_BINDING })
+    await page.evaluate(binding => {
+      window.__forged = false
+      window[binding](
+        JSON.stringify({ type: 'eval', id: 'forged', code: 'window.__forged = true' })
+      )
+    }, AUTOCONSENT_BINDING)
+    await new Promise(resolve => setTimeout(resolve, 1000))
+    return page.evaluate(() => window.__forged)
+  })
+
+  t.false(await run(), 'main-world messages must not reach the autoconsent handler')
+})
+
+test('autoconsent keeps messaging after a back/forward cache restore', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(
+      "<html><head><script>window.__persisted = []; addEventListener('pageshow', event => window.__persisted.push(event.persisted))</script></head><body><h1>hello</h1></body></html>"
+    )
+  })
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url })
+    await goto(page, { url: url.replace('127.0.0.1', 'localhost') })
+    await page.goBack({ waitUntil: 'load' })
+    await waitForInitDone(page)
+    const restoredFromCache = await page.evaluate(() => window.__persisted.includes(true))
+
+    const reply = await evaluateInAutoconsentWorld(page, () => {
+      return new Promise(resolve => {
+        const timeout = setTimeout(() => resolve('NO_REPLY'), 3000)
+        window.autoconsentReceiveMessage = msg => {
+          if (msg.type === 'evalResp' && msg.id === 'bfcache') {
+            clearTimeout(timeout)
+            resolve(msg.result)
+          }
+        }
+        try {
+          window.autoconsentSendMessage({ type: 'eval', id: 'bfcache', code: '40 + 2' })
+        } catch (error) {
+          clearTimeout(timeout)
+          resolve(`THREW ${error.message}`)
+        }
+      })
+    })
+
+    return { restoredFromCache, reply }
+  })
+
+  const { restoredFromCache, reply } = await run()
+  t.true(restoredFromCache, 'the page must be restored from the back/forward cache')
+  t.is(reply, 42)
 })
 
 const consentBanner = buttons => `<html><body>
@@ -537,14 +659,15 @@ test('autoconsent does not run in child frames and ignores their messages', asyn
 
     const childWorld = await evaluateInAutoconsentWorld(
       page,
-      () => {
+      binding => {
         const initialized = typeof window.autoconsentReceiveMessage === 'function'
-        window.autoconsentSendMessage(
+        window[binding](
           JSON.stringify({ type: 'eval', id: 'frame-eval', code: 'window.__iframeEval = true' })
         )
         return initialized
       },
-      iframe
+      iframe,
+      [AUTOCONSENT_BINDING]
     )
 
     await new Promise(resolve => setTimeout(resolve, 1000))

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -159,7 +159,7 @@ test('a failing autoconsent message handler does not raise an unhandled rejectio
   t.is(stdout.trim(), 'ok')
 })
 
-test('the content script runs a bundle that starts with a parenthesis', t => {
+test('the content script terminates the wrapper so future bundles starting with a parenthesis still run', t => {
   const adblockPath = path.resolve(__dirname, '../../../src/adblock.js')
   const script = `
     const fsp = require('fs/promises')
@@ -211,8 +211,8 @@ test('the content script runs a bundle that starts with a parenthesis', t => {
 })
 
 test('setup autoconsent when `adblock` is enabled', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -223,8 +223,8 @@ test('setup autoconsent when `adblock` is enabled', async t => {
 })
 
 test('skip autoconsent setup when `adblock` is false', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url, adblock: false })
@@ -238,8 +238,8 @@ test('skip autoconsent setup when `adblock` is false', async t => {
 })
 
 test('autoconsent leaves no globals in the main world of any frame', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrlWithFrame(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url, waitUntil: 'load' })
@@ -259,7 +259,6 @@ test('autoconsent leaves no globals in the main world of any frame', async t => 
 })
 
 test('autoconsent creates its isolated world only in the top frame', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await runServer(t, ({ req, res }) => {
     res.setHeader('content-type', 'text/html')
     if (req.url.startsWith('/leaf')) return res.end('<html><body><p>leaf</p></body></html>')
@@ -269,10 +268,14 @@ test('autoconsent creates its isolated world only in the top frame', async t => 
     )
     res.end(`<html><body><h1>top</h1>${iframes.join('')}</body></html>`)
   })
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url, waitUntil: 'load' })
     const initDone = await waitForInitDone(page)
+    for (let attempts = 0; attempts < 50 && page.frames().length < 6; attempts++) {
+      await new Promise(resolve => setTimeout(resolve, 100))
+    }
     const session = await page.createCDPSession()
     const contexts = []
     session.on('Runtime.executionContextCreated', ({ context }) => contexts.push(context))
@@ -293,8 +296,8 @@ test('autoconsent creates its isolated world only in the top frame', async t => 
 })
 
 test('autoconsent evaluates its content script once per document', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     const client = page._client()
@@ -316,9 +319,97 @@ test('autoconsent evaluates its content script once per document', async t => {
   t.is(await run(), 1, 'the fallback must not re-evaluate a successful injection')
 })
 
-test('initResp includes rules', async t => {
+test('autoconsent initializes from the injected script without an initResp round trip', async t => {
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end(consentBanner(REJECT_BANNER_BUTTONS))
+  })
   const browserless = await getBrowserContext(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const client = page._client()
+    const inits = []
+    let initResps = 0
+
+    client.on('Runtime.bindingCalled', ({ payload }) => {
+      if (payload.includes('"type":"init"')) inits.push(JSON.parse(payload))
+    })
+
+    const send = client.send.bind(client)
+    client.send = (method, params, ...rest) => {
+      if (
+        method === 'Runtime.callFunctionOn' &&
+        params?.arguments?.[0]?.value?.type === 'initResp'
+      ) {
+        initResps += 1
+      }
+      return send(method, params, ...rest)
+    }
+
+    await goto(page, { url })
+    await waitForInitDone(page)
+    const clicked = await waitForClicked(page)
+    await new Promise(resolve => setTimeout(resolve, 300))
+    return {
+      clicked,
+      inits: inits.length,
+      preinitialized: inits.every(message => message.preinitialized === true),
+      initResps
+    }
+  })
+
+  const { clicked, inits, preinitialized, initResps } = await run()
+  t.is(clicked, 'reject', 'autoconsent must run from the embedded initResp')
+  t.is(inits, 1)
+  t.true(preinitialized, 'the bootstrap init must be marked as preinitialized')
+  t.is(initResps, 0, 'Node must not send a second initResp')
+})
+
+test('autoconsent prehides consent popups before its bundle runs and cleans up alone', async t => {
+  const url = await runServer(t, ({ res }) => {
+    res.setHeader('content-type', 'text/html')
+    res.end('<html><body><h1>hello</h1><div id="didomi-popup">consent popup</div></body></html>')
+  })
+  const browserless = await getBrowserContext(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const client = page._client()
+    const send = client.send.bind(client)
+    client.send = (method, params, ...rest) =>
+      method === 'Runtime.evaluate' &&
+      params?.expression &&
+      params.expression === page._autoconsentScript
+        ? Promise.resolve({})
+        : send(method, params, ...rest)
+
+    const popupState = () =>
+      page.evaluate(() => ({
+        opacity: window.getComputedStyle(document.getElementById('didomi-popup')).opacity,
+        prehideStyle: !!document.getElementById('autoconsent-prehide')
+      }))
+
+    await goto(page, { url })
+    const prehidden = await popupState()
+    await new Promise(resolve => setTimeout(resolve, 2500))
+    return { prehidden, afterTimeout: await popupState() }
+  })
+
+  const { prehidden, afterTimeout } = await run()
+  t.deepEqual(
+    prehidden,
+    { opacity: '0', prehideStyle: true },
+    'the early prehide must hide the popup'
+  )
+  t.deepEqual(
+    afterTimeout,
+    { opacity: '1', prehideStyle: false },
+    'an unclaimed prehide must be removed'
+  )
+})
+
+test('initResp includes rules', async t => {
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -363,8 +454,8 @@ test('initResp includes rules', async t => {
 })
 
 test('initResp includes config with expected shape', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -422,12 +513,32 @@ const suppressAutoconsentInjection = (client, { suppressed = true } = {}) => {
       if (!(state.suppressed && payload.context.auxData?.isDefault)) handler(payload)
     })
   }
+  const send = client.send.bind(client)
+  const scriptIdentifiers = []
+  client.send = async (method, params, ...rest) => {
+    if (
+      method !== 'Page.addScriptToEvaluateOnNewDocument' ||
+      params?.worldName !== AUTOCONSENT_WORLD
+    ) {
+      return send(method, params, ...rest)
+    }
+    if (state.suppressed) return { identifier: '' }
+    const result = await send(method, params, ...rest)
+    scriptIdentifiers.push(result.identifier)
+    return result
+  }
+  state.suppress = async () => {
+    state.suppressed = true
+    for (const identifier of scriptIdentifiers.splice(0)) {
+      await send('Page.removeScriptToEvaluateOnNewDocument', { identifier })
+    }
+  }
   return state
 }
 
 test('runAutoConsent fallback initializes autoconsent when injection did not run', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     suppressAutoconsentInjection(page._client())
@@ -439,8 +550,8 @@ test('runAutoConsent fallback initializes autoconsent when injection did not run
 })
 
 test('runAutoConsent fallback reuses the running autoconsent instance', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     const client = page._client()
@@ -480,8 +591,8 @@ test('runAutoConsent fallback reuses the running autoconsent instance', async t 
 })
 
 test('runAutoConsent fallback initializes every new document on a reused page', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     const client = page._client()
@@ -495,7 +606,7 @@ test('runAutoConsent fallback initializes every new document on a reused page', 
     await goto(page, { url: `${url}one` })
     await waitForInitDone(page)
 
-    injection.suppressed = true
+    await injection.suppress()
     await goto(page, { url: `${url}two` })
     await waitForInitDone(page)
     return initContextIds.length
@@ -521,8 +632,8 @@ const spyAdblockListeners = client => {
 }
 
 test('concurrent goto calls on the same page set up autoconsent once', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     const { added } = spyAdblockListeners(page._client())
@@ -534,8 +645,8 @@ test('concurrent goto calls on the same page set up autoconsent once', async t =
 })
 
 test('autoconsent session listeners are removed when the page closes', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     const { added, removed } = spyAdblockListeners(page._client())
@@ -550,8 +661,8 @@ test('autoconsent session listeners are removed when the page closes', async t =
 })
 
 test('autoconsent tracks only the contexts of the current document', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     for (const path of ['one', 'two', 'three']) await goto(page, { url: `${url}${path}` })
@@ -563,8 +674,8 @@ test('autoconsent tracks only the contexts of the current document', async t => 
 })
 
 test('autoconsent ignores messages from other worlds even when the binding reaches them', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -584,19 +695,19 @@ test('autoconsent ignores messages from other worlds even when the binding reach
 })
 
 test('autoconsent keeps messaging after a back/forward cache restore', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await runServer(t, ({ res }) => {
     res.setHeader('content-type', 'text/html')
     res.end(
       "<html><head><script>window.__persisted = []; addEventListener('pageshow', event => window.__persisted.push(event.persisted))</script></head><body><h1>hello</h1></body></html>"
     )
   })
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     const injection = suppressAutoconsentInjection(page._client(), { suppressed: false })
     await goto(page, { url })
     await goto(page, { url: url.replace('127.0.0.1', 'localhost') })
-    injection.suppressed = true
+    await injection.suppress()
     await page.goBack({ waitUntil: 'load' })
     await waitForAutoconsentContext(page)
     const restoredFromCache = await page.evaluate(() => window.__persisted.includes(true))
@@ -645,9 +756,85 @@ const waitForClicked = async page => {
   return false
 }
 
-test('heuristic dismisses a consent banner with only an acknowledge button', async t => {
+const REJECT_BANNER_BUTTONS =
+  "<button onclick=\"window.__clicked='reject';document.getElementById('consent-fixture').remove()\">Reject all</button>" +
+  '<button onclick="window.__clicked=\'accept\'">Accept all</button>'
+
+const NAMED_ELEMENT = '<div id="autoconsentReceiveMessage"></div>'
+
+const namedElementPages = {
+  'in the initial HTML': ({ res }) => {
+    res.end(consentBanner(REJECT_BANNER_BUTTONS).replace('<body>', `<body>${NAMED_ELEMENT}`))
+  },
+  'streamed before the banner': async ({ res }) => {
+    const [head, tail] = consentBanner(REJECT_BANNER_BUTTONS).split('<div id="consent-fixture"')
+    res.write(head.replace('<body>', `<body>${NAMED_ELEMENT}`))
+    await new Promise(resolve => setTimeout(resolve, 300))
+    res.end(`<div id="consent-fixture"${tail}`)
+  },
+  'added by setTimeout(0) after the banner': ({ res }) => {
+    const addElement = `<script>setTimeout(() => document.body.insertAdjacentHTML('beforeend', '${NAMED_ELEMENT}'), 0)</script>`
+    res.end(consentBanner(REJECT_BANNER_BUTTONS).replace('</body>', `${addElement}</body>`))
+  }
+}
+
+for (const [label, handler] of Object.entries(namedElementPages)) {
+  test(`autoconsent opts out when an element named autoconsentReceiveMessage is ${label}`, async t => {
+    const url = await runServer(t, async ({ req, res }) => {
+      res.setHeader('content-type', 'text/html')
+      await handler({ req, res })
+    })
+    const browserless = await getBrowserContext(t)
+
+    const run = browserless.withPage((page, goto) => async () => {
+      await goto(page, { url })
+      return waitForClicked(page)
+    })
+
+    t.is(await run(), 'reject', 'named access must not look like a running autoconsent')
+  })
+}
+
+test('autoconsent keeps running after a prerendered page is activated', async t => {
+  const url = await runServer(t, ({ req, res }) => {
+    res.setHeader('content-type', 'text/html')
+    if (req.url.startsWith('/prerender-host')) {
+      return res.end(
+        '<!doctype html><html><head><script type="speculationrules">{"prerender":[{"source":"list","urls":["/prerendered"],"eagerness":"immediate"}]}</script></head><body><h1>host</h1></body></html>'
+      )
+    }
+    res.end(consentBanner(REJECT_BANNER_BUTTONS))
+  })
   const browserless = await getBrowserContext(t)
 
+  const run = browserless.withPage((page, goto) => async () => {
+    const firstSession = page._client()
+    let activated = false
+    for (let attempt = 0; attempt < 3 && !activated; attempt++) {
+      await goto(page, { url: `${url}prerender-host?attempt=${attempt}` })
+      await new Promise(resolve => setTimeout(resolve, 2500))
+      await Promise.all([
+        page.waitForNavigation({ timeout: 10000 }).catch(() => {}),
+        page.evaluate(() => {
+          window.location.href = '/prerendered'
+        })
+      ])
+      activated = await page
+        .evaluate(() => window.performance.getEntriesByType('navigation')[0].activationStart > 0)
+        .catch(() => false)
+    }
+    const sessionSwapped = page._client() !== firstSession
+    await goto(page, { url: `${url}banner` })
+    return { activated, sessionSwapped, clicked: await waitForClicked(page) }
+  })
+
+  const { activated, sessionSwapped, clicked } = await run()
+  t.true(activated, 'the page must be activated from a prerender')
+  t.true(sessionSwapped, 'activation must swap the CDP session')
+  t.is(clicked, 'reject', 'autoconsent must run on the new CDP session')
+})
+
+test('heuristic dismisses a consent banner with only an acknowledge button', async t => {
   const url = await runServer(t, ({ res }) => {
     res.setHeader('content-type', 'text/html')
     res.end(
@@ -656,6 +843,7 @@ test('heuristic dismisses a consent banner with only an acknowledge button', asy
       )
     )
   })
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -666,8 +854,6 @@ test('heuristic dismisses a consent banner with only an acknowledge button', asy
 })
 
 test('heuristic prefers the reject button over acknowledge', async t => {
-  const browserless = await getBrowserContext(t)
-
   const url = await runServer(t, ({ res }) => {
     res.setHeader('content-type', 'text/html')
     res.end(
@@ -677,6 +863,7 @@ test('heuristic prefers the reject button over acknowledge', async t => {
       )
     )
   })
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -687,8 +874,8 @@ test('heuristic prefers the reject button over acknowledge', async t => {
 })
 
 test('eval that succeeds returns the actual result', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -715,8 +902,8 @@ test('eval that succeeds returns the actual result', async t => {
 })
 
 test('eval snippets run in the main world', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -746,8 +933,8 @@ test('eval snippets run in the main world', async t => {
 })
 
 test('invalid messages are silently ignored', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -773,8 +960,8 @@ test('invalid messages are silently ignored', async t => {
 })
 
 test('autoconsent eval that throws still sends evalResp with result false', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -805,8 +992,8 @@ test('autoconsent eval that throws still sends evalResp with result false', asyn
 })
 
 test('autoconsent eval that hangs is timed out', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
@@ -837,8 +1024,8 @@ test('autoconsent eval that hangs is timed out', async t => {
 })
 
 test('autoconsent does not run in child frames and ignores their messages', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrlWithFrame(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url, waitUntil: 'load' })
@@ -1000,8 +1187,8 @@ test('ghostery DOM scans do not run in the page main world', async t => {
 })
 
 test('`disableAdblock` removes blocker listeners and keeps request interception enabled', async t => {
-  const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
+  const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     const interceptionCalls = []

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -57,6 +57,12 @@ const waitForInitDone = async page => {
   return page._autoconsentInitDone === true
 }
 
+const waitForAutoconsentContext = async page => {
+  for (let attempts = 0; attempts < 50 && !(page._autoconsentContextIds?.size > 0); attempts++) {
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+}
+
 const autoconsentGlobals = () =>
   Object.getOwnPropertyNames(window).filter(name => /autoconsent|puppeteer_/i.test(name))
 
@@ -111,6 +117,45 @@ test('pre-warm rules failure does not crash the process', t => {
   })
 
   t.is(status, 0, `process crashed: ${stderr}`)
+  t.is(stdout.trim(), 'ok')
+})
+
+test('a failing autoconsent message handler does not raise an unhandled rejection', t => {
+  const adblockPath = path.resolve(__dirname, '../../../src/adblock.js')
+  const script = `
+    const fsp = require('fs/promises')
+    const readFile = fsp.readFile
+    fsp.readFile = (...args) =>
+      String(args[0]).includes('compact-rules.json')
+        ? Promise.reject(new Error('simulated ENOENT'))
+        : readFile(...args)
+    const adblock = require(${JSON.stringify(adblockPath)})
+    const handlers = {}
+    const client = { on: (event, handler) => { handlers[event] = handler }, off: () => {}, send: async () => ({}) }
+    const page = { _client: () => client, mainFrame: () => ({ _id: 'main' }), on: () => {}, off: () => {} }
+    const run = async ({ fn }) => ({ value: await fn.catch(() => {}) })
+    process.on('unhandledRejection', error => {
+      process.stdout.write('unhandled: ' + error.message)
+      process.exit(2)
+    })
+    adblock.enableBlockingInPage(page, run, 5000)
+    handlers['Runtime.executionContextCreated']({
+      context: { id: 1, name: adblock.AUTOCONSENT_WORLD, auxData: { frameId: 'main' } }
+    })
+    handlers['Runtime.bindingCalled']({
+      name: adblock.AUTOCONSENT_BINDING,
+      executionContextId: 1,
+      payload: JSON.stringify({ type: 'init' })
+    })
+    setTimeout(() => { process.stdout.write('ok'); process.exit(0) }, 500)
+  `
+
+  const { status, stdout, stderr } = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8',
+    timeout: 15000
+  })
+
+  t.is(status, 0, `${stdout} ${stderr}`)
   t.is(stdout.trim(), 'ok')
 })
 
@@ -314,6 +359,43 @@ test('runAutoConsent fallback reuses the running autoconsent instance', async t 
   )
 })
 
+test('runAutoConsent fallback initializes every new document on a reused page', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const client = page._client()
+    const initContextIds = []
+    let scriptIdentifier
+
+    client.on('Runtime.bindingCalled', ({ payload, executionContextId }) => {
+      if (payload.includes('"type":"init"')) initContextIds.push(executionContextId)
+    })
+
+    const send = client.send.bind(client)
+    client.send = async (method, params, ...rest) => {
+      const result = await send(method, params, ...rest)
+      if (
+        method === 'Page.addScriptToEvaluateOnNewDocument' &&
+        params?.worldName === AUTOCONSENT_WORLD
+      ) {
+        scriptIdentifier = result.identifier
+      }
+      return result
+    }
+
+    await goto(page, { url: `${url}one` })
+    await waitForInitDone(page)
+
+    await send('Page.removeScriptToEvaluateOnNewDocument', { identifier: scriptIdentifier })
+    await goto(page, { url: `${url}two` })
+    await waitForInitDone(page)
+    return initContextIds.length
+  })
+
+  t.is(await run(), 2, 'the fallback must initialize the second document')
+})
+
 const spyAdblockListeners = client => {
   const added = []
   const removed = new Set()
@@ -406,7 +488,7 @@ test('autoconsent keeps messaging after a back/forward cache restore', async t =
     await goto(page, { url })
     await goto(page, { url: url.replace('127.0.0.1', 'localhost') })
     await page.goBack({ waitUntil: 'load' })
-    await waitForInitDone(page)
+    await waitForAutoconsentContext(page)
     const restoredFromCache = await page.evaluate(() => window.__persisted.includes(true))
 
     const reply = await evaluateInAutoconsentWorld(page, () => {

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -207,6 +207,64 @@ test('autoconsent leaves no globals in the main world of any frame', async t => 
   t.deepEqual(childFrame, [])
 })
 
+test('autoconsent creates its isolated world only in the top frame', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await runServer(t, ({ req, res }) => {
+    res.setHeader('content-type', 'text/html')
+    if (req.url.startsWith('/leaf')) return res.end('<html><body><p>leaf</p></body></html>')
+    const iframes = Array.from(
+      { length: 5 },
+      (_, index) => `<iframe src="/leaf?i=${index}"></iframe>`
+    )
+    res.end(`<html><body><h1>top</h1>${iframes.join('')}</body></html>`)
+  })
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url, waitUntil: 'load' })
+    const initDone = await waitForInitDone(page)
+    const session = await page.createCDPSession()
+    const contexts = []
+    session.on('Runtime.executionContextCreated', ({ context }) => contexts.push(context))
+    await session.send('Runtime.enable')
+    await new Promise(resolve => setTimeout(resolve, 300))
+    await session.detach()
+    return {
+      initDone,
+      frames: page.frames().length,
+      autoconsentContexts: contexts.filter(context => context.name === AUTOCONSENT_WORLD).length
+    }
+  })
+
+  const { initDone, frames, autoconsentContexts } = await run()
+  t.true(initDone)
+  t.is(frames, 6)
+  t.is(autoconsentContexts, 1, 'child frames must not get an autoconsent world')
+})
+
+test('autoconsent evaluates its content script once per document', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    const client = page._client()
+    let evaluations = 0
+    const send = client.send.bind(client)
+    client.send = (method, params, ...rest) => {
+      if (method === 'Runtime.evaluate' && params?.expression === page._autoconsentScript) {
+        evaluations += 1
+      }
+      return send(method, params, ...rest)
+    }
+
+    await goto(page, { url })
+    await waitForInitDone(page)
+    await new Promise(resolve => setTimeout(resolve, 500))
+    return evaluations
+  })
+
+  t.is(await run(), 1, 'the fallback must not re-evaluate a successful injection')
+})
+
 test('initResp includes rules', async t => {
   const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
@@ -299,19 +357,29 @@ test('initResp includes config with expected shape', async t => {
   t.is(config.enablePopupMutationObserver, true)
 })
 
+const suppressAutoconsentInjection = (client, { suppressed = true } = {}) => {
+  const state = { suppressed }
+  const on = client.on.bind(client)
+  client.on = (event, handler) => {
+    if (
+      event !== 'Runtime.executionContextCreated' ||
+      !new Error().stack.includes('/src/adblock.js')
+    ) {
+      return on(event, handler)
+    }
+    return on(event, payload => {
+      if (!(state.suppressed && payload.context.auxData?.isDefault)) handler(payload)
+    })
+  }
+  return state
+}
+
 test('runAutoConsent fallback initializes autoconsent when injection did not run', async t => {
   const browserless = await getBrowserContext(t)
   const url = await getUrl(t)
 
   const run = browserless.withPage((page, goto) => async () => {
-    /* simulate a document where the new-document injection never ran */
-    const client = page._client()
-    const send = client.send.bind(client)
-    client.send = (method, params, ...rest) =>
-      method === 'Page.addScriptToEvaluateOnNewDocument' && params?.worldName === AUTOCONSENT_WORLD
-        ? Promise.resolve({ identifier: '' })
-        : send(method, params, ...rest)
-
+    suppressAutoconsentInjection(page._client())
     await goto(page, { url })
     return waitForInitDone(page)
   })
@@ -345,6 +413,7 @@ test('runAutoConsent fallback reuses the running autoconsent instance', async t 
     await waitForInitDone(page)
 
     page._autoconsentInitDone = false
+    page._autoconsentInjection = undefined
     await runAutoConsent(page)
     await new Promise(resolve => setTimeout(resolve, 500))
     return { initContextIds, fallbackContextIds }
@@ -366,28 +435,16 @@ test('runAutoConsent fallback initializes every new document on a reused page', 
   const run = browserless.withPage((page, goto) => async () => {
     const client = page._client()
     const initContextIds = []
-    let scriptIdentifier
+    const injection = suppressAutoconsentInjection(client, { suppressed: false })
 
     client.on('Runtime.bindingCalled', ({ payload, executionContextId }) => {
       if (payload.includes('"type":"init"')) initContextIds.push(executionContextId)
     })
 
-    const send = client.send.bind(client)
-    client.send = async (method, params, ...rest) => {
-      const result = await send(method, params, ...rest)
-      if (
-        method === 'Page.addScriptToEvaluateOnNewDocument' &&
-        params?.worldName === AUTOCONSENT_WORLD
-      ) {
-        scriptIdentifier = result.identifier
-      }
-      return result
-    }
-
     await goto(page, { url: `${url}one` })
     await waitForInitDone(page)
 
-    await send('Page.removeScriptToEvaluateOnNewDocument', { identifier: scriptIdentifier })
+    injection.suppressed = true
     await goto(page, { url: `${url}two` })
     await waitForInitDone(page)
     return initContextIds.length
@@ -485,8 +542,10 @@ test('autoconsent keeps messaging after a back/forward cache restore', async t =
   })
 
   const run = browserless.withPage((page, goto) => async () => {
+    const injection = suppressAutoconsentInjection(page._client(), { suppressed: false })
     await goto(page, { url })
     await goto(page, { url: url.replace('127.0.0.1', 'localhost') })
+    injection.suppressed = true
     await page.goBack({ waitUntil: 'load' })
     await waitForAutoconsentContext(page)
     const restoredFromCache = await page.evaluate(() => window.__persisted.includes(true))

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -159,6 +159,57 @@ test('a failing autoconsent message handler does not raise an unhandled rejectio
   t.is(stdout.trim(), 'ok')
 })
 
+test('the content script runs a bundle that starts with a parenthesis', t => {
+  const adblockPath = path.resolve(__dirname, '../../../src/adblock.js')
+  const script = `
+    const fsp = require('fs/promises')
+    const vm = require('vm')
+    const readFile = fsp.readFile
+    fsp.readFile = (...args) =>
+      String(args[0]).includes('autoconsent.playwright.js')
+        ? Promise.resolve('(() => { window.__bundleStarted = true })()')
+        : readFile(...args)
+    const adblock = require(${JSON.stringify(adblockPath)})
+    const handlers = {}
+    let expression
+    const client = {
+      on: (event, handler) => { handlers[event] = handler },
+      off: () => {},
+      send: async (method, params) => {
+        if (method === 'Page.createIsolatedWorld') return { executionContextId: 7 }
+        if (method === 'Runtime.evaluate') expression = params.expression
+        return {}
+      }
+    }
+    const page = { _client: () => client, mainFrame: () => ({ _id: 'main' }), on: () => {}, off: () => {} }
+    const run = async ({ fn }) => ({ value: await fn.catch(() => {}) })
+    adblock.enableBlockingInPage(page, run, 5000)
+    const startedAt = Date.now()
+    const poll = setInterval(() => {
+      if (!page._autoconsentScript && Date.now() - startedAt < 10000) return
+      clearInterval(poll)
+      handlers['Runtime.executionContextCreated']({
+        context: { id: 1, auxData: { isDefault: true, frameId: 'main' } }
+      })
+      setTimeout(() => {
+        const sandbox = { JSON }
+        sandbox.window = sandbox
+        vm.runInNewContext(expression || '', sandbox)
+        process.stdout.write(String(sandbox.__bundleStarted === true))
+        process.exit(0)
+      }, 50)
+    }, 20)
+  `
+
+  const { status, stdout, stderr } = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8',
+    timeout: 15000
+  })
+
+  t.is(status, 0, stderr)
+  t.is(stdout.trim(), 'true', 'the bundle must execute after the wrapper assignment')
+})
+
 test('setup autoconsent when `adblock` is enabled', async t => {
   const browserless = await getBrowserContext(t)
   const url = await getUrl(t)

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -120,6 +120,45 @@ test('pre-warm rules failure does not crash the process', t => {
   t.is(stdout.trim(), 'ok')
 })
 
+test('a failed rules read is retried by the next setup', t => {
+  const adblockPath = path.resolve(__dirname, '../../../src/adblock.js')
+  const script = `
+    const fsp = require('fs/promises')
+    const readFile = fsp.readFile
+    let rulesReads = 0
+    fsp.readFile = (...args) =>
+      String(args[0]).includes('compact-rules.json') && rulesReads++ === 0
+        ? Promise.reject(new Error('simulated ENOENT'))
+        : readFile(...args)
+    const adblock = require(${JSON.stringify(adblockPath)})
+    const createPage = () => {
+      const client = { on: () => {}, off: () => {}, send: async () => ({}) }
+      return { _client: () => client, mainFrame: () => ({ _id: 'main' }), on: () => {}, off: () => {} }
+    }
+    const run = async ({ fn }) => ({ value: await fn.catch(() => {}) })
+    adblock.enableBlockingInPage(createPage(), run, 5000)
+    setTimeout(() => {
+      const page = createPage()
+      adblock.enableBlockingInPage(page, run, 5000)
+      const startedAt = Date.now()
+      const poll = setInterval(() => {
+        if (!page._autoconsentScript && Date.now() - startedAt < 10000) return
+        clearInterval(poll)
+        process.stdout.write(page._autoconsentScript ? 'ok' : 'stuck')
+        process.exit(0)
+      }, 20)
+    }, 500)
+  `
+
+  const { status, stdout, stderr } = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8',
+    timeout: 20000
+  })
+
+  t.is(status, 0, stderr)
+  t.is(stdout.trim(), 'ok', 'a rejected rules read must not be cached')
+})
+
 test('a failing autoconsent message handler does not raise an unhandled rejection', t => {
   const adblockPath = path.resolve(__dirname, '../../../src/adblock.js')
   const script = `
@@ -208,6 +247,25 @@ test('the content script terminates the wrapper so future bundles starting with 
 
   t.is(status, 0, stderr)
   t.is(stdout.trim(), 'true', 'the bundle must execute after the wrapper assignment')
+})
+
+test('test servers close after the browser context that holds their connections', async t => {
+  let onPendingRequest
+  const pendingRequest = new Promise(resolve => {
+    onPendingRequest = resolve
+  })
+  const url = await runServer(t, ({ req, res }) => {
+    if (req.url === '/pending') return onPendingRequest()
+    res.setHeader('content-type', 'text/html')
+    res.end("<html><body><h1>hello</h1><script>fetch('/pending')</script></body></html>")
+  })
+  const browserless = await getBrowserContext(t)
+  const page = await browserless.page()
+
+  await browserless.goto(page, { url, waitUntil: 'load' })
+  await pendingRequest
+
+  t.is(await page.evaluate(() => document.querySelector('h1').textContent), 'hello')
 })
 
 test('setup autoconsent when `adblock` is enabled', async t => {
@@ -328,11 +386,12 @@ test('autoconsent initializes from the injected script without an initResp round
 
   const run = browserless.withPage((page, goto) => async () => {
     const client = page._client()
-    const inits = []
-    let initResps = 0
+    const events = []
 
     client.on('Runtime.bindingCalled', ({ payload }) => {
-      if (payload.includes('"type":"init"')) inits.push(JSON.parse(payload))
+      if (payload.includes('"type":"init"')) {
+        events.push({ type: 'init', preinitialized: JSON.parse(payload).preinitialized === true })
+      }
     })
 
     const send = client.send.bind(client)
@@ -341,7 +400,7 @@ test('autoconsent initializes from the injected script without an initResp round
         method === 'Runtime.callFunctionOn' &&
         params?.arguments?.[0]?.value?.type === 'initResp'
       ) {
-        initResps += 1
+        events.push({ type: 'initResp' })
       }
       return send(method, params, ...rest)
     }
@@ -350,19 +409,16 @@ test('autoconsent initializes from the injected script without an initResp round
     await waitForInitDone(page)
     const clicked = await waitForClicked(page)
     await new Promise(resolve => setTimeout(resolve, 300))
-    return {
-      clicked,
-      inits: inits.length,
-      preinitialized: inits.every(message => message.preinitialized === true),
-      initResps
-    }
+    return { clicked, events }
   })
 
-  const { clicked, inits, preinitialized, initResps } = await run()
-  t.is(clicked, 'reject', 'autoconsent must run from the embedded initResp')
-  t.is(inits, 1)
-  t.true(preinitialized, 'the bootstrap init must be marked as preinitialized')
-  t.is(initResps, 0, 'Node must not send a second initResp')
+  const { clicked, events } = await run()
+  t.is(clicked, 'reject', 'autoconsent must initialize and opt out')
+  t.deepEqual(
+    events,
+    [{ type: 'initResp' }, { type: 'init', preinitialized: true }],
+    'initResp must be queued before autoconsent sends init, and sent only once'
+  )
 })
 
 test('autoconsent prehides consent popups before its bundle runs and cleans up alone', async t => {
@@ -513,25 +569,8 @@ const suppressAutoconsentInjection = (client, { suppressed = true } = {}) => {
       if (!(state.suppressed && payload.context.auxData?.isDefault)) handler(payload)
     })
   }
-  const send = client.send.bind(client)
-  const scriptIdentifiers = []
-  client.send = async (method, params, ...rest) => {
-    if (
-      method !== 'Page.addScriptToEvaluateOnNewDocument' ||
-      params?.worldName !== AUTOCONSENT_WORLD
-    ) {
-      return send(method, params, ...rest)
-    }
-    if (state.suppressed) return { identifier: '' }
-    const result = await send(method, params, ...rest)
-    scriptIdentifiers.push(result.identifier)
-    return result
-  }
-  state.suppress = async () => {
+  state.suppress = () => {
     state.suppressed = true
-    for (const identifier of scriptIdentifiers.splice(0)) {
-      await send('Page.removeScriptToEvaluateOnNewDocument', { identifier })
-    }
   }
   return state
 }
@@ -806,34 +845,71 @@ for (const [label, handler] of Object.entries(namedElementPages)) {
   })
 }
 
-test('autoconsent keeps running after a prerendered page is activated', async t => {
-  const url = await runServer(t, ({ req, res }) => {
+const COOKIEBOT_PAGE = `<!doctype html><html><head><script>
+window.Cookiebot = { hasResponse: false, declined: false, dialog: { visible: true }, withdraw () {}, hide () { this.declined = true; this.dialog.visible = false } }
+</script></head><body><h1>cookiebot</h1>
+<div id="CybotCookiebotDialog" style="position:fixed;top:0;left:0;right:0;height:200px;background:#fff;z-index:10000"><p>Cookiebot</p>
+<a id="CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll" href="#" onclick="event.preventDefault();window.__clicked='cookiebot-decline';window.Cookiebot.declined=true;window.Cookiebot.hasResponse=true;document.getElementById('CybotCookiebotDialog').remove()">Use necessary cookies only</a></div>
+</body></html>`
+
+const runPrerenderServer = (t, prerenderedPage) => {
+  const beacons = new Set()
+  const url = runServer(t, ({ req, res }) => {
+    const { pathname, search, searchParams } = new URL(req.url, 'http://localhost')
     res.setHeader('content-type', 'text/html')
-    if (req.url.startsWith('/prerender-host')) {
+    if (pathname === '/prerender-host') {
+      const target = searchParams.get('target')
       return res.end(
-        '<!doctype html><html><head><script type="speculationrules">{"prerender":[{"source":"list","urls":["/prerendered"],"eagerness":"immediate"}]}</script></head><body><h1>host</h1></body></html>'
+        `<!doctype html><html><head><script type="speculationrules">{"prerender":[{"source":"list","urls":["${target}"],"eagerness":"immediate"}]}</script></head><body><h1>host</h1></body></html>`
+      )
+    }
+    if (pathname === '/prerender-beacon') {
+      beacons.add(search)
+      return res.end()
+    }
+    if (pathname === '/prerendered') {
+      return res.end(
+        prerenderedPage.replace(
+          '</body>',
+          "<script>fetch('/prerender-beacon' + window.location.search)</script></body>"
+        )
       )
     }
     res.end(consentBanner(REJECT_BANNER_BUTTONS))
   })
+  return url.then(url => ({ url, beacons }))
+}
+
+const activatePrerender = async ({ page, goto, url, beacons }) => {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const search = `?attempt=${attempt}`
+    await goto(page, {
+      url: `${url}prerender-host?target=${encodeURIComponent(`/prerendered${search}`)}`
+    })
+    for (let waited = 0; waited < 100 && !beacons.has(search); waited++) {
+      await new Promise(resolve => setTimeout(resolve, 100))
+    }
+    await Promise.all([
+      page.waitForNavigation({ timeout: 10000 }).catch(() => {}),
+      page.evaluate(href => {
+        window.location.href = href
+      }, `/prerendered${search}`)
+    ])
+    const activated = await page
+      .evaluate(() => window.performance.getEntriesByType('navigation')[0].activationStart > 0)
+      .catch(() => false)
+    if (activated) return true
+  }
+  return false
+}
+
+test('autoconsent keeps running after a prerendered page is activated', async t => {
+  const { url, beacons } = await runPrerenderServer(t, consentBanner(REJECT_BANNER_BUTTONS))
   const browserless = await getBrowserContext(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     const firstSession = page._client()
-    let activated = false
-    for (let attempt = 0; attempt < 3 && !activated; attempt++) {
-      await goto(page, { url: `${url}prerender-host?attempt=${attempt}` })
-      await new Promise(resolve => setTimeout(resolve, 2500))
-      await Promise.all([
-        page.waitForNavigation({ timeout: 10000 }).catch(() => {}),
-        page.evaluate(() => {
-          window.location.href = '/prerendered'
-        })
-      ])
-      activated = await page
-        .evaluate(() => window.performance.getEntriesByType('navigation')[0].activationStart > 0)
-        .catch(() => false)
-    }
+    const activated = await activatePrerender({ page, goto, url, beacons })
     const sessionSwapped = page._client() !== firstSession
     await goto(page, { url: `${url}banner` })
     return { activated, sessionSwapped, clicked: await waitForClicked(page) }
@@ -845,47 +921,32 @@ test('autoconsent keeps running after a prerendered page is activated', async t 
   t.is(clicked, 'reject', 'autoconsent must run on the new CDP session')
 })
 
-test('runAutoConsent re-registers on a swapped CDP session and injects with the early prehide', t => {
-  const adblockPath = path.resolve(__dirname, '../../../src/adblock.js')
-  const script = `
-    const adblock = require(${JSON.stringify(adblockPath)})
-    const createSession = () => ({
-      sent: [],
-      on: () => {},
-      off: () => {},
-      async send (method) {
-        this.sent.push(method)
-        return method === 'Page.createIsolatedWorld' ? { executionContextId: 1 } : {}
-      }
-    })
-    const hostSession = createSession()
-    const activatedSession = createSession()
-    let session = hostSession
-    const page = { _client: () => session, mainFrame: () => ({ _id: 'main' }), on: () => {}, off: () => {} }
-    const run = async ({ fn }) => ({ value: await fn.catch(() => {}) })
-    adblock.enableBlockingInPage(page, run, 5000)
-    const startedAt = Date.now()
-    const poll = setInterval(async () => {
-      if (!page._autoconsentScript && Date.now() - startedAt < 10000) return
-      clearInterval(poll)
-      page._autoconsentInitDone = true
-      session = activatedSession
-      await adblock.runAutoConsent(page)
-      process.stdout.write(JSON.stringify(activatedSession.sent))
-      process.exit(0)
-    }, 20)
-  `
+test('runAutoConsent moves autoconsent to the CDP session a prerender activation swaps in', async t => {
+  const { url, beacons } = await runPrerenderServer(t, COOKIEBOT_PAGE)
+  const browserless = await getBrowserContext(t)
 
-  const { status, stdout, stderr } = spawnSync(process.execPath, ['-e', script], {
-    encoding: 'utf8',
-    timeout: 15000
+  const run = browserless.withPage((page, goto) => async () => {
+    const hostSession = page._client()
+    const hostListeners = () =>
+      ['Runtime.executionContextCreated', 'Runtime.executionContextsCleared'].map(event =>
+        hostSession.listenerCount(event)
+      )
+    const before = hostListeners()
+    const activated = await activatePrerender({ page, goto, url, beacons })
+    const sessionSwapped = page._client() !== hostSession
+    await runAutoConsent(page)
+    const clicked = await waitForClicked(page)
+    const leftover = hostListeners().map((count, index) => count - before[index])
+    return { activated, sessionSwapped, clicked, leftover }
   })
 
-  t.is(status, 0, stderr)
-  t.deepEqual(
-    JSON.parse(stdout),
-    ['Runtime.addBinding', 'Page.createIsolatedWorld', 'Runtime.evaluate', 'Runtime.evaluate'],
-    'the swapped session needs the binding, the world, the early prehide and the content script'
+  const { activated, sessionSwapped, clicked, leftover } = await run()
+  t.true(activated, 'the page must be activated from a prerender')
+  t.true(sessionSwapped, 'activation must swap the CDP session')
+  t.is(clicked, 'cookiebot-decline', 'eval replies must reach autoconsent on the new session')
+  t.true(
+    leftover.every(count => count <= 0),
+    `adblock listeners must leave the old session: ${leftover}`
   )
 })
 


### PR DESCRIPTION
## Summary

autoconsent ran in the page's main world, so any page could detect it: `puppeteer_autoconsentSendMessage`, `autoconsentSendMessage` and `autoconsentReceiveMessage` sat on `window`, and its DOM scans showed up in stack traces captured by page hooks. This PR runs autoconsent like the content script it is designed as (`isMainWorld: false`), in one isolated world in the top frame. It hides consent popups before first paint far more often than master and keeps opt-out timing. The cost is a documented per-document overhead, see [Accepted trade-off](#accepted-trade-off).

## Design

- **Top frame only, isolated world.** When the top frame's default execution context is created, `Page.createIsolatedWorld({ worldName: 'browserless_autoconsent' })` runs, then the content script is evaluated in that world. `Page.addScriptToEvaluateOnNewDocument` is not used: it has no frame filter, so Chrome would create the world in every frame of every document (see the worlds row below).
- **Early prehide.** A small script evaluated immediately after the world is created applies autoconsent's own prehide CSS (`style#autoconsent-prehide`, opacity rule), with selectors precomputed once in Node via `decodeRules`. It runs before the 144 KB bundle is compiled. autoconsent appends to and removes the same element; an unclaimed prehide removes itself after `prehideTimeout`.
- **No init round trip, no rules in the script.** The per-document script is only the 144 KB bundle. On a world's first run it marks `initResp` as pending in the isolated world. A `Runtime.callFunctionOn`, queued right behind that evaluation, delivers the cached config and rules as a protocol value, the same way master's `initResp` travels, so V8 does not keep the rules as script source. Its bootstrap `init` is marked `preinitialized`, so Node does not send a second reply. Later `init` messages still get one.
- **Messaging.** `Runtime.addBinding({ name: 'browserlessAutoconsentBinding', executionContextName })` exposes the binding only to that world, under its own name, so Chrome re-installing bindings on a back/forward cache restore cannot replace the `autoconsentSendMessage` wrapper. Replies go through `Runtime.callFunctionOn` into the exact context that sent the message. Messages are accepted only from the top frame's autoconsent contexts, which are cleared on `Runtime.executionContextsCleared`. Measured: navigations only emit `cleared`, and context ids are reused across documents.
- **Named access.** In isolated worlds `window.<id>` still resolves to page elements. The content script defines an own `autoconsentReceiveMessage` property before the bundle's startup guard runs, and the reply path checks for an own function property. A page with `<div id="autoconsentReceiveMessage">` therefore still opts out.
- **Setup keyed on the CDP session.** Puppeteer swaps the page to a new session when a prerendered page is activated. Setup compares `page._client()` with the session it registered on, and moves the binding and listeners when it changes; the steady path is one identity compare. Master has the same bug; see the prerender row.
- **Unchanged behavior.** Setup is cached per page before the first await; listeners detach on page close. A failed rules read is not cached, so the next setup retries. The `runAutoConsent` fallback awaits the per-document injection and only re-injects when it did not run or failed. It re-runs setup first if the session changed mid-goto. `eval` rule snippets still run in the **main world** (`page.evaluate(message.code)`), by design.
- **Puppeteer internals used.** `page._client()` (already used in `packages/browserless/src/index.js`) and `frame._id`. No extra CDP session and no extra `Runtime.enable`.

## Measured

Final numbers on `117a4b2d`, master is `origin/master` in the same session unless noted.

- Timing: critic's harness, 8 setups (Cookiebot and heuristic fixtures, with and without a subresource, `auto` and `domcontentloaded`) × 20 runs.
- Heap per document: forced GC, one page, `heapgc` harness.
- Payload: every CDP command adblock sends, per `goto` on a reused page (`send-sizes`), and total per `goto` over 30 runs (`cost`).
- Iframes: critic's frames harness, 3 runs each; the master column there is from the critic's run.

| Metric | master | **this PR** |
|---|---|---|
| Prehide before first paint | 92/160 (8 to 14 per setup) | **160/160** (20/20 in every setup) |
| Opted out | 160/160 | **160/160**, one init per document |
| Banner visible after `goto` returns | 46 | **44** |
| Opt-out p90, Cookiebot setups (auto, +sub, dcl, +sub dcl) | 46.3 / 36.8 / 33.6 / 34.0 ms | **38.5 / 34.4 / 27.0 / 28.9 ms** |
| Opt-out p90, heuristic setups (auto, +sub, dcl, +sub dcl) | 623.3 / 550.7 / 548.0 / 553.0 ms | **549.1 / 545.1 / 550.4 / 543.2 ms** |
| `goto` p50 (`cost`, 30 runs) | 536 ms | 539 ms |
| JS heap, 0 / 20 / 50 iframes (frames harness) | 3.28 / 11.10 / 24.14 MB | 3.16 / 11.77 / **22.08 MB** |
| JS heap per document after GC, first / after 5 documents | 1.49 / 3.92 MB | 1.70 / 4.90 MB |
| Adblock CDP payload, first `goto` on a page / each later `goto` | 440.3 / 289.5 KB | 448.0 / 447.9 KB |
| Adblock CDP payload per `goto` (`cost`, p50) | 678.9 KB | 861.4 KB |
| autoconsent worlds at 50 iframes | main world of all 51 frames | **1 isolated world** |
| Main-world autoconsent globals | 3 per frame | **0** |
| After prerender activation (9 navigations) | 0 inits, 0 opt-outs | **opt-out on all 9** |
| `<div id="autoconsentReceiveMessage">` pages (initial, streamed, `setTimeout(0)`) | opt out | **3/3 opt out** |

Opt-out p90 is at or below master in 7 of 8 setups and +2.4 ms in `heuristic/domcontentloaded`. Master's 623.3 ms on `heuristic/auto` is the harness screenshot at `goto` return stalling the renderer before detection fires, not a real master slowdown: with screenshots disabled both variants sit near 550 ms (master 547.9, PR 555.3 in round 2).

## Accepted trade-off

Measured at 0 iframes and accepted for this PR:

- **+0.21 MB JS heap per document** (1.70 vs 1.49 MB first document, 4.90 vs 3.92 MB after 5). This is the cost of an isolated world; the design that registers the world in every frame (`6320fed6`) paid the same +0.2 MB at 0 iframes.
- **+158 KB of local CDP traffic per navigation after the first** (447.9 vs 289.5 KB). Master registers the 144 KB bundle once per page with `addScriptToEvaluateOnNewDocument`, but that registration creates a world in every frame. Top frame only means evaluating the bundle (144.7 KB) and the prehide script (16.7 KB) per document. The traffic is local to the DevTools socket.
- **Heap at 20 iframes** measured 11.77 MB against 11.10 MB in the critic's master run (different session). At 50 iframes the PR is 2.06 MB below master, where per-frame designs grow to 30.12 MB.

In return: popups hidden before first paint in 160/160 runs instead of 92/160, no autoconsent globals in any main world, one world instead of one per frame, and opt-out after prerender activation, which master misses.

## Follow-ups

Left for separate PRs. The first two come from injecting per document instead of registering once per page; neither breaks opt-out, because autoconsent's guard keeps a single instance per world. The third predates this PR.

- **Double evaluation on interrupted navigation.** When a navigation is interrupted after the top frame's context is created, the `runAutoConsent` fallback can evaluate the bundle a second time. The cost is one extra 144 KB evaluation.
- **bfcache re-evaluation.** Every back/forward cache restore re-evaluates the 144 KB content script once, and autoconsent logs "autoconsent already initialized" in the isolated world.
- **Teardown order in other test files (pre-existing).** ava runs teardowns last-in-first-out, so a test that starts its HTTP server after the browser context closes the server while Chrome still holds connections, and can hang up to ava's timeout. This PR fixes the order in the adblock tests and adds a test that fails when it is reversed; other test files still use the reversed order.

## Tests

`packages/goto/test/unit/adblock/index.js`, 39 tests. 8 consecutive clean full-file runs at 38 tests, then 39/39 with the teardown-order test. Every mutation below was applied to the current code, run, and reverted; each one fails at least one test.

| Test | Fails when |
|---|---|
| no autoconsent globals in any frame's main world | run on `origin/master` |
| one autoconsent world with 5 iframes | world registered in every frame |
| content script evaluated once per document | fallback injects without awaiting the per-document injection |
| initializes from the injected script without an `initResp` round trip (banner still rejected) | pending-`initResp` delivery removed (M3) |
| early prehide hides the popup, unclaimed prehide removes itself | prehide not sent; self-removal removed |
| opts out with `<div id="autoconsentReceiveMessage">` ×3 | own-property guard removed |
| keeps running after prerender activation | setup keyed on the page instead of the CDP session |
| `runAutoConsent` moves autoconsent to the session a prerender activation swaps in (real browser, Cookiebot `eval` replies, listener counts on the old session) | only the binding re-registered (D2); old listeners not detached (D5) |
| a failed rules read is retried by the next setup | `lazy` caches rejections |
| fallback initializes every new document on a reused page | init flag reset removed (M7). `6320fed6` is an obsolete design and no longer a target |
| concurrent goto sets up once; listeners removed on close | setup not cached before the first await; detach removed |
| tracks only current-document contexts; ignores other worlds and child frames | cleanup, world filter or frame filter removed |
| keeps messaging after a bfcache restore | shared binding name |
| a failing handler raises no unhandled rejection | `.catch` removed |
| terminates the wrapper so future bundles starting with `(` still run | `;` removed |
| test servers close after the browser context that holds their connections | server started after the context (M6), times out |

All mutations M1 to M7 and D1 to D5 fail. Prerender activation tests wait for a beacon from the prerendered document and passed 10/10 runs each. `standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116zka7w2WKPSi3kqHyVAET
