### PR TITLE
fix(goto): run Ghostery DOM scans in an isolated world

### DIFF
--- a/packages/goto/src/adblock.js
+++ b/packages/goto/src/adblock.js
@@ -15,9 +15,20 @@ const lazy = fn => {
 
 const autoconsentDir = path.dirname(require.resolve('@duckduckgo/autoconsent'))
 
+const withIsolatedEvaluate = frame =>
+  new Proxy(frame, {
+    get: (target, property) => {
+      if (property === 'evaluate') return (...args) => target.isolatedRealm().evaluate(...args)
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    }
+  })
+
 const getEngine = lazy(() =>
   fs.readFile(path.resolve(__dirname, './engine.bin')).then(buffer => {
     const engine = PuppeteerBlocker.deserialize(new Uint8Array(buffer))
+    const { onFrameNavigated } = engine
+    engine.onFrameNavigated = frame => onFrameNavigated(withIsolatedEvaluate(frame))
     engine.on('request-blocked', ({ url }) => debug('block', url))
     engine.on('request-redirected', ({ url }) => debug('redirect', url))
     return engine

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -447,6 +447,98 @@ test('eval triggered from child frame is rejected', async t => {
   t.is(result, false, 'eval from child frame must not execute in main frame')
 })
 
+const GHOSTERY_DOM_SELECTORS = [
+  '[id]:not(html):not(body),[class]:not(html):not(body),[href]:not(html):not(body)',
+  'iframe[src],iframe[href]'
+]
+
+const cosmeticFixture = `<html><head><script>
+  window.__foreignSelectors = []
+  for (const proto of [Document.prototype, Element.prototype]) {
+    const querySelectorAll = proto.querySelectorAll
+    proto.querySelectorAll = function (selector) {
+      const frames = (new Error().stack || '').split('\\n').slice(2)
+      if (!frames.some(frame => frame.includes(location.origin))) window.__foreignSelectors.push(String(selector))
+      return querySelectorAll.apply(this, arguments)
+    }
+  }
+</script></head><body>
+  <div id="content-box">content</div>
+  <div id="ad_banner">ad banner</div>
+  <div class="ad-slot">ad slot</div>
+  <iframe id="ad-frame" src="https://securepubads.g.doubleclick.net/gampad/ads?iu=/1/ad"></iframe>
+</body></html>`
+
+const getCosmeticUrl = async t => {
+  const url = new URL(
+    await runServer(t, ({ res }) => {
+      res.setHeader('content-type', 'text/html')
+      res.end(cosmeticFixture)
+    })
+  )
+  url.hostname = 'ghostery.localhost'
+  return url.toString()
+}
+
+const waitForHidden = async (page, id) => {
+  for (let attempts = 0; attempts < 100; attempts++) {
+    const hidden = await page
+      .evaluate(id => window.getComputedStyle(document.getElementById(id)).display === 'none', id)
+      .catch(() => false)
+    if (hidden) return true
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  return false
+}
+
+test('cosmetic filters from DOM features still hide elements and remove blocked iframes', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getCosmeticUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url })
+    const adBannerHidden = await waitForHidden(page, 'ad_banner')
+    return page.evaluate(
+      adBannerHidden => ({
+        adBannerHidden,
+        adSlotHidden:
+          window.getComputedStyle(document.getElementsByClassName('ad-slot')[0]).display === 'none',
+        contentHidden:
+          window.getComputedStyle(document.getElementById('content-box')).display === 'none',
+        adFramePresent: !!document.getElementById('ad-frame')
+      }),
+      adBannerHidden
+    )
+  })
+
+  t.deepEqual(await run(), {
+    adBannerHidden: true,
+    adSlotHidden: true,
+    contentHidden: false,
+    adFramePresent: false
+  })
+})
+
+test('ghostery DOM scans do not run in the page main world', async t => {
+  const browserless = await getBrowserContext(t)
+  const url = await getCosmeticUrl(t)
+
+  const run = browserless.withPage((page, goto) => async () => {
+    await goto(page, { url })
+    const adBannerHidden = await waitForHidden(page, 'ad_banner')
+    const foreignSelectors = await page.evaluate(() => window.__foreignSelectors)
+    return { adBannerHidden, foreignSelectors }
+  })
+
+  const { adBannerHidden, foreignSelectors } = await run()
+
+  t.true(adBannerHidden, 'DOM features must have been scanned')
+  t.deepEqual(
+    foreignSelectors.filter(selector => GHOSTERY_DOM_SELECTORS.includes(selector)),
+    []
+  )
+})
+
 test('`disableAdblock` removes blocker listeners and keeps request interception enabled', async t => {
   const browserless = await getBrowserContext(t)
   const url = await getUrl(t)

--- a/packages/goto/test/unit/adblock/index.js
+++ b/packages/goto/test/unit/adblock/index.js
@@ -4,7 +4,21 @@ const { spawnSync } = require('child_process')
 const path = require('path')
 const test = require('ava')
 
+const { PuppeteerBlocker } = require('@ghostery/adblocker-puppeteer')
 const { runServer, getBrowserContext } = require('@browserless/test')
+
+const TEST_RULES = [
+  '###browserless-test-ad',
+  '##.browserless-test-ad',
+  '||framed-ad.localhost^$subdocument'
+]
+
+const { deserialize } = PuppeteerBlocker
+PuppeteerBlocker.deserialize = function (...args) {
+  const engine = deserialize.apply(this, args)
+  engine.updateFromDiff({ added: TEST_RULES })
+  return engine
+}
 
 const getUrl = t =>
   runServer(t, ({ res }) => {
@@ -452,33 +466,64 @@ const GHOSTERY_DOM_SELECTORS = [
   'iframe[src],iframe[href]'
 ]
 
-const cosmeticFixture = `<html><head><script>
-  window.__foreignSelectors = []
-  for (const proto of [Document.prototype, Element.prototype]) {
-    const querySelectorAll = proto.querySelectorAll
-    proto.querySelectorAll = function (selector) {
-      const frames = (new Error().stack || '').split('\\n').slice(2)
-      if (!frames.some(frame => frame.includes(location.origin))) window.__foreignSelectors.push(String(selector))
-      return querySelectorAll.apply(this, arguments)
+const cosmeticFixture = port => `<html><head><script>
+  window.__foreignCalls = []
+  const record = (api, detail) => {
+    const frames = (new Error().stack || '').split('\\n').slice(3)
+    if (!frames.some(frame => frame.includes(location.origin))) {
+      window.__foreignCalls.push({ api, detail: String(detail), stack: frames.join('\\n') })
     }
   }
+  const hookMethod = (proto, name) => {
+    const original = proto[name]
+    proto[name] = function (detail) {
+      record(name, detail)
+      return original.apply(this, arguments)
+    }
+  }
+  const hookGetter = (proto, name) => {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, name)
+    Object.defineProperty(proto, name, {
+      ...descriptor,
+      get () {
+        record(name, '')
+        return descriptor.get.call(this)
+      }
+    })
+  }
+  hookMethod(Document.prototype, 'querySelectorAll')
+  hookMethod(Element.prototype, 'querySelectorAll')
+  hookMethod(Element.prototype, 'getAttribute')
+  hookGetter(Element.prototype, 'classList')
+  hookGetter(Node.prototype, 'nodeName')
+  hookGetter(Document.prototype, 'documentElement')
 </script></head><body>
   <div id="content-box">content</div>
-  <div id="ad_banner">ad banner</div>
-  <div class="ad-slot">ad slot</div>
-  <iframe id="ad-frame" src="https://securepubads.g.doubleclick.net/gampad/ads?iu=/1/ad"></iframe>
+  <div id="browserless-test-ad">ad banner</div>
+  <div class="browserless-test-ad">ad slot</div>
+  <a href="/somewhere">link</a>
+  <iframe id="ad-frame" src="http://framed-ad.localhost:${port}/frame"></iframe>
 </body></html>`
 
 const getCosmeticUrl = async t => {
+  const frameRequests = []
   const url = new URL(
-    await runServer(t, ({ res }) => {
+    await runServer(t, ({ req, res }) => {
       res.setHeader('content-type', 'text/html')
-      res.end(cosmeticFixture)
+      if (req.url === '/frame') {
+        frameRequests.push(req.headers.host)
+        return res.end('<html><body>framed ad</body></html>')
+      }
+      res.end(cosmeticFixture(req.headers.host.split(':')[1]))
     })
   )
   url.hostname = 'ghostery.localhost'
-  return url.toString()
+  return { url: url.toString(), frameRequests }
 }
+
+const isGhosteryScan = ({ api, detail, stack }) =>
+  stack.includes('extractFeaturesFromDOM') ||
+  (api === 'querySelectorAll' && GHOSTERY_DOM_SELECTORS.includes(detail))
 
 const waitForHidden = async (page, id) => {
   for (let attempts = 0; attempts < 100; attempts++) {
@@ -493,16 +538,17 @@ const waitForHidden = async (page, id) => {
 
 test('cosmetic filters from DOM features still hide elements and remove blocked iframes', async t => {
   const browserless = await getBrowserContext(t)
-  const url = await getCosmeticUrl(t)
+  const { url, frameRequests } = await getCosmeticUrl(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
-    const adBannerHidden = await waitForHidden(page, 'ad_banner')
+    const adBannerHidden = await waitForHidden(page, 'browserless-test-ad')
     return page.evaluate(
       adBannerHidden => ({
         adBannerHidden,
         adSlotHidden:
-          window.getComputedStyle(document.getElementsByClassName('ad-slot')[0]).display === 'none',
+          window.getComputedStyle(document.getElementsByClassName('browserless-test-ad')[0])
+            .display === 'none',
         contentHidden:
           window.getComputedStyle(document.getElementById('content-box')).display === 'none',
         adFramePresent: !!document.getElementById('ad-frame')
@@ -511,7 +557,11 @@ test('cosmetic filters from DOM features still hide elements and remove blocked 
     )
   })
 
-  t.deepEqual(await run(), {
+  const result = await run()
+
+  t.true(frameRequests.length > 0, 'the blocked iframe must have started loading locally')
+  t.true(frameRequests.every(host => host.startsWith('framed-ad.localhost:')))
+  t.deepEqual(result, {
     adBannerHidden: true,
     adSlotHidden: true,
     contentHidden: false,
@@ -521,20 +571,20 @@ test('cosmetic filters from DOM features still hide elements and remove blocked 
 
 test('ghostery DOM scans do not run in the page main world', async t => {
   const browserless = await getBrowserContext(t)
-  const url = await getCosmeticUrl(t)
+  const { url } = await getCosmeticUrl(t)
 
   const run = browserless.withPage((page, goto) => async () => {
     await goto(page, { url })
-    const adBannerHidden = await waitForHidden(page, 'ad_banner')
-    const foreignSelectors = await page.evaluate(() => window.__foreignSelectors)
-    return { adBannerHidden, foreignSelectors }
+    const adBannerHidden = await waitForHidden(page, 'browserless-test-ad')
+    const foreignCalls = await page.evaluate(() => window.__foreignCalls)
+    return { adBannerHidden, foreignCalls }
   })
 
-  const { adBannerHidden, foreignSelectors } = await run()
+  const { adBannerHidden, foreignCalls } = await run()
 
   t.true(adBannerHidden, 'DOM features must have been scanned')
   t.deepEqual(
-    foreignSelectors.filter(selector => GHOSTERY_DOM_SELECTORS.includes(selector)),
+    [...new Set(foreignCalls.filter(isGhosteryScan).map(({ api, detail }) => `${api} ${detail}`))],
     []
   )
 })


### PR DESCRIPTION
## Summary

With `adblock: true` (the default), `@ghostery/adblocker-puppeteer` calls `frame.evaluate` in the page **main world** for two DOM scans:

- `extractFeaturesFromDOM`: the cosmetic feature scan (`querySelectorAll('[id]…,[class]…,[href]…')`). It runs once per frame and re-runs every 500ms while new features appear, up to 10 times.
- `removeBlockedFrames`: `querySelectorAll('iframe[src],iframe[href]')`, plus the removal of each matching iframe.

A page that hooks DOM APIs sees these calls coming from a `pptr:` automation stack.

This PR wraps `engine.onFrameNavigated` in `packages/goto/src/adblock.js`. The frame handed to Ghostery routes `evaluate` to `frame.isolatedRealm()`; every other member stays bound to the real frame. No `node_modules` patching. `FiltersEngine.deserialize` builds through `new this`, but `onFrame` is an instance arrow function, so a subclass would mean copying Ghostery's ~100-line frame handler. The proxy keeps the source diff to 11 lines.

Unchanged by design:
- **Scriptlets** still run in the main world, which they require.
- **Styles:** Puppeteer 25.10's `addStyleTag`/`addScriptTag` already build their elements inside the isolated realm and only transfer the handle (`api/Frame.js:668`, `:707`), so they leave no main-world stack.

`frame.isolatedRealm()` is `@internal` in puppeteer-core's typings. It is the same API used in #920, #921 and #924, and Puppeteer's own public `Frame` methods call it.

## Before / after

**Ghostery selector calls seen by a main-world `querySelectorAll` hook** (goto with adblock on, then 4s settle, 3 runs each):

| host | origin/master | this PR |
|---|---|---|
| `127.0.0.1` | 3 / 3 / 3 | 0 / 0 / 0 |
| `ghostery.localhost` | 3 / 3 / 3 | 0 / 0 / 0 |

**All hooked main-world accesses** (querySelectorAll, getters, getComputedStyle, and others), attributed by stack:

| scenario | Ghostery frames master → PR | total master → PR |
|---|---|---|
| goto | 6 → 0 | 308 → 302 |
| screenshot viewport | 6 → 0 | 309 → 303 |
| screenshot fullPage | 6 → 0 | 1491 → 1485 |

The remaining calls belong to other main-world helpers, tracked separately: autoconsent (#926), overlay dismissal (#925), screenshot helpers (#924).

**Blocking behavior**, functional A/B on a local fixture served as `ghostery.localhost`. `*.localhost` resolves to loopback in Chrome, and the prebuilt engine returns no DOM-derived cosmetic rules for bare IPs.

| check | origin/master | this PR |
|---|---|---|
| `#ad_banner` hidden (DOM id rule) | yes | yes |
| `.ad-slot` hidden (DOM class rule) | yes | yes |
| `a[href^="https://ad.doubleclick.net/"]` hidden (DOM href rule) | yes | yes |
| content element visible | yes | yes |
| blocked `securepubads.g.doubleclick.net` iframe removed | yes | yes |
| element inserted after 1.2s hidden | no | no (upstream stops scanning once no new features appear) |

**Cost:**

| | origin/master | this PR |
|---|---|---|
| CDP round trips per goto (`127.0.0.1` / `ghostery.localhost`) | 67 / 75 | 67 / 75 |
| CDP round trips per screenshot (viewport / fullPage) | 88 / 95 | 88 / 95 |
| goto median ms (`127.0.0.1` / `ghostery.localhost`) | 536 / 536 | 537 / 534 |

## Style injection: measured, left as is

Ghostery's injected `<style>` is still visible as a DOM node. I measured the alternatives on Chrome 152 (a `#target{display:none}` rule applied, then observed from the main world):

| option | hides target | `<style>` nodes | `document.styleSheets` | `document.adoptedStyleSheets` | MutationObserver sees node | CDP round trips |
|---|---|---|---|---|---|---|
| `frame.addStyleTag` (current) | yes | 1 | 1 | 0 | `STYLE` | 4 |
| `<style>` created in isolated realm | yes | 1 | 1 | 0 | `STYLE` | 1 |
| constructed sheet via isolated `adoptedStyleSheets` | yes | 0 | 0 | **1** | none | 1 |
| CDP `CSS.createStyleSheet` + `setStyleSheetText` | yes | 0 | 0 | 0 | none | 4 (requires `DOM.enable` + `CSS.enable`) |

Only the CDP inspector stylesheet is invisible on all four signals. It requires enabling the DOM and CSS domains on every page, which streams DOM/stylesheet events for the whole session, and it has to be recreated per document and per frame. That breaks the no-added-cost constraint, so this PR keeps `addStyleTag`. It's a candidate follow-up if the DOM/CSS domain overhead is measured acceptable.

## Tests

The tests use only local traffic and their own rules. The test file wraps `PuppeteerBlocker.deserialize` to add three test-only rules via `updateFromDiff`: `###browserless-test-ad`, `##.browserless-test-ad` and `||framed-ad.localhost^$subdocument`. The blocked iframe is served by the test server under `framed-ad.localhost`, so no request leaves the machine, and a change to the prebuilt lists can't change the result.

- New in `packages/goto/test/unit/adblock/index.js`:
  - `ghostery DOM scans do not run in the page main world`: page hooks cover `querySelectorAll`, `getAttribute`, `classList`, `nodeName` and `documentElement`, and flag every call coming from `extractFeaturesFromDOM` plus the blocked-iframe scan selector.
    - On origin/master's `adblock.js` it fails with the whole scan: `querySelectorAll iframe[src],iframe[href]`, `querySelectorAll [id]:not(html)…`, `documentElement`, `nodeName`, `getAttribute id`, `getAttribute href`, `classList`.
    - It passes with this PR.
  - `cosmetic filters from DOM features still hide elements and remove blocked iframes`: passes on both, guarding that the isolated scans still feed Ghostery's rules. It also asserts the blocked iframe started loading from the local server before it was removed (1 request in 5 of 5 runs).
- Adblock test file: 17/17 pass.
- `pnpm --filter @browserless/goto test` locally: all pass except the 3 `unit › evasions` WebGL tests (`getContext('webgl')` returns null on this Mac). They fail identically with origin/master's `adblock.js` loaded, and they don't touch adblock.
- `standard` clean on both changed files.

## Measurable outcome

Ghostery's DOM scans leave 0 main-world call traces (from 3 selector calls / 6 hooked accesses per page on the fixture, scaling with frames × scan iterations). Blocking results, CDP round trips and goto latency are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116zka7w2WKPSi3kqHyVAET

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default adblock integration via Puppeteer’s internal `isolatedRealm()` API; new tests assert blocking parity and isolation, but edge cases around frame evaluation could still differ from upstream Ghostery behavior.
> 
> **Overview**
> **Ghostery adblock DOM scans no longer run in the page main world** when `adblock` is on. After the blocker deserializes, `onFrameNavigated` passes frames through a small proxy so `evaluate` calls use `frame.isolatedRealm().evaluate` instead of main-world evaluation. Cosmetic feature extraction and blocked-iframe removal stay on the same Ghostery path; scriptlets and request blocking are unchanged.
> 
> **Tests** patch `PuppeteerBlocker.deserialize` in the adblock unit suite to inject local-only cosmetic/subdocument rules, then add coverage that ads still get hidden and blocked iframes removed, and that main-world hooks do not see Ghostery’s `extractFeaturesFromDOM` / iframe scan selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a2022a6c570233bb6ab820468ab6cb2caf3057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ad blocking for frames by running page evaluations in an isolated execution context.
  - Cosmetic filters now correctly hide matching advertisements while preserving visible content.
  - Blocked advertisement frames are removed from the page as expected.
  - Ghostery scans no longer execute DOM queries in the page’s main context.

- **Tests**
  - Added coverage for cosmetic filtering, blocked subframes, and isolated Ghostery DOM scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->